### PR TITLE
Harden node LUKS rebuild and AWS pod identity webhook

### DIFF
--- a/hack/luks-node-init.sh
+++ b/hack/luks-node-init.sh
@@ -95,6 +95,8 @@ disk="${TARGET_DISK}"
 boot="${disk}p1"
 root="${disk}p2"
 mapper="cryptroot"
+expected_disk_model_substring="${EXPECTED_DISK_MODEL_SUBSTRING:-}"
+minimum_disk_size_bytes="${MINIMUM_DISK_SIZE_BYTES:-}"
 work_dir="$(mktemp -d /tmp/luks-node-init.XXXXXX)"
 src_boot="$work_dir/src-boot"
 src_root="$work_dir/src-root"
@@ -104,6 +106,7 @@ pass_file="${REMOTE_PASS_FILE}"
 
 cleanup() {
   set +e
+  umount "$dst_root/dev/pts" 2>/dev/null || true
   umount "$dst_root/boot/firmware" 2>/dev/null || true
   umount "$dst_root/dev" 2>/dev/null || true
   umount "$dst_root/proc" 2>/dev/null || true
@@ -269,6 +272,8 @@ printf '\n' >> "$dst_root/etc/dropbear/initramfs/authorized_keys"
 chmod 600 "$dst_root/etc/dropbear/initramfs/authorized_keys"
 
 mount --bind /dev "$dst_root/dev"
+mkdir -p "$dst_root/dev/pts"
+mount -t devpts devpts "$dst_root/dev/pts"
 mount --bind /proc "$dst_root/proc"
 mount --bind /sys "$dst_root/sys"
 mount --bind /run "$dst_root/run"

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -8,4 +8,3 @@ dependencies:
 - name: amazon-eks-pod-identity-webhook
   version: 2.6.2
   repository: https://jkroepke.github.io/helm-charts/
-  alias: pod-identity-webhook

--- a/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,13 +1,27 @@
 name: amazon-eks-pod-identity-webhook
 namespace: default
 
+replicaCount: 2
+
+strategy:
+  rollingUpdate:
+    maxUnavailable: 0
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 pod-identity-webhook:
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - pod-identity-webhook
+          topologyKey: kubernetes.io/hostname
   resources:
     requests:
       cpu: 10m
@@ -17,3 +31,6 @@ pod-identity-webhook:
   config:
     defaultAwsRegion: eu-west-1
     tokenAudience: oidc.siutsin.com
+
+mutatingWebhook:
+  failurePolicy: Fail

--- a/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,17 +1,16 @@
 name: amazon-eks-pod-identity-webhook
 namespace: default
 
-replicaCount: 2
-
-strategy:
-  rollingUpdate:
-    maxUnavailable: 0
-
-podDisruptionBudget:
-  enabled: true
-  minAvailable: 1
-
-pod-identity-webhook:
+amazon-eks-pod-identity-webhook:
+  replicaCount: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  mutatingWebhook:
+    failurePolicy: Fail
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -20,7 +19,7 @@ pod-identity-webhook:
               - key: app.kubernetes.io/name
                 operator: In
                 values:
-                  - pod-identity-webhook
+                  - amazon-eks-pod-identity-webhook
           topologyKey: kubernetes.io/hostname
   resources:
     requests:
@@ -31,6 +30,3 @@ pod-identity-webhook:
   config:
     defaultAwsRegion: eu-west-1
     tokenAudience: oidc.siutsin.com
-
-mutatingWebhook:
-  failurePolicy: Fail


### PR DESCRIPTION
## Summary
- fix hack/luks-node-init.sh to carry expected disk validation inputs into the remote shell and mount devpts inside the chroot before package operations
- make the Amazon EKS pod identity webhook highly available with two replicas, a PDB, strict anti-affinity, and a zero-unavailable rolling update
- switch the webhook mutating failure policy to Fail so pods do not start without AWS credential injection when the webhook is unavailable

## Validation
- make test

## Context
These changes came out of the node 00 encrypted-root migration. The LUKS rebuild script fixes address real migration-time failures and warnings, and the webhook changes prevent silent fail-open admission that produced Missing credentials in config on replacement jung2bot pods during recovery.
