### PR TITLE
add jung2bot irsa service account

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -17,14 +17,16 @@ local _grafanaDashboards = [
   'dashboards/prometheus-stats.yaml',
 ];
 
+//local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };
+local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: "123456789012" }] };
 local application = [
   { wave: '10', name: 'blocky', namespace: 'blocky' },
   { wave: '10', name: 'cyberchef', namespace: 'cyberchef' },
   { wave: '10', name: 'excalidraw', namespace: 'excalidraw' },
   { wave: '10', name: 'home-assistant-volume', namespace: 'home-assistant' },
   { wave: '10', name: 'jsoncrack', namespace: 'jsoncrack' },
-  { wave: '10', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot' },
-  { wave: '10', name: 'jung2bot-dev', namespace: 'jung2bot-dev', path: 'helm-charts/jung2bot', helm: { valueFiles: ['value/dev.yaml'] } },
+  { wave: '10', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot', helm: jung2botHelm },
+  { wave: '10', name: 'jung2bot-dev', namespace: 'jung2bot-dev', path: 'helm-charts/jung2bot', helm: jung2botHelm { valueFiles: ['value/dev.yaml'] } },
   { wave: '10', name: 'yaade-volume', namespace: 'yaade' },
   { wave: '11', name: 'home-assistant', namespace: 'home-assistant' },
   { wave: '11', name: 'yaade', namespace: 'yaade' },

--- a/helm-charts/argocd-bootstrap/templates/bootstrap.yaml
+++ b/helm-charts/argocd-bootstrap/templates/bootstrap.yaml
@@ -11,6 +11,8 @@ spec:
     repoURL: https://github.com/siutsin/otaru.git
     path: argocd
     targetRevision: {{ .Values.targetRevision }}
+{{/*    plugin:*/}}
+{{/*      name: jsonnet-with-secret*/}}
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/helm-charts/argocd/templates/external-secret.yaml
+++ b/helm-charts/argocd/templates/external-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-jsonnet-secret
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: argocd-secret
+        metadataPolicy: None
+        property: AWS_ACCOUNT_ID
+      secretKey: AWS_ACCOUNT_ID

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 argo-cd:
   global:
     affinity:
@@ -17,7 +19,67 @@ argo-cd:
       server.insecure: true
       server.basehref: /argocd/
       server.rootpath: /argocd
+    cmp:
+      create: true
+      plugins:
+        jsonnet-with-secret:
+          discover:
+            fileName: "manifest.jsonnet"
+          generate:
+            command: [ "sh", "-c" ]
+            args: [ "jsonnet manifest.jsonnet > /tmp/rendered.yaml && cat /tmp/rendered.yaml" ]
   dex:
     enabled: false
   notifications:
     enabled: false
+  repoServer:
+    rbac:
+      - apiGroups: [""]
+        resources: ["secrets"]
+        verbs: ["get"]
+        resourceNames: ["argocd-jsonnet-secret"]
+    initContainers:
+      - name: wait-for-secret
+        image: bitnami/kubectl:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Waiting for secret argocd-jsonnet-secret..."
+            until kubectl get secret argocd-jsonnet-secret -n argocd; do
+              echo "Secret not found, retrying in 5 seconds..."
+              sleep 5
+            done
+            echo "Secret argocd-jsonnet-secret found!"
+        securityContext:
+          runAsUser: 1000
+    extraContainers:
+      - name: jsonnet-with-secret
+        env:
+          - name: AWS_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: argocd-jsonnet-secret
+                key: AWS_ACCOUNT_ID
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        image: bitnami/jsonnet
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            subPath: jsonnet-with-secret.yaml
+            name: argocd-cmp-cm
+          - mountPath: /tmp
+            name: cmp-tmp
+    volumes:
+      - name: argocd-cmp-cm
+        configMap:
+          name: argocd-cmp-cm
+      - name: cmp-tmp
+        emptyDir: {}

--- a/helm-charts/jung2bot/templates/irsa.yaml
+++ b/helm-charts/jung2bot/templates/irsa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.irsa.awsAccountId }}:role/{{ .Values.namespace }}

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -5,6 +5,9 @@ secret:
   remoteRef:
     key: jung2bot
 
+irsa:
+  awsAccountId: ~
+
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot


### PR DESCRIPTION
## Summary by Sourcery

Introduce IRSA support for jung2bot by adding a service account template, updating ArgoCD and bootstrap configurations to inject AWS account ID, and managing secrets via external secret integration.

New Features:
- Add IRSA service account template for jung2bot with AWS IAM role annotation.

Enhancements:
- Configure jung2bot and jung2bot-dev ArgoCD applications to use AWS account ID via Jsonnet extVar and Helm parameters.
- Add external secret for AWS account ID to ArgoCD controller via environment variable.

Build:
- Set namespace in ArgoCD Helm values and update bootstrap to pass AWS account ID as a Jsonnet extVar.