### PR TITLE
update renovatebot for github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -27,7 +27,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@5b950139b732971f3c4338f6d8bdc2015a47661c
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
 
       - name: add repos
         run: |
@@ -50,7 +50,7 @@ jobs:
           helm repo add stakater https://stakater.github.io/stakater-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@3e001cb8c68933439c7e721650f20a07a1a5c61e
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: helm-charts
           skip_existing: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,13 +2,14 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'helpers:pinGitHubActionDigests',
   ],
   automerge: true,
   major: {
     automerge: false,
   },
   minimumReleaseAge: '3 days',
-  rebaseWhen: "behind-base-branch",
+  rebaseWhen: 'behind-base-branch',
   packageRules: [
     {
       matchDepNames: [


### PR DESCRIPTION
## Summary by Sourcery

Update the CI pipeline by bumping key GitHub Actions versions in the release workflow and refresh the Renovate bot configuration.

CI:
- Update release workflow to use actions/checkout@v4.2.2, azure/setup-helm@v4.3.0, and helm/chart-releaser-action@v1.7.0

Chores:
- Update renovate.json5 configuration for GitHub Actions