### PR TITLE
add jung2bot irsa iam role

### DIFF
--- a/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/.terraform.lock.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/.terraform.lock.hcl
@@ -1,0 +1,107 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/backblaze/b2" {
+  version     = "0.10.0"
+  constraints = "~> 0.8"
+  hashes = [
+    "h1:XopbGPMYulGkGsOipKMYwwiWkL4vfMRQ1gHhH61dFfI=",
+    "zh:03d4ec22a8a47dfc4e1beccd261f37b22113646d246853195fe5d8cb6febf90c",
+    "zh:08c9ea953b3dcb01aeebd372b9bd2c1a6c1f0b996125bde03c094bc5e75fb55b",
+    "zh:4f8589276b11f00feb511bd500e2f02abe41371ce2ab74507dd53a7e1110e944",
+    "zh:8bfcdb1b1cfaa20fa0f717758fca38290e6bd5ff6499ad196dd2f68f95aeab18",
+    "zh:dfac030714a098956d6df3bf6277d08c19b5b037cd7ec30821ec2edb0de49328",
+  ]
+}
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.4.0"
+  constraints = "~> 5.4"
+  hashes = [
+    "h1:KjToQWBCake9Stqj8aZ5cld29sWRCTy/2CIM3MJJEvQ=",
+    "zh:08b35ad7c1125bd0f34a0e719231389a679dc4a0247aa7c46374a55f13658a5a",
+    "zh:10c68c3a847b22c85db45d401febb9b34e0c0dadc38c4cc8f22b031cc9ff53de",
+    "zh:1750f58bd37db19f1d92a4232db359505993f1e2d8ba7d6732b1b59f098da902",
+    "zh:3929072b8dab83cc630d18a2ec04b339342d6dea7da7f51b733ffbd2543177b8",
+    "zh:9b297eeb027cd7e01f392d94a408070dcb801f09bf58a60a1a7f356bd78b40f5",
+    "zh:9d90bd226699737d00532927491e7ae0c30a5df407d39d0a29fa0bb2eedb5a7e",
+    "zh:a3b28a5e0114488b50ef0887e3fb8f8baa74058d1b33a57b1c8917e5be954ef1",
+    "zh:afd7388049fdbe3b0c21f3141ad623c970ab6c341c8fbab91041dc665c4331f7",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.67"
+  hashes = [
+    "h1:wQQOWfS0ADOnuolmBBliS6YzKRYVDkBS5juqG1FJLNY=",
+    "zh:0399db801d5847d3f1aae8528b0ec7e9342431f2d42a4f06841d43c9479e45ac",
+    "zh:2a1fdb04d30340c8e5fa06f0c7e97feaa3f2f76bc65175471170b42a7f0ebab4",
+    "zh:3dec38efcdef0e4dfb93998b87ca7a1bfe528f0fa825f99b113c816424c311ba",
+    "zh:42c9da03e3f3e42cbb19278932af093d27487bc7fc75c689d0bbddf5c9da1786",
+    "zh:821fc83ffebc81e51be4c70ab6ae42c32821ac0f41b81016908891663afa9476",
+    "zh:8d790c719e467a4b5c84f5d35a1702c8c27b052cc88db12e37d097781d50b077",
+    "zh:e9a0e61b8e576f5c38ffca3a16e523ef295f57da1d29fab5773ce66bbbfebcc5",
+    "zh:ec49b0ef15033912aa9919122163cd0e06bb3a7463380f4c1fd41704a9964170",
+    "zh:f123de397ce8fb792d8181250e85a79b5446ac392a7470d7597b7d7319d4dbbf",
+    "zh:fe1ea027408453dac877b8ef5d325d6fba82250960c90ad42fcb90da97588863",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.6.0"
+  constraints = "~> 6.6"
+  hashes = [
+    "h1:P4SRG4605PvPKASeDu1lW49TTz1cCGsjQ7qbOBgNd6I=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.opentofu.org/paultyng/unifi" {
+  version     = "0.41.0"
+  constraints = "~> 0.41"
+  hashes = [
+    "h1:fc0gUNc7ddxeLKVgVbt2iuYBn0U9GKE9lxK78w8oRF4=",
+    "zh:03ddd3aee05a08e1446f75a7b3f52810181d3307728cba08ce8fb67f109a9c00",
+    "zh:11b14b79ad02b0a55fd6116b10c0eb6fab432dd7d1f3527af0e2055adf292451",
+    "zh:18c0eb19889927f115a1e05d64f59b4e8d530ccdf1a8b574940a86be20973564",
+    "zh:2df9ca0c21830d2757758e574b19d0d4e54965ce80dbbfb3f124db1dac3d7e8f",
+    "zh:36274af3b7e8b08ba69c04a226c63e0dd2ec386c583288ebd7bc2a30e349ee8f",
+    "zh:413eb222ef30889bab33ccbfc46c9fb64307555da34eac4625d51e696ac72e1d",
+    "zh:4839814ff9f405a13397ffadd6f1052c770b88802280a4d8cde066f9a19718c7",
+    "zh:9547b7831852cc5b9c0fd13ab447d48539eae94582c8725ad255af36e31fb5d9",
+    "zh:a855c89b12326eb1c89bbf292a2bb1de3651794e3409d5012076ada89aabdc8a",
+    "zh:aef12a33b90fd77a9bf4e9d397966ccbfa4a037a648a1725074aff2db2d90fb0",
+    "zh:b3c72a6a02e29b4d21aa0d0831a272ca7cb82c3f8c2c3c7f09fcc2d2dcd78752",
+    "zh:c8354eaaab5f526e8e530b098544c7583a0f0b5b27d67500c7b3e9da56a3a7e5",
+    "zh:dc29f1e70f20ce86d3c6a66c7a817616f993a1cf9d941604dfd5222a06992c4c",
+    "zh:e772779333419f34d2c6da333c7f7d235a5a34f21ea47636b548e132aed74f3b",
+  ]
+}
+
+provider "registry.opentofu.org/vexxhost/uptimerobot" {
+  version     = "0.8.2"
+  constraints = "~> 0.8"
+  hashes = [
+    "h1:p8uVdU+JgHBPmBy7SqwM6Js3jsk03uiq8yV6WSQSyEk=",
+    "zh:348b22a27496b3f88103f6a08791d51531b0b20c35a7cf32c7dcf6a9a5b58d26",
+    "zh:77cdae6f3c852c677a70be4bc335372aba7ceef9556d4b4427bbc683030d5f7d",
+    "zh:7ef18e4bae4d9e92bdda3e4b5c633f1b7e614a9f8613df01d88334a4d86b1f99",
+    "zh:aa46d603a3dce7651ebb84e6b2b0419010594efbc8ab2d57c9f4906590f2c43f",
+  ]
+}

--- a/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/terragrunt.hcl
@@ -1,0 +1,45 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}//modules/aws-iam-irsa"
+}
+
+locals {
+  oidc_vars = read_terragrunt_config(find_in_parent_folders("oidc.hcl")).locals
+
+  name          = "jung2bot-dev"
+  oidc_provider = local.oidc_vars.oidc_provider
+}
+
+inputs = {
+  name            = local.name
+  oidc_provider   = local.oidc_provider
+  service_account = "system:serviceaccount:${local.name}:jung2bot"
+  role_policies = {
+    dynamodb = {
+      actions = ["dynamodb:*"]
+      resources = [
+        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds",
+        "arn:aws:dynamodb:*:*:table/${local.name}-messages",
+        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds/index/*",
+        "arn:aws:dynamodb:*:*:table/${local.name}-messages/index/*",
+      ]
+    }
+    dynamodb-generic = {
+      actions = ["dynamodb:List*", "dynamodb:Describe*"]
+      resources = ["*"]
+    }
+    sqs = {
+      actions = ["sqs:*"]
+      resources = [
+        "arn:aws:sqs:*:*:${local.name}-event-queue",
+      ]
+    }
+    sqs-generic = {
+      actions = ["sqs:List*", "sqs:Describe*"]
+      resources = ["*"]
+    }
+  }
+}

--- a/infrastructure/cloud/aws/jung2bot/iam-irsa/.terraform.lock.hcl
+++ b/infrastructure/cloud/aws/jung2bot/iam-irsa/.terraform.lock.hcl
@@ -1,0 +1,107 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/backblaze/b2" {
+  version     = "0.10.0"
+  constraints = "~> 0.8"
+  hashes = [
+    "h1:XopbGPMYulGkGsOipKMYwwiWkL4vfMRQ1gHhH61dFfI=",
+    "zh:03d4ec22a8a47dfc4e1beccd261f37b22113646d246853195fe5d8cb6febf90c",
+    "zh:08c9ea953b3dcb01aeebd372b9bd2c1a6c1f0b996125bde03c094bc5e75fb55b",
+    "zh:4f8589276b11f00feb511bd500e2f02abe41371ce2ab74507dd53a7e1110e944",
+    "zh:8bfcdb1b1cfaa20fa0f717758fca38290e6bd5ff6499ad196dd2f68f95aeab18",
+    "zh:dfac030714a098956d6df3bf6277d08c19b5b037cd7ec30821ec2edb0de49328",
+  ]
+}
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.4.0"
+  constraints = "~> 5.4"
+  hashes = [
+    "h1:KjToQWBCake9Stqj8aZ5cld29sWRCTy/2CIM3MJJEvQ=",
+    "zh:08b35ad7c1125bd0f34a0e719231389a679dc4a0247aa7c46374a55f13658a5a",
+    "zh:10c68c3a847b22c85db45d401febb9b34e0c0dadc38c4cc8f22b031cc9ff53de",
+    "zh:1750f58bd37db19f1d92a4232db359505993f1e2d8ba7d6732b1b59f098da902",
+    "zh:3929072b8dab83cc630d18a2ec04b339342d6dea7da7f51b733ffbd2543177b8",
+    "zh:9b297eeb027cd7e01f392d94a408070dcb801f09bf58a60a1a7f356bd78b40f5",
+    "zh:9d90bd226699737d00532927491e7ae0c30a5df407d39d0a29fa0bb2eedb5a7e",
+    "zh:a3b28a5e0114488b50ef0887e3fb8f8baa74058d1b33a57b1c8917e5be954ef1",
+    "zh:afd7388049fdbe3b0c21f3141ad623c970ab6c341c8fbab91041dc665c4331f7",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "~> 5.67"
+  hashes = [
+    "h1:wQQOWfS0ADOnuolmBBliS6YzKRYVDkBS5juqG1FJLNY=",
+    "zh:0399db801d5847d3f1aae8528b0ec7e9342431f2d42a4f06841d43c9479e45ac",
+    "zh:2a1fdb04d30340c8e5fa06f0c7e97feaa3f2f76bc65175471170b42a7f0ebab4",
+    "zh:3dec38efcdef0e4dfb93998b87ca7a1bfe528f0fa825f99b113c816424c311ba",
+    "zh:42c9da03e3f3e42cbb19278932af093d27487bc7fc75c689d0bbddf5c9da1786",
+    "zh:821fc83ffebc81e51be4c70ab6ae42c32821ac0f41b81016908891663afa9476",
+    "zh:8d790c719e467a4b5c84f5d35a1702c8c27b052cc88db12e37d097781d50b077",
+    "zh:e9a0e61b8e576f5c38ffca3a16e523ef295f57da1d29fab5773ce66bbbfebcc5",
+    "zh:ec49b0ef15033912aa9919122163cd0e06bb3a7463380f4c1fd41704a9964170",
+    "zh:f123de397ce8fb792d8181250e85a79b5446ac392a7470d7597b7d7319d4dbbf",
+    "zh:fe1ea027408453dac877b8ef5d325d6fba82250960c90ad42fcb90da97588863",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.6.0"
+  constraints = "~> 6.6"
+  hashes = [
+    "h1:P4SRG4605PvPKASeDu1lW49TTz1cCGsjQ7qbOBgNd6I=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.opentofu.org/paultyng/unifi" {
+  version     = "0.41.0"
+  constraints = "~> 0.41"
+  hashes = [
+    "h1:fc0gUNc7ddxeLKVgVbt2iuYBn0U9GKE9lxK78w8oRF4=",
+    "zh:03ddd3aee05a08e1446f75a7b3f52810181d3307728cba08ce8fb67f109a9c00",
+    "zh:11b14b79ad02b0a55fd6116b10c0eb6fab432dd7d1f3527af0e2055adf292451",
+    "zh:18c0eb19889927f115a1e05d64f59b4e8d530ccdf1a8b574940a86be20973564",
+    "zh:2df9ca0c21830d2757758e574b19d0d4e54965ce80dbbfb3f124db1dac3d7e8f",
+    "zh:36274af3b7e8b08ba69c04a226c63e0dd2ec386c583288ebd7bc2a30e349ee8f",
+    "zh:413eb222ef30889bab33ccbfc46c9fb64307555da34eac4625d51e696ac72e1d",
+    "zh:4839814ff9f405a13397ffadd6f1052c770b88802280a4d8cde066f9a19718c7",
+    "zh:9547b7831852cc5b9c0fd13ab447d48539eae94582c8725ad255af36e31fb5d9",
+    "zh:a855c89b12326eb1c89bbf292a2bb1de3651794e3409d5012076ada89aabdc8a",
+    "zh:aef12a33b90fd77a9bf4e9d397966ccbfa4a037a648a1725074aff2db2d90fb0",
+    "zh:b3c72a6a02e29b4d21aa0d0831a272ca7cb82c3f8c2c3c7f09fcc2d2dcd78752",
+    "zh:c8354eaaab5f526e8e530b098544c7583a0f0b5b27d67500c7b3e9da56a3a7e5",
+    "zh:dc29f1e70f20ce86d3c6a66c7a817616f993a1cf9d941604dfd5222a06992c4c",
+    "zh:e772779333419f34d2c6da333c7f7d235a5a34f21ea47636b548e132aed74f3b",
+  ]
+}
+
+provider "registry.opentofu.org/vexxhost/uptimerobot" {
+  version     = "0.8.2"
+  constraints = "~> 0.8"
+  hashes = [
+    "h1:p8uVdU+JgHBPmBy7SqwM6Js3jsk03uiq8yV6WSQSyEk=",
+    "zh:348b22a27496b3f88103f6a08791d51531b0b20c35a7cf32c7dcf6a9a5b58d26",
+    "zh:77cdae6f3c852c677a70be4bc335372aba7ceef9556d4b4427bbc683030d5f7d",
+    "zh:7ef18e4bae4d9e92bdda3e4b5c633f1b7e614a9f8613df01d88334a4d86b1f99",
+    "zh:aa46d603a3dce7651ebb84e6b2b0419010594efbc8ab2d57c9f4906590f2c43f",
+  ]
+}

--- a/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
@@ -1,0 +1,45 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}//modules/aws-iam-irsa"
+}
+
+locals {
+  oidc_vars = read_terragrunt_config(find_in_parent_folders("oidc.hcl")).locals
+
+  name          = "jung2bot"
+  oidc_provider = local.oidc_vars.oidc_provider
+}
+
+inputs = {
+  name            = local.name
+  oidc_provider   = local.oidc_provider
+  service_account = "system:serviceaccount:${local.name}:jung2bot"
+  role_policies = {
+    dynamodb = {
+      actions = ["dynamodb:*"]
+      resources = [
+        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds",
+        "arn:aws:dynamodb:*:*:table/${local.name}-messages",
+        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds/index/*",
+        "arn:aws:dynamodb:*:*:table/${local.name}-messages/index/*",
+      ]
+    }
+    dynamodb-generic = {
+      actions = ["dynamodb:List*", "dynamodb:Describe*"]
+      resources = ["*"]
+    }
+    sqs = {
+      actions = ["sqs:*"]
+      resources = [
+        "arn:aws:sqs:*:*:${local.name}-event-queue",
+      ]
+    }
+    sqs-generic = {
+      actions = ["sqs:List*", "sqs:Describe*"]
+      resources = ["*"]
+    }
+  }
+}

--- a/infrastructure/cloud/aws/oidc.hcl
+++ b/infrastructure/cloud/aws/oidc.hcl
@@ -1,0 +1,3 @@
+locals {
+  oidc_provider = "https://oidc.siutsin.com"
+}

--- a/infrastructure/modules/aws-iam-irsa/data.tf
+++ b/infrastructure/modules/aws-iam-irsa/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/infrastructure/modules/aws-iam-irsa/irsa.tf
+++ b/infrastructure/modules/aws-iam-irsa/irsa.tf
@@ -1,0 +1,50 @@
+locals {
+  oidc_provider_without_https = replace(var.oidc_provider, "https://", "")
+  identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_provider_without_https}"]
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = local.identifiers
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_without_https}:aud"
+      values   = [local.oidc_provider_without_https]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_without_https}:sub"
+      values   = [var.service_account]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "role" {
+  dynamic "statement" {
+    for_each = var.role_policies
+    content {
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "role" {
+  name   = var.name
+  role   = aws_iam_role.role.id
+  policy = data.aws_iam_policy_document.role.json
+}
+
+resource "aws_iam_role" "role" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}

--- a/infrastructure/modules/aws-iam-irsa/variables.tf
+++ b/infrastructure/modules/aws-iam-irsa/variables.tf
@@ -1,0 +1,18 @@
+variable "name" {
+  type = string
+}
+
+variable "oidc_provider" {
+  type = string
+}
+
+variable "service_account" {
+  type = string
+}
+
+variable "role_policies" {
+  type = map(object({
+    actions = list(string)
+    resources = list(string)
+  }))
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce reusable Terraform module and Terragrunt configurations for creating AWS IAM roles with OIDC-based IRSA for jung2bot and jung2bot-dev environments.

Enhancements:
- Add a generic Terraform module for AWS IAM roles with OIDC IRSA support and configurable policies.

Build:
- Add Terragrunt configurations for jung2bot and jung2bot-dev to provision IRSA roles with required DynamoDB and SQS permissions.