### PR TITLE
fix external secrets crd api version

### DIFF
--- a/applications/kubernetes-service-patcher/internal/controller/kubernetesservicepatcher_controller.go
+++ b/applications/kubernetes-service-patcher/internal/controller/kubernetesservicepatcher_controller.go
@@ -61,7 +61,7 @@ func (r *KubernetesServicePatcherReconciler) Reconcile(ctx context.Context, req 
 		// Update the service
 		service.Spec.Type = corev1.ServiceTypeLoadBalancer
 
-		// Ensure the resource version matches
+		// Ensure the resource version matches to prevent race conditions and ensure consistency when multiple clients try to update the same resource simultaneously
 		service.ResourceVersion = originalResourceVersion
 
 		// Add or update the annotations

--- a/helm-charts/argocd-config/templates/external-secret.yaml
+++ b/helm-charts/argocd-config/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-secret

--- a/helm-charts/atlantis/templates/external-secret-aws.yaml
+++ b/helm-charts/atlantis/templates/external-secret-aws.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-aws

--- a/helm-charts/atlantis/templates/external-secret-b2.yaml
+++ b/helm-charts/atlantis/templates/external-secret-b2.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-b2

--- a/helm-charts/atlantis/templates/external-secret-cloudflare.yaml
+++ b/helm-charts/atlantis/templates/external-secret-cloudflare.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-cloudflare

--- a/helm-charts/atlantis/templates/external-secret-github-webhook.yaml
+++ b/helm-charts/atlantis/templates/external-secret-github-webhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-github-webhook

--- a/helm-charts/atlantis/templates/external-secret-github.yaml
+++ b/helm-charts/atlantis/templates/external-secret-github.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-github

--- a/helm-charts/atlantis/templates/external-secret-unifi.yaml
+++ b/helm-charts/atlantis/templates/external-secret-unifi.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-unifi

--- a/helm-charts/atlantis/templates/external-secret-uptime-robot.yaml
+++ b/helm-charts/atlantis/templates/external-secret-uptime-robot.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}-uptime-robot

--- a/helm-charts/cilium-gateway/templates/external-secret.yaml
+++ b/helm-charts/cilium-gateway/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-acme-verification-secret

--- a/helm-charts/cloudflare-tunnel/templates/external-secret.yaml
+++ b/helm-charts/cloudflare-tunnel/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.name }}

--- a/helm-charts/external-secrets/templates/cluster-secret-store.yaml
+++ b/helm-charts/external-secrets/templates/cluster-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: onepassword-secret-store

--- a/helm-charts/healthcheck-io/templates/external-secret.yaml
+++ b/helm-charts/healthcheck-io/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: healthcheck-io

--- a/helm-charts/jung2bot/templates/external-secret.yaml
+++ b/helm-charts/jung2bot/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: jung2bot-secrets

--- a/helm-charts/longhorn/templates/external-secret.yaml
+++ b/helm-charts/longhorn/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.encryption.secretName }}
@@ -53,7 +53,7 @@ spec:
         metadataPolicy: None
         property: CRYPTO_PBKDF
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.backup.secretName }}

--- a/helm-charts/monitoring/templates/external-secret.yaml
+++ b/helm-charts/monitoring/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana


### PR DESCRIPTION
## Summary by Sourcery

Update External Secrets CRD API version from v1beta1 to v1 across multiple Helm chart templates

Enhancements:
- Upgrade External Secrets Custom Resource Definitions to the stable v1 API version in various Helm chart templates

Chores:
- Update API version for ExternalSecret and ClusterSecretStore resources in multiple Kubernetes Helm chart configurations