### PR TITLE
Remove Wi-Fi networking, use eth only with higher priority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(BLUE)Cluster Management:$(NC)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		grep -E "^(setup-cluster|build-cluster|maintenance|nuke-cluster|restart-all|upgrade-cluster):" | \
+		grep -E "^(setup-cluster|reconcile-node-k3s|build-cluster|maintenance|nuke-cluster|restart-all|upgrade-cluster):" | \
 		sort | awk 'BEGIN {FS = ":.*?## "}; {gsub(/\(DANGEROUS!\)/, "$(RED)(DANGEROUS!)$(NC)"); printf "  $(YELLOW)%-25s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(MAGENTA)Development & Infrastructure:$(NC)"
@@ -55,6 +55,10 @@ endef
 .PHONY: setup-cluster
 setup-cluster: ## Run complete cluster setup playbook (etcd + rpi + k3s)
 	$(call ansible_playbook,setup-cluster)
+
+.PHONY: reconcile-node-k3s
+reconcile-node-k3s: ## Reconcile Raspberry Pi node and k3s playbooks without touching etcd
+	$(call ansible_playbook,reconcile-node-k3s)
 
 .PHONY: maintenance
 maintenance: ## Run maintenance ansible playbook

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ Bare-Metal Home Lab for Kubernetes and Technical Playground.
     make setup-cluster
     ```
 
+    To reconcile Raspberry Pi node configuration and K3s
+    without touching etcd:
+
+    ```shell
+    make reconcile-node-k3s
+    ```
+
 ## Oopsy
 
 Update host packages and reboot the entire cluster.
@@ -199,6 +206,13 @@ Rebuild the cluster.
 
 ```shell
 make build-cluster
+```
+
+Reconcile Raspberry Pi node configuration and K3s without
+touching etcd.
+
+```shell
+make reconcile-node-k3s
 ```
 
 Restart all workloads.

--- a/README.md
+++ b/README.md
@@ -159,10 +159,9 @@ Bare-Metal Home Lab for Kubernetes and Technical Playground.
     rpi_wifi_password: <password>
     ```
 
-    Raspberry Pi inventory entries use two networking variables:
+    Raspberry Pi inventory entries use one networking variable:
 
     - `ansible_host`: the current Ansible connection target
-    - `ansible_host_eth`: the static LAN IP for `eth0`
 
     Current network layout:
 

