### PR TITLE
fix init cluster

### DIFF
--- a/ansible/playbooks/k3s/001-cni.yaml
+++ b/ansible/playbooks/k3s/001-cni.yaml
@@ -24,7 +24,7 @@
 
     - name: Apply cilium Helm template
       # https://github.com/cilium/cilium/issues/33239#issuecomment-2177949109
-      shell: "helm template ../../../helm-charts/cilium -n kube-system --api-versions='gateway.networking.k8s.io/v1/GatewayClass' | kubectl create -f - 2>/dev/null || true"
+      shell: "helm template ../../../helm-charts/cilium -n kube-system --api-versions='gateway.networking.k8s.io/v1/GatewayClass' --set cilium.operator.replicas=1 | kubectl create -f - 2>/dev/null || true"
 
     - name: Wait for cilium-operator to rollout
       shell: "kubectl rollout status deploy/cilium-operator -n kube-system --timeout=15m"

--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -10,10 +10,11 @@ longhorn:
     defaultDataLocality: disabled # change to best-effort once added more drives
   defaultSettings:
     replicaAutoBalance: best-effort
-    backupTarget: s3://github-otaru-media-storage@eu-west-1/
-    backupTargetCredentialSecret: b2-secret
     snapshotMaxCount: 250
     autoCleanupSnapshotWhenDeleteBackup: true
+  defaultBackupStore:
+    backupTarget: s3://github-otaru-media-storage@eu-west-1/
+    backupTargetCredentialSecret: b2-secret
 
 encryption:
   secretName: longhorn-crypto


### PR DESCRIPTION
## Summary by Sourcery

Modify Longhorn backup configuration and adjust Cilium deployment settings in the cluster initialization process

Enhancements:
- Restructured Longhorn backup store configuration to use a more explicit `defaultBackupStore` section

Chores:
- Updated Cilium operator deployment to explicitly set replica count