### PR TITLE
fix scheduled backup

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/scheduled-backups.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/scheduled-backups.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   cluster:
     name: {{ $clusterConfig.clusterName }}
-  schedule: {{ $scheduledBackup.schedule | default "0 2 * * *" | quote }}
+  schedule: {{ $scheduledBackup.schedule | default "0 0 2 * * *" | quote }}
   method: plugin
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -36,7 +36,7 @@ defaults:
       enabled: false
   scheduledBackup:
     enabled: true
-    schedule: "0 2 * * *"
+    schedule: "0 0 2 * * *"
   objectStore:
     retentionPolicy: 2d
     wal:


### PR DESCRIPTION
## Summary by Sourcery

Fix the default scheduled backup cron expression to include seconds and ensure it runs daily at 02:00 UTC

Bug Fixes:
- Update default cron schedule in template from "0 2 * * *" to "0 0 2 * * *"

Enhancements:
- Sync the default schedule value in values.yaml with the updated template format