### PR TITLE
Publish HA Longhorn volume library

### DIFF
--- a/helm-charts/longhorn-volume-lib/Chart.yaml
+++ b/helm-charts/longhorn-volume-lib/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: longhorn-volume-lib
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.2
+version: 0.2.3
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/longhorn-volume-lib/templates/volume.yaml
+++ b/helm-charts/longhorn-volume-lib/templates/volume.yaml
@@ -27,7 +27,7 @@ spec:
     driver: driver.longhorn.io
     fsType: ext4
     volumeAttributes:
-      numberOfReplicas: "1"
+      numberOfReplicas: "2"
       dataLocality: disabled
       replicaAutoBalance: best-effort
       encrypted: "true"
@@ -39,7 +39,7 @@ spec:
       namespace: longhorn-system
     volumeHandle: {{ $key }}-vol
   persistentVolumeReclaimPolicy: Delete
-  storageClassName: longhorn-crypto-global
+  storageClassName: longhorn-crypto-global-ha
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -55,7 +55,7 @@ metadata:
     recurring-job-group.longhorn.io/trim: enabled
     {{- end }}
 spec:
-  storageClassName: longhorn-crypto-global
+  storageClassName: longhorn-crypto-global-ha
   accessModes:
     - ReadWriteOnce
   resources:
@@ -83,6 +83,6 @@ spec:
   encrypted: true
   frontend: blockdev
   size: {{ $value.sizeBytes | quote }}
-  numberOfReplicas: 1
+  numberOfReplicas: 2
   fromBackup: {{ $value.fromBackup | quote }}
 {{- end }}


### PR DESCRIPTION
## Summary
- update longhorn-volume-lib to render the HA storage class and 2 replicas
- publish the real HA template as version 0.2.3 on master
- unblock the GitOps-managed Longhorn volumes needed for node 02 evacuation

## Testing
- make test