### PR TITLE
Revert "Update ghcr.io/0xerr0r/blocky Docker tag to v0.26"

### DIFF
--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -8,7 +8,7 @@ app:
 deployment:
   image:
     repository: ghcr.io/0xerr0r/blocky
-    tag: v0.26
+    tag: v0.25
   probeExec:
     command:
       - /app/blocky


### PR DESCRIPTION
Reverts siutsin/otaru#1315

## Summary by Sourcery

Bug Fixes:
- Restore the Helm chart’s Blocky image tag from v0.26 back to v0.25