### PR TITLE
Revert "Update values.yaml"

### DIFF
--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -54,10 +54,6 @@ configYaml:
         - https://badmojr.gitlab.io/1hosts/Pro/domains.txt
         - https://big.oisd.nl/domainswild
         - https://raw.githubusercontent.com/hagezi/dns-blocklists/main/hosts/pro.txt
-    allowlists:
-      ads:
-        - |
-          graph.facebook.com
     clientGroupsBlock:
       default:
         - ads


### PR DESCRIPTION
Reverts siutsin/otaru#1225

## Summary by Sourcery

Chores:
- Remove a specific allowlist configuration for graph.facebook.com in the Blocky Helm chart