### PR TITLE
remove minio and fix cnpg config

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -27,7 +27,7 @@ defaults:
         max_slot_wal_keep_size: "256MB" # Reduce WAL for inactive slots
         max_wal_size: "2GB"             # Reduce WAL size to minimise storage
         wal_keep_size: "256MB"          # Reduce WAL retention for replicas
-        wal_level: "minimal"            # Minimal WAL logging to reduce costs
+        wal_level: "replica"            # Replica WAL level required for HA/replication
       pg_hba: # Default pg_hba configuration for certificate-only authentication
         - hostssl all all 0.0.0.0/0 cert
         - hostssl all all ::0/0 cert

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -54,21 +54,18 @@ grafana:
       disable_sanitize_html: true
 
 loki:
-  # Single Replica mode
   deploymentMode: SingleBinary
   singleBinary:
     replicas: 1
     nodeSelector:
       volume: "true"
   minio:
-    enabled: true
-    nodeSelector:
-      volume: "true"
-    persistence:
-      size: 20Gi
+    enabled: false
   chunksCache:
     enabled: false
-
+  memberlist:
+    service:
+      publishNotReadyAddresses: true
   loki:
     commonConfig:
       replication_factor: 1
@@ -77,7 +74,7 @@ loki:
       configs:
         - from: "2024-04-01"
           store: tsdb
-          object_store: s3
+          object_store: filesystem
           schema: v13
           index:
             prefix: loki_index_
@@ -85,7 +82,8 @@ loki:
     compactor:
       working_directory: /var/loki/compactor
       retention_enabled: true
-      delete_request_store: s3
+      retention_delete_delay: 1h
+      delete_request_store: filesystem
     pattern_ingester:
       enabled: true
     limits_config:
@@ -94,6 +92,8 @@ loki:
       volume_enabled: true
     rulerConfig:
       enable_api: true
+    storage:
+      type: filesystem
 
   # Zero-out replica counts of other deployment modes
   backend:
@@ -115,8 +115,6 @@ loki:
   compactor:
     replicas: 0
   indexGateway:
-    replicas: 0
-  bloomCompactor:
     replicas: 0
   bloomGateway:
     replicas: 0

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -85,6 +85,7 @@ loki:
     compactor:
       working_directory: /var/loki/compactor
       retention_enabled: true
+      delete_request_store: s3
     pattern_ingester:
       enabled: true
     limits_config:


### PR DESCRIPTION
## Summary by Sourcery

Disable embedded MinIO in the Loki Helm chart and migrate its storage and compactor settings to the local filesystem, add memberlist configuration, remove unused bloomCompactor, and update the cloudnative-pg default WAL level for replication.

Enhancements:
- Disable embedded MinIO and remove its persistence configuration in the Loki Helm values
- Switch Loki object_store and delete_request_store to filesystem and set storage type to filesystem
- Add compactor retention_delete_delay and filesystem delete_request_store settings for Loki
- Enable memberlist service.publishNotReadyAddresses in Loki configuration
- Remove bloomCompactor replica zeroing from the Loki chart
- Update cloudnative-pg default wal_level from minimal to replica for HA/replication