--- a/README.md
+++ b/README.md
@@ -159,20 +159,16 @@ Bare-Metal Home Lab for Kubernetes and Technical Playground.
     rpi_wifi_password: <password>
     ```
 
-    Raspberry Pi inventory entries use four networking variables:
+    Raspberry Pi inventory entries use two networking variables:
 
     - `ansible_host`: the current Ansible connection target
     - `ansible_host_eth`: the static LAN IP for `eth0`
-    - `ansible_host_wifi`: the static Wi-Fi IP for `wlan0`
-    - `ansible_host_wifi_gateway`: the Wi-Fi gateway for the SSID network
 
     Current network layout:
 
     - LAN `eth0`: `192.168.1.60-63`
-    - Wi-Fi `wlan0`: `192.168.1.80-83`
-    - Wi-Fi gateway: `192.168.1.1`
 
-    Keep `ansible_host` on LAN during rollout. After Wi-Fi access is verified, Ansible can be moved to Wi-Fi later without changing the intended interface addresses.
+    Keep `ansible_host` on LAN during rollout.
 
 5. **Bootstrap Cluster**
 

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
 inventory = ./inventory.yaml
+
+[connection]
+retries = 5

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -9,25 +9,21 @@ all:
         raspberrypi-00.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.60
-          ansible_host_eth: 192.168.1.60
     node01:
       hosts:
         raspberrypi-01.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.61
-          ansible_host_eth: 192.168.1.61
     node02:
       hosts:
         raspberrypi-02.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.62
-          ansible_host_eth: 192.168.1.62
     node03:
       hosts:
         raspberrypi-03.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.63
-          ansible_host_eth: 192.168.1.63
     etcd:
       hosts:
         ubuntu.local:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -10,32 +10,24 @@ all:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.60
           ansible_host_eth: 192.168.1.60
-          ansible_host_wifi: 192.168.1.80
-          ansible_host_wifi_gateway: 192.168.1.1
     node01:
       hosts:
         raspberrypi-01.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.61
           ansible_host_eth: 192.168.1.61
-          ansible_host_wifi: 192.168.1.81
-          ansible_host_wifi_gateway: 192.168.1.1
     node02:
       hosts:
         raspberrypi-02.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.62
           ansible_host_eth: 192.168.1.62
-          ansible_host_wifi: 192.168.1.82
-          ansible_host_wifi_gateway: 192.168.1.1
     node03:
       hosts:
         raspberrypi-03.local:
           ansible_ssh_user: pi
           ansible_host: 192.168.1.63
           ansible_host_eth: 192.168.1.63
-          ansible_host_wifi: 192.168.1.83
-          ansible_host_wifi_gateway: 192.168.1.1
     etcd:
       hosts:
         ubuntu.local:

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -8,7 +8,7 @@ all:
       hosts:
         raspberrypi-00.local:
           ansible_ssh_user: pi
-          ansible_host: raspberrypi-00.local
+          ansible_host: 192.168.1.60
           ansible_host_eth: 192.168.1.60
           ansible_host_wifi: 192.168.1.80
           ansible_host_wifi_gateway: 192.168.1.1
@@ -16,7 +16,7 @@ all:
       hosts:
         raspberrypi-01.local:
           ansible_ssh_user: pi
-          ansible_host: raspberrypi-01.local
+          ansible_host: 192.168.1.61
           ansible_host_eth: 192.168.1.61
           ansible_host_wifi: 192.168.1.81
           ansible_host_wifi_gateway: 192.168.1.1
@@ -24,7 +24,7 @@ all:
       hosts:
         raspberrypi-02.local:
           ansible_ssh_user: pi
-          ansible_host: raspberrypi-02.local
+          ansible_host: 192.168.1.62
           ansible_host_eth: 192.168.1.62
           ansible_host_wifi: 192.168.1.82
           ansible_host_wifi_gateway: 192.168.1.1
@@ -32,7 +32,7 @@ all:
       hosts:
         raspberrypi-03.local:
           ansible_ssh_user: pi
-          ansible_host: raspberrypi-03.local
+          ansible_host: 192.168.1.63
           ansible_host_eth: 192.168.1.63
           ansible_host_wifi: 192.168.1.83
           ansible_host_wifi_gateway: 192.168.1.1
@@ -57,9 +57,14 @@ all:
     pineberry_pi_hatdrive:
       children:
         node03: { }
-    volume:
+    nvme_boot:
       children:
         node02: { }
+    brcmfmac_options:
+      children:
+        node02: { }
+    extra_storage:
+      children:
         node03: { }
     raspberrypi:
       children:

--- a/ansible/playbooks/etcd/003-luks.yaml
+++ b/ansible/playbooks/etcd/003-luks.yaml
@@ -58,8 +58,7 @@
 
     - name: Wait for system to become reachable again
       wait_for:
-        host: "{{ inventory_hostname }}"
+        host: "{{ ansible_host | default(inventory_hostname, true) }}"
         port: 22
         delay: 10
         timeout: 600
-

--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -48,7 +48,7 @@
           --flannel-backend=none \
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
-          --tls-san {{ ansible_host_eth }} \
+          --tls-san {{ ansible_host }} \
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \

--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -49,7 +49,6 @@
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
           --tls-san {{ ansible_host_eth }} \
-          --tls-san {{ ansible_host_wifi }} \
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \

--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -78,6 +78,7 @@
       delegate_to: raspberrypi-00.local
       run_once: true
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"
+      changed_when: false
 
     - name: Replace 'default' with 'raspberrypi' in local kube config
       replace:
@@ -89,6 +90,7 @@
       become_user: simon
       run_once: true
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"
+      changed_when: false
 
     - name: Replace '127.0.0.1' with first master IP in local kube config
       replace:
@@ -100,3 +102,4 @@
       become_user: simon
       run_once: true
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"
+      changed_when: false

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -41,7 +41,6 @@
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
           --tls-san {{ ansible_host_eth }} \
-          --tls-san {{ ansible_host_wifi }} \
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \
@@ -61,8 +60,7 @@
         [ -f "$cert" ] || exit 1
         sans=$(openssl x509 -in "$cert" -noout -ext subjectAltName 2>/dev/null)
         echo "$sans" | grep -q "{{ LB_API_SERVER_IP }}" && \
-        echo "$sans" | grep -q "{{ ansible_host_eth }}" && \
-        echo "$sans" | grep -q "{{ ansible_host_wifi }}"
+        echo "$sans" | grep -q "{{ ansible_host_eth }}"
       register: san_check
       changed_when: false
       failed_when: false

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -40,7 +40,7 @@
           --flannel-backend=none \
           --secrets-encryption \
           --tls-san {{ LB_API_SERVER_IP }} \
-          --tls-san {{ ansible_host_eth }} \
+          --tls-san {{ ansible_host }} \
           --write-kubeconfig-mode=644 \
           --kube-apiserver-arg \
           --anonymous-auth=true \
@@ -60,7 +60,7 @@
         [ -f "$cert" ] || exit 1
         sans=$(openssl x509 -in "$cert" -noout -ext subjectAltName 2>/dev/null)
         echo "$sans" | grep -q "{{ LB_API_SERVER_IP }}" && \
-        echo "$sans" | grep -q "{{ ansible_host_eth }}"
+        echo "$sans" | grep -q "{{ ansible_host }}"
       register: san_check
       changed_when: false
       failed_when: false

--- a/ansible/playbooks/k3s/003-node-label.yaml
+++ b/ansible/playbooks/k3s/003-node-label.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: volume
+- hosts: extra_storage
 
   tasks:
     - name: Label the node as a volume node

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -13,6 +13,8 @@
 - hosts: raspberrypi
   become: true
   serial: 1
+  vars:
+    k3s_kubeconfig: /etc/rancher/k3s/k3s.yaml
 
   tasks:
     - name: Get node name by removing .local from inventory_hostname
@@ -21,6 +23,8 @@
 
     - name: Cordon the node
       command: kubectl cordon {{ node_name }}
+      environment:
+        KUBECONFIG: "{{ k3s_kubeconfig }}"
 
     - name: Drain the node, ignoring PDBs
       command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
@@ -28,16 +32,21 @@
       retries: 5
       delay: 30
       until: drain_result.rc == 0
+      environment:
+        KUBECONFIG: "{{ k3s_kubeconfig }}"
 
     - name: Reboot the system
       reboot:
+        reboot_command: systemctl reboot --job-mode=replace-irreversibly
 
     - name: Wait for system to become reachable
       wait_for:
-        host: "{{ inventory_hostname }}"
+        host: "{{ ansible_host | default(inventory_hostname, true) }}"
         port: 22
         delay: 10
         timeout: 600
 
     - name: Uncordon the node
       command: kubectl uncordon {{ node_name }}
+      environment:
+        KUBECONFIG: "{{ k3s_kubeconfig }}"

--- a/ansible/playbooks/reconcile-node-k3s.yaml
+++ b/ansible/playbooks/reconcile-node-k3s.yaml
@@ -1,0 +1,17 @@
+---
+# rpi
+- import_playbook: rpi/000-disable-write-log-to-disk.yaml
+- import_playbook: rpi/001-packages.yaml
+- import_playbook: rpi/002-pineberry-pi-hatdrive.yaml
+- import_playbook: rpi/003-waveshare-poe-hat.yaml
+- import_playbook: rpi/004-volume.yaml
+- import_playbook: rpi/005-networking.yaml
+- import_playbook: rpi/006-cgroup.yaml
+- import_playbook: rpi/007-brcmfmac-options.yaml
+# k3s
+- import_playbook: k3s/000-init-cluster.yaml
+- import_playbook: k3s/001-cni.yaml
+- import_playbook: k3s/002-nodes.yaml
+- import_playbook: k3s/003-node-label.yaml
+- import_playbook: k3s/004-fix-iptables.yaml
+- import_playbook: k3s/005-bootstrap.yaml

--- a/ansible/playbooks/rpi/000-disable-write-log-to-disk.yaml
+++ b/ansible/playbooks/rpi/000-disable-write-log-to-disk.yaml
@@ -2,24 +2,36 @@
 - hosts: raspberrypi
   become: yes
 
-  # Configure journald to use volatile storage and limit log size to prevent excessive disk writes,
-  # clear existing logs, and disable rsyslog to further reduce logging to disk.
-  # This helps extend the lifespan of the SD card by minimizing unnecessary writes.
+  # Configure journald to limit log size and reduce unnecessary disk writes.
+  # SD card nodes use volatile (RAM) storage to extend card lifespan.
+  # NVMe boot nodes use persistent storage but cap log size to 100M.
   tasks:
-    - name: Set journald to volatile storage
+    - name: Set journald to volatile storage (SD card nodes)
       lineinfile:
         path: /etc/systemd/journald.conf
         regexp: '^#?Storage='
         line: 'Storage=volatile'
+      when: inventory_hostname not in groups['nvme_boot']
       notify: &notify
         - Restart journald
         - Clear all logs in /var/log
 
-    - name: Set journald RuntimeMaxUse
+    - name: Set journald to persistent storage (NVMe boot nodes)
       lineinfile:
         path: /etc/systemd/journald.conf
-        regexp: '^#?RuntimeMaxUse='
-        line: 'RuntimeMaxUse=100M'
+        regexp: '^#?Storage='
+        line: 'Storage=persistent'
+      when: inventory_hostname in groups['nvme_boot']
+      notify: *notify
+
+    - name: Set journald max log size
+      lineinfile:
+        path: /etc/systemd/journald.conf
+        regexp: '^#?{{ item.key }}='
+        line: '{{ item.key }}={{ item.value }}'
+      loop:
+        - { key: RuntimeMaxUse, value: 100M }
+        - { key: SystemMaxUse, value: 100M }
       notify: *notify
 
     - name: Disable rsyslog service

--- a/ansible/playbooks/rpi/004-volume.yaml
+++ b/ansible/playbooks/rpi/004-volume.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: volume
+- hosts: extra_storage
   become: true
 
   tasks:

--- a/ansible/playbooks/rpi/005-networking.yaml
+++ b/ansible/playbooks/rpi/005-networking.yaml
@@ -3,29 +3,11 @@
   become: true
   gather_facts: true
   vars:
-    rpi_local_vault_file: "{{ lookup('env', 'HOME') }}/dotfiles/password/ansible_vault.yaml"
     rpi_netplan_file: /etc/netplan/50-cloud-init.yaml
     rpi_netplan_work_file: /home/pi/50-cloud-init.yaml
     rpi_eth0_address: "{{ ansible_host_eth | default(ansible_host, true) }}/24"
-    rpi_wifi_address: "{{ ansible_host_wifi | default('', true) }}"
     rpi_gateway: 192.168.1.1
     rpi_subnet: 192.168.1.0/24
-    rpi_wifi_gateway: "{{ ansible_host_wifi_gateway | default(rpi_gateway, true) }}"
-    rpi_wifi_optional: true
-    rpi_wifi_configure: "{{ (rpi_wifi_ssid | default('', true) | length > 0) and (rpi_wifi_password | default('', true) | length > 0) and (rpi_wifi_address | length > 0) }}"
-
-  pre_tasks:
-    - name: Check if local Ansible vault file exists
-      stat:
-        path: "{{ rpi_local_vault_file }}"
-      delegate_to: localhost
-      become: false
-      register: rpi_local_vault_stat
-
-    - name: Load Wi-Fi credentials from local Ansible vault
-      include_vars:
-        file: "{{ rpi_local_vault_file }}"
-      when: rpi_local_vault_stat.stat.exists
 
   tasks:
     # https://metallb.universe.tf/troubleshooting/#using-wifi-and-cant-reach-the-service
@@ -34,32 +16,24 @@
         path: /etc/systemd/system/promisc-mode.service
       register: promisc_mode_service
 
-    - name: Check if promisc-mode service is inactive or not
-      command: systemctl show promisc-mode.service --property=ActiveState
-      register: promisc_mode_status
-      changed_when: false
-      failed_when: false
-
-    - name: Create systemd service to enable promiscuous mode for eth0 and wlan0
+    - name: Create systemd service to enable promiscuous mode for eth0
       copy:
         dest: /etc/systemd/system/promisc-mode.service
         content: |
           [Unit]
-          Description=Enable promiscuous mode for eth0 and wlan0
+          Description=Enable promiscuous mode for eth0
           After=network.target
 
           [Service]
           Type=oneshot
           ExecStart=/sbin/ifconfig eth0 promisc
-          ExecStart=/sbin/ifconfig wlan0 promisc
 
           [Install]
           WantedBy=multi-user.target
         owner: root
         group: root
         mode: '0644'
-      when: promisc_mode_status.stdout.strip() != "ActiveState=inactive"
-      changed_when: true
+      when: not promisc_mode_service.stat.exists
       notify:
         - Reload systemd and start promisc-mode service
 
@@ -83,7 +57,7 @@
           (.network.ethernets.eth0.dhcp4) = false |
           (.network.ethernets.eth0.addresses) = ["{{ rpi_eth0_address }}"] |
           (.network.ethernets.eth0.routes) = [
-            {"to": "0.0.0.0/0", "via": "{{ rpi_gateway }}", "metric": 600},
+            {"to": "0.0.0.0/0", "via": "{{ rpi_gateway }}", "metric": 100},
             {"to": "0.0.0.0/0", "via": "{{ rpi_gateway }}", "table": 100},
             {"to": "{{ rpi_subnet }}", "scope": "link", "table": 100}
           ] |
@@ -92,33 +66,6 @@
         ' "{{ rpi_netplan_work_file }}"
       become: false  # Run this as pi, since the file is owned by pi
       changed_when: false
-
-    - name: Configure wlan0 netplan settings using yq
-      command: |
-        /snap/bin/yq -i '
-          del(.network.wifis.wlan0.gateway4) |
-          (.network.wifis.wlan0.dhcp4) = false |
-          (.network.wifis.wlan0.optional) = env(RPI_WIFI_OPTIONAL) == "true" |
-          (.network.wifis.wlan0.addresses) = [env(RPI_WIFI_ADDRESS) + "/24"] |
-          (.network.wifis.wlan0.routes) = [
-            {"to": "0.0.0.0/0", "via": env(RPI_WIFI_GATEWAY), "metric": 100},
-            {"to": "0.0.0.0/0", "via": env(RPI_WIFI_GATEWAY), "table": 200},
-            {"to": env(RPI_SUBNET), "scope": "link", "table": 200}
-          ] |
-          (.network.wifis.wlan0."routing-policy") = [{"from": env(RPI_WIFI_ADDRESS) + "/32", "table": 200, "priority": 200}] |
-          (.network.wifis.wlan0.nameservers.addresses) = [env(RPI_WIFI_GATEWAY)] |
-          (.network.wifis.wlan0.access-points) = {env(RPI_WIFI_SSID): {"password": env(RPI_WIFI_PASSWORD)}}
-        ' "{{ rpi_netplan_work_file }}"
-      become: false  # Run this as pi, since the file is owned by pi
-      changed_when: false
-      when: rpi_wifi_configure
-      environment:
-        RPI_WIFI_OPTIONAL: "{{ 'true' if rpi_wifi_optional else 'false' }}"
-        RPI_WIFI_ADDRESS: "{{ rpi_wifi_address }}"
-        RPI_WIFI_GATEWAY: "{{ rpi_wifi_gateway }}"
-        RPI_WIFI_SSID: "{{ rpi_wifi_ssid | default('', true) }}"
-        RPI_WIFI_PASSWORD: "{{ rpi_wifi_password | default('', true) }}"
-        RPI_SUBNET: "{{ rpi_subnet }}"
 
     - name: Check if the modified netplan file is different from the original
       shell: diff "{{ rpi_netplan_work_file }}" "{{ rpi_netplan_file }}"

--- a/ansible/playbooks/rpi/005-networking.yaml
+++ b/ansible/playbooks/rpi/005-networking.yaml
@@ -5,7 +5,7 @@
   vars:
     rpi_netplan_file: /etc/netplan/50-cloud-init.yaml
     rpi_netplan_work_file: /home/pi/50-cloud-init.yaml
-    rpi_eth0_address: "{{ ansible_host_eth | default(ansible_host, true) }}/24"
+    rpi_eth0_address: "{{ ansible_host }}/24"
     rpi_gateway: 192.168.1.1
     rpi_subnet: 192.168.1.0/24
 
@@ -61,7 +61,7 @@
             {"to": "0.0.0.0/0", "via": "{{ rpi_gateway }}", "table": 100},
             {"to": "{{ rpi_subnet }}", "scope": "link", "table": 100}
           ] |
-          (.network.ethernets.eth0."routing-policy") = [{"from": "{{ ansible_host_eth | default(ansible_host, true) }}/32", "table": 100, "priority": 100}] |
+          (.network.ethernets.eth0."routing-policy") = [{"from": "{{ ansible_host }}/32", "table": 100, "priority": 100}] |
           (.network.ethernets.eth0.nameservers.addresses) = ["{{ rpi_gateway }}"]
         ' "{{ rpi_netplan_work_file }}"
       become: false  # Run this as pi, since the file is owned by pi
@@ -111,7 +111,7 @@
 
     - name: Wait for system to become reachable
       wait_for:
-        host: "{{ ansible_host_eth | default(ansible_host, true) }}"
+        host: "{{ ansible_host }}"
         port: 22
         delay: 3
         timeout: 600

--- a/ansible/playbooks/rpi/006-cgroup.yaml
+++ b/ansible/playbooks/rpi/006-cgroup.yaml
@@ -26,11 +26,12 @@
 
     - name: Reboot the system if cmdline.txt is updated
       reboot:
+        reboot_command: systemctl reboot --job-mode=replace-irreversibly
       when: update_cmdline is changed
 
     - name: Wait for system to become reachable again
       wait_for:
-        host: "{{ inventory_hostname }}"
+        host: "{{ ansible_host | default(inventory_hostname, true) }}"
         port: 22
         delay: 10
         timeout: 600

--- a/ansible/playbooks/rpi/007-brcmfmac-options.yaml
+++ b/ansible/playbooks/rpi/007-brcmfmac-options.yaml
@@ -1,0 +1,25 @@
+---
+- hosts: brcmfmac_options
+  become: true
+
+  # Apply brcmfmac module options to fix Wi-Fi association failures on RPi5.
+  # Disables firmware-assisted roaming and firmware-side SAE/SWSUP so that
+  # wpa_supplicant handles authentication in WPA2 mode.
+  # See documentation/gotcha.md - RPi5 Wi-Fi Stuck in Association Loop.
+  tasks:
+    - name: Configure brcmfmac module options
+      copy:
+        dest: /etc/modprobe.d/brcmfmac.conf
+        content: |
+          # Disable firmware-assisted roaming and firmware-side SAE/SWSUP.
+          # See documentation/gotcha.md - RPi5 Wi-Fi Stuck in Association Loop.
+          options brcmfmac roamoff=1 feature_disable=0x82000
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload brcmfmac
+
+  handlers:
+    - name: Reload brcmfmac
+      shell: modprobe -r brcmfmac_wcc brcmfmac && modprobe brcmfmac
+      changed_when: true

--- a/ansible/playbooks/setup-cluster.yaml
+++ b/ansible/playbooks/setup-cluster.yaml
@@ -5,18 +5,4 @@
 - import_playbook: etcd/002-firewall.yaml
 - import_playbook: etcd/001-config.yaml
 - import_playbook: etcd/004-etcd.yaml
-# rpi
-- import_playbook: rpi/000-disable-write-log-to-disk.yaml
-- import_playbook: rpi/001-packages.yaml
-- import_playbook: rpi/002-pineberry-pi-hatdrive.yaml
-- import_playbook: rpi/003-waveshare-poe-hat.yaml
-- import_playbook: rpi/004-volume.yaml
-- import_playbook: rpi/005-networking.yaml
-- import_playbook: rpi/006-cgroup.yaml
-# k3s
-- import_playbook: k3s/000-init-cluster.yaml
-- import_playbook: k3s/001-cni.yaml
-- import_playbook: k3s/002-nodes.yaml
-- import_playbook: k3s/003-node-label.yaml
-- import_playbook: k3s/004-fix-iptables.yaml
-- import_playbook: k3s/005-bootstrap.yaml
+- import_playbook: reconcile-node-k3s.yaml

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-* [Create a bootable SD card with Raspberry Pi OS](create_rpi_image.md)
+* [Create a bootable SD card with Raspberry Pi OS](create_rpi4_image.md)
 * [How to Set Up RPI with Waveshare PoE HAT (B) and Install K3s from scratch](set_up_rpi.md)
 * [Gotchas and Workarounds](gotcha.md)
 * [Static IP Assignment](ip.md)

--- a/documentation/create_rpi5_nvme_image.md
+++ b/documentation/create_rpi5_nvme_image.md
@@ -174,5 +174,5 @@ sudo resize2fs /dev/nvme0n1p2
 Run on the **host** (Mac). Add the new node to `ansible/inventory.yaml`, then run:
 
 ```shell
