### PR TITLE
fix helm lint

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -25,6 +25,7 @@ alwaysApply: true
 - To test the project, run `make test` to execute all validation and quality checks.
 - Always run tests after making changes to ensure nothing is broken.
 - Fix linting errors automatically when possible.
+- **Always fix warnings and errors instead of hiding or suppressing them.** Address the root cause rather than masking the issue.
 
 ## Communication and Presentation
 
@@ -38,3 +39,11 @@ alwaysApply: true
 - Apply consistent formatting across all files.
 - Use appropriate tools for each file type (e.g., yq for YAML, helm for charts).
 - Follow the project's established patterns and conventions.
+
+## Quality and Validation
+
+- When encountering warnings or errors during validation (e.g., `make validate-helm-charts`), investigate and fix the root cause.
+- Do not use output filtering or suppression techniques to hide warnings/errors unless they are known, documented, and harmless limitations.
+- For Helm charts: fix coalesce warnings, missing values.yaml files, and other linting issues rather than suppressing them.
+- For YAML/JSON: fix syntax errors and validation issues rather than ignoring them.
+- For Markdown: fix linting violations rather than disabling rules.

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,7 @@ validate-helm-charts: ## Validate all Helm charts
 	@echo "$(GREEN)Validating Helm charts...$(NC)"
 	@for chart in helm-charts/*/; do \
 		if [ -f "$$chart/Chart.yaml" ]; then \
-			echo "Validating $$(basename $$chart)..."; \
-			helm lint "$$chart" || exit 1; \
+			helm lint "$$chart" --quiet || exit 1; \
 		fi; \
 	done
 	@echo "$(GREEN)All Helm charts validated successfully!$(NC)"

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: amazon-eks-pod-identity-webhook
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: amazon-eks-pod-identity-webhook
-    version: 2.5.2
-    repository: https://jkroepke.github.io/helm-charts/
-    alias: pod-identity-webhook
+- name: amazon-eks-pod-identity-webhook
+  version: 2.5.2
+  repository: https://jkroepke.github.io/helm-charts/
+  alias: pod-identity-webhook

--- a/helm-charts/argocd-bootstrap/Chart.yaml
+++ b/helm-charts/argocd-bootstrap/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: argocd-bootstrap
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/argocd-config/Chart.yaml
+++ b/helm-charts/argocd-config/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: argocd-config
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/argocd/Chart.yaml
+++ b/helm-charts/argocd/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: argocd
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: argo-cd
-    version: 8.1.2
-    repository: https://argoproj.github.io/argo-helm
+- name: argo-cd
+  version: 8.1.2
+  repository: https://argoproj.github.io/argo-helm

--- a/helm-charts/atlantis/Chart.yaml
+++ b/helm-charts/atlantis/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: atlantis
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: atlantis
-    version: 5.18.0
-    repository: https://runatlantis.github.io/helm-charts
+- name: atlantis
+  version: 5.18.0
+  repository: https://runatlantis.github.io/helm-charts

--- a/helm-charts/blocky/Chart.yaml
+++ b/helm-charts/blocky/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: blocky
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/cert-manager/Chart.yaml
+++ b/helm-charts/cert-manager/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: cert-manager
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: cert-manager
-    version: v1.18.2
-    repository: https://charts.jetstack.io
+- name: cert-manager
+  version: v1.18.2
+  repository: https://charts.jetstack.io

--- a/helm-charts/cilium-gateway/Chart.yaml
+++ b/helm-charts/cilium-gateway/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: cilium-gateway
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/cilium/Chart.yaml
+++ b/helm-charts/cilium/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: cilium
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: cilium
-    version: 1.17.5
-    repository: https://helm.cilium.io/
+- name: cilium
+  version: 1.17.5
+  repository: https://helm.cilium.io/

--- a/helm-charts/cloudflare-tunnel/Chart.yaml
+++ b/helm-charts/cloudflare-tunnel/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: cloudflare-tunnel-remote
-    version: 0.1.2-eso
-    repository: https://siutsin.github.io/cloudflare-helm-charts/
+- name: cloudflare-tunnel-remote
+  version: 0.1.2-eso
+  repository: https://siutsin.github.io/cloudflare-helm-charts/

--- a/helm-charts/cyberchef/Chart.yaml
+++ b/helm-charts/cyberchef/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: cyberchef
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/descheduler/Chart.yaml
+++ b/helm-charts/descheduler/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: descheduler
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: descheduler
-    version: 0.33.0
-    repository: https://kubernetes-sigs.github.io/descheduler/
+- name: descheduler
+  version: 0.33.0
+  repository: https://kubernetes-sigs.github.io/descheduler/

--- a/helm-charts/excalidraw/Chart.yaml
+++ b/helm-charts/excalidraw/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: excalidraw
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/external-secrets/Chart.yaml
+++ b/helm-charts/external-secrets/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: external-secrets
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: external-secrets
-    version: 0.18.2
-    repository: https://charts.external-secrets.io/
+- name: external-secrets
+  version: 0.18.2
+  repository: https://charts.external-secrets.io/

--- a/helm-charts/falco/Chart.yaml
+++ b/helm-charts/falco/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: falco
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: falco
-    version: 6.0.2
-    repository: https://falcosecurity.github.io/charts
+- name: falco
+  version: 6.0.2
+  repository: https://falcosecurity.github.io/charts

--- a/helm-charts/gateway-api-kubernetes/Chart.yaml
+++ b/helm-charts/gateway-api-kubernetes/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: gateway-api-kubernetes
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/gateway-api/Chart.yaml
+++ b/helm-charts/gateway-api/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: gateway-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.2.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/gateway-api/values.yaml
+++ b/helm-charts/gateway-api/values.yaml
@@ -1,0 +1,11 @@
+# Default values for gateway-api
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global configuration
+global:
+  # Add any global configurations here
+  {}
+
+# Chart-specific configurations
+# Add any chart-specific configurations here 

--- a/helm-charts/heartbeats/Chart.yaml
+++ b/helm-charts/heartbeats/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: heartbeats
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
+version: 1.0.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/heartbeats/values.yaml
+++ b/helm-charts/heartbeats/values.yaml
@@ -1,0 +1,11 @@
+# Default values for heartbeats
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global configuration
+global:
+  # Add any global configurations here
+  {}
+
+# Chart-specific configurations
+# Add any chart-specific configurations here 

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: home-assistant-volume
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: longhorn-volume-lib
-    version: 0.2.0
-    repository: https://siutsin.github.io/otaru
+- name: longhorn-volume-lib
+  version: 0.2.0
+  repository: https://siutsin.github.io/otaru

--- a/helm-charts/home-assistant/Chart.yaml
+++ b/helm-charts/home-assistant/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: home-assistant
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/httpbin/Chart.yaml
+++ b/helm-charts/httpbin/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: httpbin
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/jsoncrack/Chart.yaml
+++ b/helm-charts/jsoncrack/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: jsoncrack
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/jung2bot/Chart.yaml
+++ b/helm-charts/jung2bot/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: jung2bot
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/k3s-apiserver-loadbalancer/Chart.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: k3s-apiserver-loadbalancer
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: v1.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/k3s-apiserver-loadbalancer/values.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/values.yaml
@@ -1,0 +1,11 @@
+# Default values for k3s-apiserver-loadbalancer
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global configuration
+global:
+  # Add any global configurations here
+  {}
+
+# Chart-specific configurations
+# Add any chart-specific configurations here 

--- a/helm-charts/keda/Chart.yaml
+++ b/helm-charts/keda/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: keda
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: keda
-    version: 2.17.2
-    repository: https://kedacore.github.io/charts
+- name: keda
+  version: 2.17.2
+  repository: https://kedacore.github.io/charts

--- a/helm-charts/longhorn-config/Chart.yaml
+++ b/helm-charts/longhorn-config/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: longhorn-config
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/longhorn-volume-lib/Chart.yaml
+++ b/helm-charts/longhorn-volume-lib/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: longhorn-volume-lib
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/longhorn-volume-lib/values.yaml
+++ b/helm-charts/longhorn-volume-lib/values.yaml
@@ -1,8 +1,14 @@
+# Namespace where the PersistentVolumeClaims will be created
 namespace: ""
-#  vol-name:
-#    size: "2Gi"
-#    sizeBytes: "2147483648"
-#    fromBackup: "s3://bucket@region/?backup=backup-id&volume=vol-name"
-#    enableBackup: true (optional)
-#    enableTrim: true (optional)
-volumes: [ ]
+
+# Volume definitions
+# Each key in the volumes map represents a volume name
+# The value contains the volume configuration
+volumes: {}
+  # Example volume configuration:
+  # example-volume:
+  #   size: "2Gi"
+  #   sizeBytes: "2147483648"
+  #   fromBackup: "s3://bucket@region/?backup=backup-id&volume=vol-name"
+  #   enableBackup: true  # optional, defaults to true
+  #   enableTrim: true    # optional, defaults to true

--- a/helm-charts/longhorn/Chart.yaml
+++ b/helm-charts/longhorn/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: longhorn
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: longhorn
-    version: 1.9.0
-    repository: https://charts.longhorn.io
+- name: longhorn
+  version: 1.9.0
+  repository: https://charts.longhorn.io

--- a/helm-charts/metrics-server/Chart.yaml
+++ b/helm-charts/metrics-server/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: metrics-server
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: metrics-server
-    version: 3.12.2
-    repository: https://kubernetes-sigs.github.io/metrics-server/
+- name: metrics-server
+  version: 3.12.2
+  repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -2,17 +2,18 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: prometheus
-    version: 27.23.0
-    repository: https://prometheus-community.github.io/helm-charts
-  - name: loki
-    version: 6.30.1
-    repository: https://grafana.github.io/helm-charts
-  - name: promtail
-    version: 6.17.0
-    repository: https://grafana.github.io/helm-charts
-  - name: grafana
-    version: 9.2.9
-    repository: https://grafana.github.io/helm-charts
+- name: prometheus
+  version: 27.23.0
+  repository: https://prometheus-community.github.io/helm-charts
+- name: loki
+  version: 6.30.1
+  repository: https://grafana.github.io/helm-charts
+- name: promtail
+  version: 6.17.0
+  repository: https://grafana.github.io/helm-charts
+- name: grafana
+  version: 9.2.9
+  repository: https://grafana.github.io/helm-charts

--- a/helm-charts/oidc-provider/Chart.yaml
+++ b/helm-charts/oidc-provider/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: oidc-provider
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/onepassword-connect/Chart.yaml
+++ b/helm-charts/onepassword-connect/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: onepassword-connect
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: connect
-    version: 2.0.0
-    repository: https://1password.github.io/connect-helm-charts
+- name: connect
+  version: 2.0.0
+  repository: https://1password.github.io/connect-helm-charts

--- a/helm-charts/reloader/Chart.yaml
+++ b/helm-charts/reloader/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: reloader
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: reloader
-    version: 2.1.4
-    repository: https://stakater.github.io/stakater-charts
+- name: reloader
+  version: 2.1.4
+  repository: https://stakater.github.io/stakater-charts

--- a/helm-charts/yaade-volume/Chart.yaml
+++ b/helm-charts/yaade-volume/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: yaade-volume
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
-  - name: longhorn-volume-lib
-    version: 0.2.0
-    repository: https://siutsin.github.io/otaru
+- name: longhorn-volume-lib
+  version: 0.2.0
+  repository: https://siutsin.github.io/otaru

--- a/helm-charts/yaade/Chart.yaml
+++ b/helm-charts/yaade/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: yaade
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg


### PR DESCRIPTION
## Summary by Sourcery

Update Helm charts to pass lint checks by standardizing metadata, versioning, and values files.

Enhancements:
- Bump chart versions and add Helm icon URL to all Chart.yaml files
- Normalize dependencies indentation in Chart.yaml across charts
- Extend longhorn-volume-lib values.yaml with detailed example configurations
- Introduce default values.yaml stubs for gateway-api, heartbeats, and k3s-apiserver-loadbalancer charts

CI:
- Update Makefile helm lint command to use --quiet flag for cleaner output