### PR TITLE
chore(argocd-bootstrap): default targetRevision to HEAD

### DIFF
--- a/helm-charts/argocd-bootstrap/values.yaml
+++ b/helm-charts/argocd-bootstrap/values.yaml
@@ -1,3 +1,3 @@
 name: argocd
 namespace: argocd
-targetRevision: rpi5
+targetRevision: HEAD


### PR DESCRIPTION
## Summary

- Change the default `targetRevision` in `helm-charts/argocd-bootstrap/values.yaml` from the environment-specific branch `rpi5` to `HEAD`.
- Aligns the bootstrap chart default with `argocd/manifest.jsonnet` (`local revision = 'HEAD'`) so initial bootstrap and ArgoCD-managed reconciliation use the repo default branch consistently.