### PR TITLE
add amazon-eks-pod-identity-webhook

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -89,6 +89,7 @@ local security = [
   { wave: '02', name: 'cert-manager', namespace: 'cert-manager' },
   { wave: '10', name: 'falco', namespace: 'falco' },
   { wave: '10', name: 'oidc-provider', namespace: 'default' },
+  { wave: '10', name: 'amazon-eks-pod-identity-webhook', namespace: 'default' },
 ];
 
 local storage = [

--- a/helm-charts/amazon-eks-pod-identity-webhook/.helmignore
+++ b/helm-charts/amazon-eks-pod-identity-webhook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.lock
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: amazon-eks-pod-identity-webhook
+  repository: https://jkroepke.github.io/helm-charts/
+  version: 2.5.1
+digest: sha256:c03e8cd9645d37558a5b4f643567d3797b78669d21f77a291c79430eaa0fa54d
+generated: "2025-05-11T16:29:13.700153+01:00"

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -7,3 +7,4 @@ dependencies:
   - name: amazon-eks-pod-identity-webhook
     version: 2.5.1
     repository: https://jkroepke.github.io/helm-charts/
+    alias: pod-identity-webhook

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: amazon-eks-pod-identity-webhook
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+dependencies:
+  - name: amazon-eks-pod-identity-webhook
+    version: 2.5.1
+    repository: https://jkroepke.github.io/helm-charts/

--- a/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,0 +1,7 @@
+name: amazon-eks-pod-identity-webhook
+namespace: default
+
+amazon-eks-pod-identity-webhook:
+  config:
+    defaultAwsRegion: eu-west-1
+    tokenAudience: oidc.siutsin.com

--- a/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,7 +1,7 @@
 name: amazon-eks-pod-identity-webhook
 namespace: default
 
-amazon-eks-pod-identity-webhook:
+pod-identity-webhook:
   config:
     defaultAwsRegion: eu-west-1
     tokenAudience: oidc.siutsin.com


### PR DESCRIPTION
## Summary by Sourcery

Introduce amazon-eks-pod-identity-webhook to the deployment stack by adding its Helm chart and integrating it into the ArgoCD deployment manifest.

New Features:
- Add amazon-eks-pod-identity-webhook Helm chart with configuration for deployment.

Enhancements:
- Register amazon-eks-pod-identity-webhook in ArgoCD manifest for deployment orchestration.