### PR TITLE
Adopt HA Longhorn volume library

### DIFF
--- a/helm-charts/changedetection-volume/Chart.lock
+++ b/helm-charts/changedetection-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: https://siutsin.github.io/otaru
-  version: 0.2.2
-digest: sha256:2f2e727f1bff78f3ee9d4c1fe0f26c5fb5f4fb85086db417be3b8abc22545735
-generated: "2026-04-14T02:50:34.526308+01:00"
+  version: 0.2.3
+digest: sha256:4fbce36bb3e584a952e52205b023442510b172d6f891ef84998d45023e503155
+generated: "2026-04-14T03:19:59.433681+01:00"

--- a/helm-charts/changedetection-volume/Chart.yaml
+++ b/helm-charts/changedetection-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.2.2
+  version: 0.2.3
   repository: https://siutsin.github.io/otaru

--- a/helm-charts/home-assistant-volume/Chart.lock
+++ b/helm-charts/home-assistant-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: https://siutsin.github.io/otaru
-  version: 0.2.2
-digest: sha256:2f2e727f1bff78f3ee9d4c1fe0f26c5fb5f4fb85086db417be3b8abc22545735
-generated: "2026-04-14T02:50:34.436137+01:00"
+  version: 0.2.3
+digest: sha256:4fbce36bb3e584a952e52205b023442510b172d6f891ef84998d45023e503155
+generated: "2026-04-14T03:19:59.432273+01:00"

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.2.2
+  version: 0.2.3
   repository: https://siutsin.github.io/otaru


### PR DESCRIPTION
## Summary
- update changedetection-volume and home-assistant-volume to consume longhorn-volume-lib 0.2.3
- refresh both dependency lockfiles from the published chart repository
- let Argo reconcile the GitOps-managed Longhorn volumes to 2 replicas on the HA storage class

## Testing
- make test