### PR TITLE
Update manifest.jsonnet

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -59,7 +59,7 @@ local monitoring = [
   { wave: '10', name: 'healthcheck-io', namespace: 'cilium-gateway' },
   { wave: '10', name: 'metrics-server', namespace: 'monitoring' },
   { wave: '10', name: 'monitoring-volume', namespace: 'monitoring' },
-  { wave: '11', name: 'monitoring', namespace: 'monitoring', helm: { valueFiles: _grafanaDashboards } },
+  //{ wave: '11', name: 'monitoring', namespace: 'monitoring', helm: { valueFiles: _grafanaDashboards } },
 ];
 
 local scheduling = [


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Temporarily disable the monitoring Helm chart deployment by commenting out its configuration in the manifest