### PR TITLE
Update test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@000eeb8522f0572907c393e8151076c205fdba1b # v1


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Pin Helm to version 3.18.4 in the GitHub Actions .github/workflows/test.yaml configuration