### PR TITLE
feat(k8s-cleaner): add cleaner for Longhorn trim jobs

### DIFF
--- a/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
+++ b/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
@@ -22,9 +22,23 @@ spec:
               return result
             end
 
+            if obj.status.conditions == nil then
+              return result
+            end
+
             for _, owner in ipairs(obj.metadata.ownerReferences) do
-              if owner.kind == "CronJob" and owner.name == "trim" then
-                result.matching = true
+              if owner.apiVersion == "batch/v1"
+                and owner.kind == "CronJob"
+                and owner.name == "trim"
+              then
+                for _, condition in ipairs(obj.status.conditions) do
+                  if (condition.type == "Complete" or condition.type == "Failed")
+                    and condition.status == "True"
+                  then
+                    result.matching = true
+                    return result
+                  end
+                end
               end
             end
 

--- a/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
+++ b/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: longhorn-trim-jobs
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  schedule: "*/5 * * * *"
+  resourcePolicySet:
+    resourceSelectors:
+      - kind: Job
+        group: batch
+        version: v1
+        namespace: {{ .Values.longhornTrimJobs.namespace }}
+        evaluate: |
+          function evaluate()
+            local result = {}
+            result.matching = false
+
+            if obj.metadata.ownerReferences == nil then
+              return result
+            end
+
+            for _, owner in ipairs(obj.metadata.ownerReferences) do
+              if owner.kind == "CronJob" and owner.name == "trim" then
+                result.matching = true
+              end
+            end
+
+            return result
+          end
+  action: Delete

--- a/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
+++ b/helm-charts/k8s-cleaner/templates/cleaner-longhorn-trim-jobs.yaml
@@ -22,7 +22,7 @@ spec:
               return result
             end
 
-            if obj.status.conditions == nil then
+            if obj.status == nil or obj.status.conditions == nil then
               return result
             end
 

--- a/helm-charts/k8s-cleaner/values.yaml
+++ b/helm-charts/k8s-cleaner/values.yaml
@@ -14,6 +14,9 @@ repave:
 failedPods:
   excludeNamespaces: *excludeNamespaces
 
+longhornTrimJobs:
+  namespace: longhorn-system
+
 k8s-cleaner:
   deployment:
     resources:


### PR DESCRIPTION
## Summary
- add a k8s-cleaner Cleaner for Longhorn trim Jobs
- delete Jobs owned by the Longhorn trim CronJob on the existing 5-minute cleaner cadence
- keep the target namespace configurable via chart values

## Tests
- make test