### PR TITLE
always ignore preserveUnknownFields

### DIFF
--- a/argocd/lib/argocd-application.libsonnet
+++ b/argocd/lib/argocd-application.libsonnet
@@ -41,7 +41,15 @@ local ArgoCDApplication(config={}, revision=defaultRevision) = {
         'CreateNamespace=true',
       ] + std.get(config, 'syncOptions', []),
     },
-    [if 'ignoreDifferences' in config then 'ignoreDifferences']: config.ignoreDifferences,
+    ignoreDifferences: [
+      {
+        group: 'apiextensions.k8s.io',
+        kind: 'CustomResourceDefinition',
+        jsonPointers: [
+          '/spec/preserveUnknownFields',
+        ],
+      },
+    ] + (if 'ignoreDifferences' in config then config.ignoreDifferences else []),
   },
 };
 {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add a default ignoreDifferences entry to ignore the /spec/preserveUnknownFields pointer on apiextensions.k8s.io CustomResourceDefinition resources