### PR TITLE
add minio heartbeat

### DIFF
--- a/helm-charts/monitoring/templates/heartbeat.yaml
+++ b/helm-charts/monitoring/templates/heartbeat.yaml
@@ -75,3 +75,42 @@ spec:
     - min: 200
       max: 299
   interval: 5m
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $minioEndpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $minioEndpointTypes }}
+    - secretKey: minio-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: heartbeats
+        metadataPolicy: None
+        property: minio-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: minio-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: minio-heartbeat
+    targetEndpointKey: minio-target-endpoint
+    healthyEndpointKey: minio-healthy-endpoint
+    unhealthyEndpointKey: minio-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m


### PR DESCRIPTION
## Summary by Sourcery

Add monitoring support for MinIO by provisioning an ExternalSecret and a Heartbeat resource to periodically check its target, healthy, and unhealthy endpoints.

New Features:
- Add ExternalSecret resource to retrieve minio target, healthy, and unhealthy endpoints from the onepassword-secret-store
- Add Heartbeat custom resource to perform periodic health checks against the minio endpoints with a 5m interval and 200–299 expected status codes