### PR TITLE
fix image tag

### DIFF
--- a/helm-charts/teslamate/templates/deployment.yaml
+++ b/helm-charts/teslamate/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: teslamate
-          image: "{{ .Values.deployment.image.image }}:{{ .Values.deployment.image.tag }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
           env: {{ toYaml .Values.deployment.env | nindent 12 }}
           envFrom: {{ toYaml .Values.deployment.envFrom | nindent 12 }}
           ports:

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -3,8 +3,8 @@ namespace: teslamate
 
 deployment:
   image:
-    image: teslamate/teslamate@sha256:e580b5e806e07baa204823d5cf7873a733e9dbebcf3993dbe5df029fefdec38c
-    tag: 2.1.0
+    repository: teslamate/teslamate
+    tag: 2.1.0@sha256:e580b5e806e07baa204823d5cf7873a733e9dbebcf3993dbe5df029fefdec38c
   env:
     - name: DISABLE_MQTT
       value: "true"


### PR DESCRIPTION
## Summary by Sourcery

Fix the Helm chart to correctly configure the teslamate image by splitting repository and tag fields and embedding the digest in the tag

Bug Fixes:
- Rename the image field to repository in values.yaml and update the Helm template to reference it

Enhancements:
- Combine version and digest into the tag field for image immutability