### PR TITLE
chore(argocd): track HEAD instead of rpi5 revision

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -1,6 +1,6 @@
 local ArgoCDApplication = import 'lib/argocd-application.libsonnet';
 
-local revision = 'rpi5';
+local revision = 'HEAD';
 
 local divisorJqPath = '.spec.template.spec.containers[].env[].valueFrom.resourceFieldRef.divisor';
 local resourceFieldRefDivisor(name) = [{


### PR DESCRIPTION
## Summary

- Change `revision` in `argocd/manifest.jsonnet` from `rpi5` to `HEAD`
- Unpins ArgoCD Applications (and the `argocd-bootstrap` child app) from the stale `rpi5` branch back to the default branch, matching the library default in `argocd/lib/argocd-application.libsonnet`