### PR TITLE
expose k8s oidc and jwks endpoint

### DIFF
--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -27,6 +27,11 @@
       when: "'master' in group_names"
 
     - name: Install k3s on the first master node
+      # Enable anonymous authentication
+      # https://stackoverflow.com/questions/74603633/k3s-allow-unauthenticated-access-to-oidc-endpoints
+      # All API server arguments need to be passed using the `kube-apiserver-arg` flag
+      # https://docs.k3s.io/cli/server#customized-flags-for-kubernetes-processes
+      # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
       shell: |
         curl -sfL https://get.k3s.io | sh -s - \
           --datastore-endpoint=https://{{ ETCD_IP }}:2379 \
@@ -42,7 +47,13 @@
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
           --tls-san $(hostname -I | awk '{print $1}') \
-          --write-kubeconfig-mode=644
+          --write-kubeconfig-mode=644 \
+          --kube-apiserver-arg \
+          --anonymous-auth=true \
+          --kube-apiserver-arg \
+          --service-account-issuer=https://oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"
       register: first_master_setup
 

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -18,6 +18,11 @@
       no_log: true
 
     - name: Install k3s on master nodes with LB_API_SERVER_IP
+      # Enable anonymous authentication
+      # https://stackoverflow.com/questions/74603633/k3s-allow-unauthenticated-access-to-oidc-endpoints
+      # All API server arguments need to be passed using the `kube-apiserver-arg` flag
+      # https://docs.k3s.io/cli/server#customized-flags-for-kubernetes-processes
+      # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
       shell: |
         curl -sfL https://get.k3s.io | sh -s - \
           --token {{ master_token.stdout }} \
@@ -34,7 +39,13 @@
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
           --tls-san $(hostname -I | awk '{print $1}') \
-          --write-kubeconfig-mode=644
+          --write-kubeconfig-mode=644 \
+          --kube-apiserver-arg \
+          --anonymous-auth=true \
+          --kube-apiserver-arg \
+          --service-account-issuer=https://oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
       retries: 5
       delay: 10
       when: "'master' in group_names"

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -88,6 +88,7 @@ local scheduling = [
 local security = [
   { wave: '02', name: 'cert-manager', namespace: 'cert-manager' },
   { wave: '10', name: 'falco', namespace: 'falco' },
+  { wave: '10', name: 'oidc-provider', namespace: 'default' },
 ];
 
 local storage = [

--- a/helm-charts/oidc-provider/.helmignore
+++ b/helm-charts/oidc-provider/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/oidc-provider/Chart.yaml
+++ b/helm-charts/oidc-provider/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: oidc-provider
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/helm-charts/oidc-provider/templates/rbac.yaml
+++ b/helm-charts/oidc-provider/templates/rbac.yaml
@@ -1,0 +1,16 @@
+# Service account issuer discovery available since Kubernetes 1.21
+# https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/kubernetes
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-reviewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated

--- a/helm-charts/oidc-provider/values.yaml
+++ b/helm-charts/oidc-provider/values.yaml
@@ -1,0 +1,2 @@
+name: oidc-provider
+namespace: default

--- a/infrastructure/cloud/cloudflare/tunnel/terragrunt.hcl
+++ b/infrastructure/cloud/cloudflare/tunnel/terragrunt.hcl
@@ -4,6 +4,7 @@ include {
 
 locals {
   zone_id       = get_env("CLOUDFLARE_ZONE_ID")
+  zone          = get_env("CLOUDFLARE_ZONE")
   account_id    = get_env("CLOUDFLARE_ACCOUNT_ID")
   name          = get_env("CLOUDFLARE_ZONE_SUBDOMAIN")
   tunnel_secret = get_env("CLOUDFLARE_TUNNEL_SECRET")
@@ -14,11 +15,12 @@ terraform {
 }
 
 inputs = {
-  zone_id           = local.zone_id
-  account_id        = local.account_id
-  name              = local.name
-  config_src        = "cloudflare"
-  tunnel_secret     = local.tunnel_secret
-  network_cidr      = "192.168.1.0/24"
-  catch_all_service = "http://cilium-gateway-ingress.cilium-gateway.svc.cluster.local"
+  zone_id         = local.zone_id
+  zone            = local.zone
+  account_id      = local.account_id
+  name            = local.name
+  config_src      = "cloudflare"
+  tunnel_secret   = local.tunnel_secret
+  network_cidr    = "192.168.1.0/24"
+  gateway_service = "http://cilium-gateway-ingress.cilium-gateway.svc.cluster.local"
 }

--- a/infrastructure/modules/cloudflare-tunnel/dns.tf
+++ b/infrastructure/modules/cloudflare-tunnel/dns.tf
@@ -2,10 +2,19 @@ locals {
   tunnel_hostname = sensitive("${cloudflare_zero_trust_tunnel_cloudflared.this.id}.cfargotunnel.com")
 }
 
-resource "cloudflare_dns_record" "this" {
+resource "cloudflare_dns_record" "public" {
   zone_id = var.zone_id
   content = local.tunnel_hostname
   name    = var.name
+  proxied = true
+  ttl     = 1
+  type    = "CNAME"
+}
+
+resource "cloudflare_dns_record" "oidc" {
+  zone_id = var.zone_id
+  content = local.tunnel_hostname
+  name    = "oidc"
   proxied = true
   ttl     = 1
   type    = "CNAME"

--- a/infrastructure/modules/cloudflare-tunnel/tunnel.tf
+++ b/infrastructure/modules/cloudflare-tunnel/tunnel.tf
@@ -28,7 +28,27 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
   config = {
     ingress = [
       {
-        service = var.catch_all_service
+        hostname = "oidc.${var.zone}"
+        service  = var.kubernetes_service
+        path     = "/.well-known/openid-configuration"
+        origin_request = {
+          ca_pool = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        }
+      },
+      {
+        hostname = "oidc.${var.zone}"
+        service  = var.kubernetes_service
+        path     = "/openid/v1/jwks"
+        origin_request = {
+          ca_pool = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        }
+      },
+      {
+        hostname = "${var.name}.${var.zone}"
+        service  = var.gateway_service
+      },
+      {
+        service = "http_status:404"
       }
     ]
   }

--- a/infrastructure/modules/cloudflare-tunnel/variables.tf
+++ b/infrastructure/modules/cloudflare-tunnel/variables.tf
@@ -3,6 +3,11 @@ variable "zone_id" {
   sensitive = true
 }
 
+variable "zone" {
+  type      = string
+  sensitive = true
+}
+
 variable "account_id" {
   type      = string
   sensitive = true
@@ -26,6 +31,11 @@ variable "network_cidr" {
   type = string
 }
 
-variable "catch_all_service" {
-  type = string
+variable "kubernetes_service" {
+  type    = string
+  default = "https://kubernetes.default.svc.cluster.local"
+}
+
+variable "gateway_service" {
+  type    = string
 }


### PR DESCRIPTION
## Summary by Sourcery

Expose Kubernetes OIDC and JWKS endpoints via Cloudflare tunnel and configure cluster for OIDC discovery.

New Features:
- Expose /.well-known/openid-configuration and /openid/v1/jwks endpoints for OIDC via Cloudflare tunnel.
- Add DNS record for oidc subdomain pointing to the tunnel.
- Introduce Helm chart for OIDC provider with RBAC for service account issuer discovery.

Enhancements:
- Update k3s cluster setup to enable anonymous authentication and configure OIDC issuer and JWKS URI.

Build:
- Add new variables and update service configuration in Terraform modules for Cloudflare tunnel.