### PR TITLE
Revert "Update manifest.jsonnet"

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -1,6 +1,6 @@
 local ArgoCDApplication = import 'lib/argocd-application.libsonnet';
 
-local revision = 'fix-monitoring';
+local revision = 'HEAD';
 
 local _ignoreDifferences = {
   scheduling: {


### PR DESCRIPTION
Reverts siutsin/otaru#1237

## Summary by Sourcery

Deployment:
- Restore the ArgoCD application revision to 'HEAD' instead of 'fix-monitoring'.