### PR TITLE
Bump longhorn-volume-lib to 0.2.2

### DIFF
--- a/helm-charts/longhorn-volume-lib/Chart.yaml
+++ b/helm-charts/longhorn-volume-lib/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: longhorn-volume-lib
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg


### PR DESCRIPTION
## Summary
- bump the longhorn-volume-lib chart version from 0.2.1 to 0.2.2
- publish the new library version on master so consumer charts can adopt it in a follow-up PR

## Testing
- make test