### PR TITLE
add blocky

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Bare-Metal Home Lab for Kubernetes and Technical Playground.
 
 | Category     | Name                                                                                                | Description                                                                                                             |
 |--------------|-----------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| Application  | [Blocky](https://0xerr0r.github.io/blocky/latest/)                                                  | Stateless DNS server                                                                                                    |
 | Application  | [CyberChef](https://github.com/gchq/CyberChef)                                                      | The Cyber Swiss Army Knife by GCHQ                                                                                      |
 | Application  | [Home Assistant](https://www.home-assistant.io/)                                                    | Home Automation                                                                                                         |
 | Application  | [JSON Crack](https://github.com/AykutSarac/jsoncrack.com)                                           | JSON, YAML, etc. visualizer and editor                                                                                  |

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -18,6 +18,7 @@ local _grafanaDashboards = [
 ];
 
 local application = [
+  { wave: '10', name: 'blocky', namespace: 'blocky' },
   { wave: '10', name: 'cyberchef', namespace: 'cyberchef' },
   { wave: '10', name: 'home-assistant-volume', namespace: 'home-assistant' },
   { wave: '10', name: 'jsoncrack', namespace: 'jsoncrack' },

--- a/helm-charts/blocky/.helmignore
+++ b/helm-charts/blocky/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/blocky/Chart.yaml
+++ b/helm-charts/blocky/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: blocky
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/helm-charts/blocky/templates/config.yaml
+++ b/helm-charts/blocky/templates/config.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}-config
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        config.yml: |
+          {{ `{{ .configYaml }}` }}
+  data:
+    - secretKey: configYaml
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: blocky
+        metadataPolicy: None
+        property: config.yml

--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.name }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: {{ .Values.deployment.ports.http | quote }}
+        prometheus.io/scrape: "true"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ .Values.name }}
+                topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: volume
+                    operator: NotIn
+                    values:
+                      - "true"
+      securityContext:
+        fsGroup: 100
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Values.name }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 100
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+          ports:
+            - name: dns-tcp
+              containerPort: 53
+              protocol: TCP
+            - name: dns-udp
+              containerPort: 53
+              protocol: UDP
+            - name: http
+              containerPort: {{ .Values.deployment.ports.http }}
+              protocol: TCP
+          env:
+            - name: TZ
+              value: {{ .Values.app.timezone }}
+          livenessProbe:
+            exec: {{ toYaml .Values.deployment.probeExec | nindent 14 }}
+          readinessProbe:
+            exec: {{ toYaml .Values.deployment.probeExec | nindent 14 }}
+          startupProbe:
+            exec: {{ toYaml .Values.deployment.probeExec | nindent 14 }}
+            failureThreshold: 120
+            periodSeconds: 5
+          volumeMounts:
+            - name: {{ .Values.name }}-config
+              mountPath: /app/config.yml
+              subPath: config.yml
+          resources: {{ toYaml .Values.deployment.resources | nindent 12 }}
+      volumes:
+        - name: {{ .Values.name }}-config
+          secret:
+            secretName: {{ .Values.name }}-config

--- a/helm-charts/blocky/templates/hpa.yaml
+++ b/helm-charts/blocky/templates/hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  minReplicas: {{ .Values.hpa.autoscaling.min }}
+  maxReplicas: {{ .Values.hpa.autoscaling.max }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/helm-charts/blocky/templates/pdb.yaml
+++ b/helm-charts/blocky/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/blocky/templates/service.yaml
+++ b/helm-charts/blocky/templates/service.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.deployment.ports.http }}
+      targetPort: {{ .Values.deployment.ports.http }}
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}
+---
+# Cilium Gateway API doesn't support TCPRoute and UDPRoute as of 13 Oct 2024
+# So we need to create a LoadBalancer service with LB IPAM sharing-key annotation to expose the DNS service
+# Ref: https://github.com/cilium/cilium/issues/21929#issuecomment-2378680937
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-dns
+  namespace: {{ .Values.namespace }}
+  annotations:
+    lbipam.cilium.io/ips: {{ .Values.ip | quote }}
+    lbipam.cilium.io/sharing-key: ingress
+    lbipam.cilium.io/sharing-cross-namespace: "*"
+  labels:
+    lb-ip-pool: cilium-gateway
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}
+  type: LoadBalancer
+  ports:
+    - name: dns-tcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53

--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -1,0 +1,28 @@
+name: blocky
+namespace: blocky
+ip: 192.168.1.51
+
+app:
+  timezone: Europe/London
+
+deployment:
+  image:
+    repository: ghcr.io/0xerr0r/blocky
+    tag: v0.25
+  probeExec:
+    command:
+      - /app/blocky
+      - healthcheck
+  ports:
+    http: 4000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 300Mi
+    limits:
+      memory: 300Mi
+
+hpa:
+  autoscaling:
+    min: 2
+    max: 2


### PR DESCRIPTION
## Summary by Sourcery

Add Blocky, a stateless DNS server, to the home lab Kubernetes cluster

New Features:
- Integrate Blocky DNS server into the home lab infrastructure

Deployment:
- Create Helm chart for Blocky deployment
- Configure LoadBalancer service with Cilium IPAM for DNS exposure

Documentation:
- Update README.md to include Blocky in the application list