### PR TITLE
Bump Longhorn volume lib consumers

### DIFF
--- a/helm-charts/changedetection-volume/Chart.lock
+++ b/helm-charts/changedetection-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: https://siutsin.github.io/otaru
-  version: 0.2.1
-digest: sha256:c24e123d4f314a7f663058267b828d97fb4b21b57a947afd1b0fcfb1b95869c6
-generated: "2025-07-06T16:52:33.40717+01:00"
+  version: 0.2.2
+digest: sha256:2f2e727f1bff78f3ee9d4c1fe0f26c5fb5f4fb85086db417be3b8abc22545735
+generated: "2026-04-14T02:50:34.526308+01:00"

--- a/helm-charts/changedetection-volume/Chart.yaml
+++ b/helm-charts/changedetection-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.2.1
+  version: 0.2.2
   repository: https://siutsin.github.io/otaru

--- a/helm-charts/home-assistant-volume/Chart.lock
+++ b/helm-charts/home-assistant-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: https://siutsin.github.io/otaru
-  version: 0.2.1
-digest: sha256:c24e123d4f314a7f663058267b828d97fb4b21b57a947afd1b0fcfb1b95869c6
-generated: "2025-07-06T16:52:26.41416+01:00"
+  version: 0.2.2
+digest: sha256:2f2e727f1bff78f3ee9d4c1fe0f26c5fb5f4fb85086db417be3b8abc22545735
+generated: "2026-04-14T02:50:34.436137+01:00"

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.2.1
+  version: 0.2.2
   repository: https://siutsin.github.io/otaru


### PR DESCRIPTION
## Summary
- update changedetection-volume and home-assistant-volume to consume longhorn-volume-lib 0.2.2
- refresh both dependency lockfiles from the published chart repository
- allow Argo to reconcile the GitOps-managed Longhorn volumes to the new HA defaults

## Testing
- make test