### PR TITLE
migrate jung2bot to use aws irsa service account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server
           helm repo add onepassword-connect https://1password.github.io/connect-helm-charts
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add siutsin https://siutsin.github.io/otaru
           helm repo add siutsin-cloudflare https://siutsin.github.io/cloudflare-helm-charts
           helm repo add stakater https://stakater.github.io/stakater-charts
 

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -17,14 +17,15 @@ local _grafanaDashboards = [
   'dashboards/prometheus-stats.yaml',
 ];
 
+local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };
 local application = [
   { wave: '10', name: 'blocky', namespace: 'blocky' },
   { wave: '10', name: 'cyberchef', namespace: 'cyberchef' },
   { wave: '10', name: 'excalidraw', namespace: 'excalidraw' },
   { wave: '10', name: 'home-assistant-volume', namespace: 'home-assistant' },
   { wave: '10', name: 'jsoncrack', namespace: 'jsoncrack' },
-  { wave: '10', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot' },
-  { wave: '10', name: 'jung2bot-dev', namespace: 'jung2bot-dev', path: 'helm-charts/jung2bot', helm: { valueFiles: ['value/dev.yaml'] } },
+  { wave: '10', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot', helm: jung2botHelm },
+  { wave: '10', name: 'jung2bot-dev', namespace: 'jung2bot-dev', path: 'helm-charts/jung2bot', helm: jung2botHelm { valueFiles: ['value/dev.yaml'] } },
   { wave: '10', name: 'yaade-volume', namespace: 'yaade' },
   { wave: '11', name: 'home-assistant', namespace: 'home-assistant' },
   { wave: '11', name: 'yaade', namespace: 'yaade' },

--- a/helm-charts/argocd/templates/external-secret.yaml
+++ b/helm-charts/argocd/templates/external-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-jsonnet-secret
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: argocd-secret
+        metadataPolicy: None
+        property: AWS_ACCOUNT_ID
+      secretKey: AWS_ACCOUNT_ID

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 argo-cd:
   global:
     affinity:
@@ -17,7 +19,69 @@ argo-cd:
       server.insecure: true
       server.basehref: /argocd/
       server.rootpath: /argocd
+    cmp:
+      create: true
+      plugins:
+        jsonnet-with-secret:
+          discover:
+            fileName: "manifest.jsonnet"
+          generate:
+            command: [ "sh", "-c" ]
+            args: [ "jsonnet --yaml-stream manifest.jsonnet --ext-str AWS_ACCOUNT_ID > /tmp/rendered.yaml && cat /tmp/rendered.yaml" ]
   dex:
     enabled: false
   notifications:
     enabled: false
+  repoServer:
+    containerSecurityContext:
+      runAsUser: 999
+    rbac:
+      - apiGroups: [ "" ]
+        resources: [ "secrets" ]
+        verbs: [ "get" ]
+        resourceNames: [ "argocd-jsonnet-secret" ]
+    initContainers:
+      - name: wait-for-secret
+        image: bitnami/kubectl
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Waiting for secret argocd-jsonnet-secret..."
+            until kubectl get secret argocd-jsonnet-secret -n argocd; do
+              echo "Secret not found, retrying in 5 seconds..."
+              sleep 5
+            done
+            echo "Secret argocd-jsonnet-secret found!"
+        securityContext:
+          runAsUser: 1000
+    extraContainers:
+      - name: jsonnet-with-secret
+        env:
+          - name: AWS_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: argocd-jsonnet-secret
+                key: AWS_ACCOUNT_ID
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+        image: bitnami/jsonnet
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            subPath: jsonnet-with-secret.yaml
+            name: argocd-cmp-cm
+          - mountPath: /tmp
+            name: cmp-tmp
+    volumes:
+      - name: argocd-cmp-cm
+        configMap:
+          name: argocd-cmp-cm
+      - name: cmp-tmp
+        emptyDir: { }

--- a/helm-charts/home-assistant-volume/Chart.lock
+++ b/helm-charts/home-assistant-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
-  repository: file://../longhorn-volume-lib
+  repository: https://siutsin.github.io/otaru
   version: 0.2.0
-digest: sha256:aaa34bf93692fee01818b2a2226f63c07f301a98f3060bc596d5085d4a7dd8a8
-generated: "2024-10-25T13:32:22.523038+01:00"
+digest: sha256:b8539486a50330242c63638c99a24fc3ea047f2d6b1a2bb9d34eacaa01415101
+generated: "2025-05-20T20:39:57.961959+01:00"

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: longhorn-volume-lib
     version: 0.2.0
-    repository: file://../longhorn-volume-lib
+    repository: https://siutsin.github.io/otaru

--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -63,7 +63,7 @@ spec:
         spec:
           containers:
             - name: scale-up-database
-              image: curlimages/curl:latest
+              image: curlimages/curl
               command: [ "curl" ]
               args:
                 - "-v"

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                     operator: NotIn
                     values:
                       - "true"
-      automountServiceAccountToken: false
+      serviceAccountName: {{ .Values.name }}
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
@@ -84,14 +84,4 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: EVENT_QUEUE_URL
-                  name: jung2bot-secrets
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  key: AWS_ACCESS_KEY_ID
-                  name: jung2bot-secrets
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: AWS_SECRET_ACCESS_KEY
                   name: jung2bot-secrets

--- a/helm-charts/jung2bot/templates/external-secret.yaml
+++ b/helm-charts/jung2bot/templates/external-secret.yaml
@@ -24,20 +24,6 @@ spec:
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: EVENT_QUEUE_URL
-    - secretKey: AWS_ACCESS_KEY_ID
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: {{ .Values.secret.remoteRef.key }}
-        metadataPolicy: None
-        property: AWS_ACCESS_KEY_ID
-    - secretKey: AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: {{ .Values.secret.remoteRef.key }}
-        metadataPolicy: None
-        property: AWS_SECRET_ACCESS_KEY
     - secretKey: OFF_FROM_WORK_URL
       remoteRef:
         conversionStrategy: Default

--- a/helm-charts/jung2bot/templates/irsa.yaml
+++ b/helm-charts/jung2bot/templates/irsa.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.irsa.awsAccountId }}:role/{{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -5,6 +5,9 @@ secret:
   remoteRef:
     key: jung2bot
 
+irsa:
+  awsAccountId: ~
+
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot

--- a/helm-charts/yaade-volume/Chart.lock
+++ b/helm-charts/yaade-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
-  repository: file://../longhorn-volume-lib
+  repository: https://siutsin.github.io/otaru
   version: 0.2.0
-digest: sha256:aaa34bf93692fee01818b2a2226f63c07f301a98f3060bc596d5085d4a7dd8a8
-generated: "2024-10-25T13:27:45.556341+01:00"
+digest: sha256:b8539486a50330242c63638c99a24fc3ea047f2d6b1a2bb9d34eacaa01415101
+generated: "2025-05-20T20:40:15.372637+01:00"

--- a/helm-charts/yaade-volume/Chart.yaml
+++ b/helm-charts/yaade-volume/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: longhorn-volume-lib
     version: 0.2.0
-    repository: file://../longhorn-volume-lib
+    repository: https://siutsin.github.io/otaru

--- a/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
@@ -21,10 +21,10 @@ inputs = {
     dynamodb = {
       actions = ["dynamodb:*"]
       resources = [
-        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds",
-        "arn:aws:dynamodb:*:*:table/${local.name}-messages",
-        "arn:aws:dynamodb:*:*:table/${local.name}-chatIds/index/*",
-        "arn:aws:dynamodb:*:*:table/${local.name}-messages/index/*",
+        "arn:aws:dynamodb:*:*:table/${local.name}-prod-chatIds",
+        "arn:aws:dynamodb:*:*:table/${local.name}-prod-messages",
+        "arn:aws:dynamodb:*:*:table/${local.name}-prod-chatIds/index/*",
+        "arn:aws:dynamodb:*:*:table/${local.name}-prod-messages/index/*",
       ]
     }
     dynamodb-generic = {
@@ -34,7 +34,7 @@ inputs = {
     sqs = {
       actions = ["sqs:*"]
       resources = [
-        "arn:aws:sqs:*:*:${local.name}-event-queue",
+        "arn:aws:sqs:*:*:${local.name}-prod-event-queue",
       ]
     }
     sqs-generic = {


### PR DESCRIPTION
## Summary by Sourcery

Migrate jung2bot to AWS IRSA for authentication, remove static AWS credentials, enhance Argo CD plugin to fetch AWS_ACCOUNT_ID dynamically, update Terraform policies and chart dependencies, and adjust CI workflow.

New Features:
- Add IRSA ServiceAccount, Role, and RoleBinding resources in the jung2bot Helm chart
- Introduce an ExternalSecret in the Argo CD chart to supply AWS_ACCOUNT_ID for the JSONNET plugin

Enhancements:
- Remove direct AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY injection from jung2bot deployment and external secrets in favor of IRSA
- Configure Argo CD CMP jsonnet-with-secret plugin with init and sidecar containers to render manifests with AWS_ACCOUNT_ID
- Pass AWS_ACCOUNT_ID as a Helm value and JSONNET extVar in manifest.jsonnet for jung2bot applications
- Update Terraform IAM policies to reference '-prod' suffix DynamoDB tables and SQS queues
- Switch volume chart dependencies to use remote Helm repository URLs
- Remove explicit ':latest' tag from the curlimages/curl image in the cron job

CI:
- Add siutsin Helm repository to the GitHub Actions release workflow