-make build-cluster
+make reconcile-node-k3s
 ```

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -177,6 +177,63 @@ kubectl delete pvc example-db-20250724-0023-2 -n cnpg-system
 kubectl delete pod example-db-20250724-0023-2 -n cnpg-system
 ```
 
+---
+
+## RPi5 Wi-Fi Stuck in Association Loop (status_code=16)
+
+On RPi5, wpa_supplicant logs show `CTRL-EVENT-ASSOC-REJECT bssid=<bssid> status_code=16` repeatedly and the node
+cannot associate with any AP. Rebooting the node does not resolve it. This was observed on node02 against a UniFi
+mesh network running a WPA2/WPA3 mixed-mode SSID.
+
+### Root Cause
+
+The `brcmfmac` firmware has two features that combine to cause this:
+
+1. **SWSUP** - the firmware offloads WPA authentication to itself rather than delegating to wpa_supplicant.
+    When the SSID runs WPA2/WPA3 mixed mode, the firmware's SAE implementation is incompatible with the AP,
+    causing an initial `status_code=16` rejection.
+
+2. **Firmware-assisted roaming** - the firmware follows 802.11v BSS Transition Requests at the kernel level,
+    bypassing wpa_supplicant's BSSID preference. This steers the node to an AP that then rejects it.
+
+Together, these trigger a retry storm: wpa_supplicant retries rapidly after each rejection, which hits the AP's
+internal rate-limiter. The rate-limiter then blocks all subsequent association attempts until the AP is rebooted.
+The blocking state lives on the AP, not the node, so rebooting the node does not help.
+
+This does not affect RPi4 nodes because the firmware version behaves differently.
+
+### Symptoms
+
+- wpa_supplicant logs show `CTRL-EVENT-ASSOC-REJECT bssid=<bssid> status_code=16` repeatedly.
+- Setting `bssid=` or `freq_list=` in wpa_supplicant config has no effect.
+- Other nodes on the same SSID connect successfully.
+- Rebooting the node does not resolve the issue.
+
+### Resolution
+
+Add the following to `/etc/modprobe.d/brcmfmac.conf` on the RPi5 node:
+
+```text
+# Disable firmware-assisted roaming (roamoff) and firmware-side SAE/SWSUP (feature_disable).
+# Without this, the brcmfmac firmware follows 802.11v BSS Transition Requests and handles
+# WPA authentication internally. On WPA2/WPA3 mixed-mode APs this causes status_code=16
+# rejections and a retry storm that triggers the AP rate-limiter.
+# See documentation/gotcha.md - RPi5 Wi-Fi Stuck in Association Loop.
+options brcmfmac roamoff=1 feature_disable=0x82000
+```
+
+Then reload the module:
+
+```shell
+sudo modprobe -r brcmfmac_wcc brcmfmac && sudo modprobe brcmfmac
+```
+
+If the AP rate-limiter has already been triggered, reboot the AP to clear its state before applying the fix.
+
+This fix is also applied by Home Assistant OS to all RPi nodes for the same reason. See
+[home-assistant/operating-system#4056](https://github.com/home-assistant/operating-system/pull/4056) and
+[RPi-Distro/firmware-nonfree#34](https://github.com/RPi-Distro/firmware-nonfree/issues/34).
+
 [envoy-issue]: https://github.com/envoyproxy/envoy/issues/23339
 [metallb-troubleshooting]: https://metallb.universe.tf/troubleshooting/#using-wifi-and-cant-reach-the-service
 [cilium-issue]: https://github.com/cilium/cilium/issues/19038

--- a/hack/update-all-helm-dependency.sh
+++ b/hack/update-all-helm-dependency.sh
@@ -11,6 +11,10 @@ JOBS="${2:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
 PARALLEL="${3:-true}"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-2}"
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/helm-update.XXXXXX")
+RESULTS_FILE="${TEMP_DIR}/results"
+COUNTER_FILE="${TEMP_DIR}/counter"
+COUNTER_LOCK_DIR="${TEMP_DIR}/counter.lock"
 
 # Check if helm is installed
 if ! command_exists helm; then
@@ -27,6 +31,12 @@ log_info "Charts directory: $CHARTS_DIR"
 log_info "Parallel jobs: $JOBS"
 log_info "Parallel mode: $PARALLEL"
 echo ""
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
 
 # Find all Chart.yaml files
 chart_files=$(find "$CHARTS_DIR" -name 'Chart.yaml' 2>/dev/null)
@@ -76,26 +86,26 @@ update_chart() {
     done
 
     if [ $helm_exit_code -eq 0 ]; then
-        echo "SUCCESS:$chart_name" >> /tmp/helm_update_results
+        echo "SUCCESS:$chart_name" >> "$RESULTS_FILE"
         if [ $attempt -gt 1 ]; then
             result_msg="${GREEN}Success: $chart_name${NC} ${YELLOW}(after $attempt attempts)${NC}"
         else
             result_msg="${GREEN}Success: $chart_name${NC}"
         fi
     else
-        echo "FAILURE:$chart_name" >> /tmp/helm_update_results
+        echo "FAILURE:$chart_name" >> "$RESULTS_FILE"
         result_msg="${RED}Failure: $chart_name${NC}\n${YELLOW}Helm output:${NC}\n$helm_output"
     fi
 
     # Pure bash lock using mkdir
-    while ! mkdir /tmp/helm_update_counter.lock 2>/dev/null; do sleep 0.05; done
-    if [ ! -f /tmp/helm_update_counter ]; then
-        echo 0 > /tmp/helm_update_counter
+    while ! mkdir "$COUNTER_LOCK_DIR" 2>/dev/null; do sleep 0.05; done
+    if [ ! -f "$COUNTER_FILE" ]; then
+        echo 0 > "$COUNTER_FILE"
     fi
-    count=$(< /tmp/helm_update_counter)
+    count=$(< "$COUNTER_FILE")
     count=$((count + 1))
-    echo "$count" > /tmp/helm_update_counter
-    rmdir /tmp/helm_update_counter.lock
+    echo "$count" > "$COUNTER_FILE"
+    rmdir "$COUNTER_LOCK_DIR"
 
     echo -e "${YELLOW}[$count/$total_charts]${NC} $result_msg"
 }
@@ -105,17 +115,17 @@ update_chart() {
 set +e
 
 # Initialize results and counter files for all modes
-rm -f /tmp/helm_update_results /tmp/helm_update_counter /tmp/helm_update_counter.lock
+rm -f "$RESULTS_FILE" "$COUNTER_FILE"
 
 if [ "$PARALLEL" = "true" ]; then
     log_info "Processing charts in parallel mode..."
     export -f update_chart
-    export PARALLEL total_charts GREEN YELLOW RED NC
+    export PARALLEL total_charts GREEN YELLOW RED NC RESULTS_FILE COUNTER_FILE COUNTER_LOCK_DIR MAX_RETRIES RETRY_DELAY_SECONDS
     echo "$chart_files" | xargs -P "$JOBS" -I {} bash -c 'update_chart "{}"'
     # Count results from the temporary file
-    if [ -f /tmp/helm_update_results ]; then
-        success_count=$(grep -c "^SUCCESS:" /tmp/helm_update_results || echo 0)
-        failure_count=$(grep -c "^FAILURE:" /tmp/helm_update_results || echo 0)
+    if [ -f "$RESULTS_FILE" ]; then
+        success_count=$(grep -c "^SUCCESS:" "$RESULTS_FILE" || echo 0)
+        failure_count=$(grep -c "^FAILURE:" "$RESULTS_FILE" || echo 0)
     fi
 else
     log_info "Processing charts sequentially..."

--- a/hack/update-all-helm-dependency.sh
+++ b/hack/update-all-helm-dependency.sh
@@ -2,12 +2,15 @@
 
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/common.sh"
 
 # Configuration
 CHARTS_DIR="${1:-./helm-charts}"
 JOBS="${2:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
 PARALLEL="${3:-true}"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-2}"
 
 # Check if helm is installed
 if ! command_exists helm; then
@@ -41,22 +44,44 @@ echo ""
 # Initialize counters
 success_count=0
 failure_count=0
-current_count=0
 
 # Function to update a single chart (works for both sequential and parallel)
 update_chart() {
     local chart="$1"
-    local chart_dir=$(dirname "$chart")
-    local chart_name=$(basename "$chart_dir")
+    local chart_dir
+    local chart_name
     local count
+    local attempt=1
+    local retry_delay="$RETRY_DELAY_SECONDS"
+    local helm_output=""
+    local helm_exit_code=0
 
-    # Capture helm output for error reporting
-    helm_output=$(helm dependency update "$chart_dir" 2>&1)
-    local helm_exit_code=$?
+    chart_dir=$(dirname "$chart")
+    chart_name=$(basename "$chart_dir")
+
+    while true; do
+        # Retry transient repository and download failures instead of failing
+        # the full run on a single connection reset.
+        helm_output=$(helm dependency update "$chart_dir" 2>&1)
+        helm_exit_code=$?
+
+        if [ $helm_exit_code -eq 0 ] || [ $attempt -ge "$MAX_RETRIES" ]; then
+            break
+        fi
+
+        echo -e "${YELLOW}Retrying ${chart_name} dependency update after attempt ${attempt}/${MAX_RETRIES}${NC}" >&2
+        sleep "$retry_delay"
+        attempt=$((attempt + 1))
+        retry_delay=$((retry_delay * 2))
+    done
 
     if [ $helm_exit_code -eq 0 ]; then
         echo "SUCCESS:$chart_name" >> /tmp/helm_update_results
-        result_msg="${GREEN}Success: $chart_name${NC}"
+        if [ $attempt -gt 1 ]; then
+            result_msg="${GREEN}Success: $chart_name${NC} ${YELLOW}(after $attempt attempts)${NC}"
+        else
+            result_msg="${GREEN}Success: $chart_name${NC}"
+        fi
     else
         echo "FAILURE:$chart_name" >> /tmp/helm_update_results
         result_msg="${RED}Failure: $chart_name${NC}\n${YELLOW}Helm output:${NC}\n$helm_output"


### PR DESCRIPTION
## Summary
- remove Wi-Fi netplan configuration and related inventory variables so nodes are configured as Ethernet-only
- restore eth0 route priority and align Ansible tasks so kubeconfig-related steps do not report false-positive changes
- drop the brcmfmac setup from cluster bootstrap and document the networking gotcha

## Testing
- not run as part of PR creation