### PR TITLE
set aud

### DIFF
--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -32,6 +32,7 @@
       # All API server arguments need to be passed using the `kube-apiserver-arg` flag
       # https://docs.k3s.io/cli/server#customized-flags-for-kubernetes-processes
       # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+      # https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md
       shell: |
         curl -sfL https://get.k3s.io | sh -s - \
           --datastore-endpoint=https://{{ ETCD_IP }}:2379 \
@@ -52,6 +53,8 @@
           --anonymous-auth=true \
           --kube-apiserver-arg \
           --service-account-issuer=https://oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --api-audiences=oidc.siutsin.com \
           --kube-apiserver-arg \
           --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -43,14 +43,12 @@
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \
-      vars:
-        k3s_server_flags: >-
-          --kube-apiserver-arg --service-account-issuer=https://oidc.siutsin.com
-          --kube-apiserver-arg --api-audiences=oidc.siutsin.com
-          --kube-apiserver-arg --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
-      shell: |
-        curl -sfL https://get.k3s.io | sh -s - \
-          --token {{ master_token.stdout }} {{ k3s_server_flags }}
+          --kube-apiserver-arg \
+          --service-account-issuer=https://oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --api-audiences=oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
       retries: 5
       delay: 10
       when: "'master' in group_names"

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -43,12 +43,14 @@
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \
-          --kube-apiserver-arg \
-          --service-account-issuer=https://oidc.siutsin.com \
-          --kube-apiserver-arg \
-          --api-audiences=oidc.siutsin.com \
-          --kube-apiserver-arg \
-          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
+      vars:
+        k3s_server_flags: >-
+          --kube-apiserver-arg --service-account-issuer=https://oidc.siutsin.com
+          --kube-apiserver-arg --api-audiences=oidc.siutsin.com
+          --kube-apiserver-arg --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
+      shell: |
+        curl -sfL https://get.k3s.io | sh -s - \
+          --token {{ master_token.stdout }} {{ k3s_server_flags }}
       retries: 5
       delay: 10
       when: "'master' in group_names"

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -23,6 +23,7 @@
       # All API server arguments need to be passed using the `kube-apiserver-arg` flag
       # https://docs.k3s.io/cli/server#customized-flags-for-kubernetes-processes
       # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+      # https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md
       shell: |
         curl -sfL https://get.k3s.io | sh -s - \
           --token {{ master_token.stdout }} \
@@ -44,6 +45,8 @@
           --anonymous-auth=true \
           --kube-apiserver-arg \
           --service-account-issuer=https://oidc.siutsin.com \
+          --kube-apiserver-arg \
+          --api-audiences=oidc.siutsin.com \
           --kube-apiserver-arg \
           --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
       retries: 5


### PR DESCRIPTION
## Summary by Sourcery

Update k3s Ansible playbooks to configure the kube-apiserver with the --api-audiences flag and add relevant documentation references.

Enhancements:
- Add --api-audiences flag to kube-apiserver arguments in cluster and node setup playbooks.

Documentation:
- Reference Amazon EKS Pod Identity Webhook self-hosted setup documentation in playbook comments.