### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Bare-Metal Home Lab for Kubernetes and Technical Playground.
 4. **Bootstrap Cluster**
 
    ```shell
-   make
+   make setup-cluster
    ```
 
 ## Oopsy


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Change cluster bootstrap instruction from `make` to `make setup-cluster` in README