### PR TITLE
disable wal cos it is £££

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/README.md
+++ b/helm-charts/cloudnative-pg-clusters/README.md
@@ -23,7 +23,7 @@ defaults:
     plugins:
     - enabled: true
       name: "barman-cloud.cloudnative-pg.io"
-      isWALArchiver: true
+      isWALArchiver: false  # Disabled to reduce costs
       parameters:
         barmanObjectName: "b2-backup"
     backup:
@@ -73,6 +73,18 @@ clusters:
 ```bash
 helm install cloudnative-pg-clusters ./helm-charts/cloudnative-pg-clusters/
 ```
+
+## WAL Configuration
+
+This chart is configured to minimise WAL (Write-Ahead Logging) costs:
+
+- **WAL Archiving**: Disabled (`isWALArchiver: false`) to reduce storage costs
+- **WAL Level**: Set to `minimal` to reduce logging overhead
+- **WAL Retention**: Reduced to 256MB for both `max_slot_wal_keep_size` and `wal_keep_size`
+- **Checkpoint Timeout**: Increased to 30 minutes to reduce checkpoint frequency
+- **Max WAL Size**: Reduced to 2GB to minimise storage usage
+
+These settings prioritise cost reduction over advanced recovery capabilities. For production environments requiring point-in-time recovery, consider re-enabling WAL archiving.
 
 ## Generated Resources
 

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -18,15 +18,16 @@ defaults:
     plugins:
       - enabled: true
         name: barman-cloud.cloudnative-pg.io
-        isWALArchiver: true
+        isWALArchiver: false
         parameters:
           barmanObjectName: b2-backup
     postgresql: &postgresql
       parameters:
-        checkpoint_timeout: "15min"     # Longer interval to reduce WAL generation
-        max_slot_wal_keep_size: "512MB" # Cap WAL for inactive slots
-        max_wal_size: "4GB"             # Increase to reduce checkpoint frequency
-        wal_keep_size: "512MB"          # Limit WAL retention for replicas
+        checkpoint_timeout: "30min"     # Longer interval to reduce WAL generation
+        max_slot_wal_keep_size: "256MB" # Reduce WAL for inactive slots
+        max_wal_size: "2GB"             # Reduce WAL size to minimise storage
+        wal_keep_size: "256MB"          # Reduce WAL retention for replicas
+        wal_level: "minimal"            # Minimal WAL logging to reduce costs
       pg_hba: # Default pg_hba configuration for certificate-only authentication
         - hostssl all all 0.0.0.0/0 cert
         - hostssl all all ::0/0 cert


### PR DESCRIPTION
## Summary by Sourcery

Optimize Helm chart defaults to reduce PostgreSQL WAL storage costs by disabling archiving, lowering WAL retention and logging levels, and adjusting checkpoint and size parameters.

Enhancements:
- Disable WAL archiving in the default plugin configuration
- Set WAL logging level to minimal
- Reduce WAL retention sizes and maximum WAL file size
- Increase checkpoint timeout to lower checkpoint frequency

Documentation:
- Add a ‘WAL Configuration’ section to the README with cost-optimized parameter explanations