### PR TITLE
config loki retention

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -64,6 +64,8 @@ loki:
     enabled: true
     nodeSelector:
       volume: "true"
+    persistence:
+      size: 20Gi
   chunksCache:
     enabled: false
 
@@ -80,9 +82,13 @@ loki:
           index:
             prefix: loki_index_
             period: 24h
+    compactor:
+      working_directory: /var/loki/compactor
+      retention_enabled: true
     pattern_ingester:
       enabled: true
     limits_config:
+      retention_period: 7d
       allow_structured_metadata: true
       volume_enabled: true
     rulerConfig:


### PR DESCRIPTION
## Summary by Sourcery

Configure default persistence and retention settings for Loki in Helm chart

Enhancements:
- Add default persistence size of 20Gi for Loki
- Enable Loki compactor with specified working directory and retention enabled
- Set limits_config retention_period to 7 days