### PR TITLE
housekeeping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ help: ## Show this help message
 
 define ansible_playbook
 	@echo "$(GREEN)Running $(1) playbook...$(NC)"
-	ansible-playbook -i $(ANSIBLE_INVENTORY) ansible/playbooks/$(1).yaml
+	ansible-playbook -v -i $(ANSIBLE_INVENTORY) ansible/playbooks/$(1).yaml
 endef
 
 # Ansible playbook targets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # otaru
 
-![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.32.6+k3s1-blue)
+![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.33.4+k3s1-blue)
 
 > Over-Engineering at Its Finest.
 

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -34,7 +34,7 @@ all:
       children:
         node00: { }
         node01: { }
-        node02: { }
+#        node02: { }
         node03: { }
     worker:
       children: { }
@@ -42,7 +42,7 @@ all:
       children:
         node00: { }
         node01: { }
-        node02: { }
+#        node02: { }
     pineberry_pi_hatdrive:
       children:
         node03: { }


### PR DESCRIPTION
## Summary by Sourcery

Perform housekeeping by enabling verbose output for Ansible runs, updating the Kubernetes version badge, and disabling an unused inventory host.

Enhancements:
- Enable verbose flag (-v) for ansible-playbook in the Makefile.

Documentation:
- Update Kubernetes version badge in README to v1.33.4+k3s1.

Chores:
- Comment out node02 entry in the Ansible inventory.