### PR TITLE
run only when there is code change

### DIFF
--- a/.github/workflows/publish-healthcheck.yaml
+++ b/.github/workflows/publish-healthcheck.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - applications/healthcheck/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish-kubernetes-service-patcher.yaml
+++ b/.github/workflows/publish-kubernetes-service-patcher.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - applications/kubernetes-service-patcher/**
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary by Sourcery

Add path filters to GitHub Actions workflows so they only run when code changes in their respective application directories.

CI:
- Add paths filter to publish-healthcheck workflow to trigger only on changes under applications/healthcheck/**.
- Add paths filter to publish-kubernetes-service-patcher workflow to trigger only on changes under applications/kubernetes-service-patcher/**.