### PR TITLE
add yaade heartbeat

### DIFF
--- a/helm-charts/yaade/templates/heartbeat.yaml
+++ b/helm-charts/yaade/templates/heartbeat.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $endpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $endpointTypes }}
+    - secretKey: {{ $.Values.name }}-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: heartbeats
+        metadataPolicy: None
+        property: {{ $.Values.name }}-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: {{ .Values.name }}-heartbeat
+    targetEndpointKey: {{ .Values.name }}-target-endpoint
+    healthyEndpointKey: {{ .Values.name }}-healthy-endpoint
+    unhealthyEndpointKey: {{ .Values.name }}-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m


### PR DESCRIPTION
## Summary by Sourcery

Add heartbeat monitoring support to the yaade Helm chart by templating ExternalSecret and Heartbeat resources

New Features:
- Introduce an ExternalSecret in the yaade Helm chart to fetch target, healthy, and unhealthy heartbeat endpoints from the onepassword secret store
- Add a Heartbeat custom resource to regularly probe those endpoints with 200–299 status code expectations at a 5-minute interval