### PR TITLE
add coap

### DIFF
--- a/helm-charts/home-assistant/templates/deployment.yaml
+++ b/helm-charts/home-assistant/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
             - name: http
               containerPort: 8123
               protocol: TCP
+            - name: coap
+              containerPort: 5683
+              protocol: UDP
           livenessProbe:
             httpGet:
               path: /

--- a/helm-charts/home-assistant/templates/service.yaml
+++ b/helm-charts/home-assistant/templates/service.yaml
@@ -14,3 +14,27 @@ spec:
       appProtocol: kubernetes.io/ws
   selector:
     app.kubernetes.io/name: home-assistant
+---
+# Cilium Gateway API doesn't support TCPRoute and UDPRoute as of 13 Oct 2024
+# So we need to create a LoadBalancer service with LB IPAM sharing-key annotation to expose the DNS service
+# Ref: https://github.com/cilium/cilium/issues/21929#issuecomment-2378680937
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-coap
+  namespace: {{ .Values.namespace }}
+  annotations:
+    lbipam.cilium.io/ips: {{ .Values.ip | quote }}
+    lbipam.cilium.io/sharing-key: ingress
+    lbipam.cilium.io/sharing-cross-namespace: "*"
+  labels:
+    lb-ip-pool: cilium-gateway
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}
+  type: LoadBalancer
+  ports:
+    - port: 5683
+      targetPort: coap
+      protocol: UDP
+      name: coap

--- a/helm-charts/home-assistant/values.yaml
+++ b/helm-charts/home-assistant/values.yaml
@@ -1,6 +1,8 @@
 name: home-assistant
 namespace: home-assistant
 
+ip: 192.168.1.51
+
 deployment:
   image:
     repository: ghcr.io/home-assistant/home-assistant


### PR DESCRIPTION
## Summary by Sourcery

Add CoAP (Constrained Application Protocol) support for Home Assistant by configuring a UDP service and exposing port 5683

New Features:
- Introduce CoAP service port for Home Assistant, enabling lightweight IoT communication protocol support

Enhancements:
- Add CoAP port configuration to the Home Assistant deployment container ports

Deployment:
- Create a LoadBalancer service with Cilium IPAM annotations to expose the CoAP service
- Configure a specific IP address (192.168.1.51) for the CoAP service