### PR TITLE
Add Kyverno policy for scoped external secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Local Air workspace metadata
+.air/

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -158,6 +158,8 @@ local scheduling = [
 
 local security = [
   { wave: '02', name: 'cert-manager', namespace: 'cert-manager' },
+  { wave: '03', name: 'kyverno', namespace: 'kyverno' },
+  { wave: '04', name: 'kyverno-policy', namespace: 'kyverno' },
   { wave: '10', name: 'oidc-provider', namespace: 'default' },
   { wave: '20', name: 'amazon-eks-pod-identity-webhook', namespace: 'default' },
 ];

--- a/helm-charts/kyverno-policy/.helmignore
+++ b/helm-charts/kyverno-policy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/kyverno-policy/Chart.yaml
+++ b/helm-charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kyverno-policy
-description: A Helm chart for Kubernetes
+description: Kyverno policies for the Otaru cluster
 type: application
 version: 0.1.0
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/kyverno-policy/Chart.yaml
+++ b/helm-charts/kyverno-policy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kyverno-policy
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -1,0 +1,237 @@
+{{- if and .Values.clusterSecretStorePolicy.enabled }}
+{{- $storeName := .Values.clusterSecretStorePolicy.storeName }}
+{{- $allowedNamespaces := keys .Values.clusterSecretStorePolicy.allowedNamespaces | sortAlpha }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-onepassword-cluster-secret-store
+spec:
+  background: false
+  rules:
+    - name: block-top-level-store-outside-approved-namespaces
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+      validate:
+        failureAction: Enforce
+        message: ExternalSecrets may only use the shared 1Password ClusterSecretStore from approved namespaces.
+        deny:
+          conditions:
+            all:
+              - key: "{{ `{{ request.object.spec.secretStoreRef.kind || '' }}` }}"
+                operator: Equals
+                value: ClusterSecretStore
+              - key: "{{ `{{ request.object.spec.secretStoreRef.name || '' }}` }}"
+                operator: Equals
+                value: {{ $storeName }}
+              - key: "{{ `{{ request.namespace }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $allowedNamespaces }}
+                  - {{ . }}
+{{- end }}
+    - name: block-data-store-outside-approved-namespaces
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret data entries may only use the shared 1Password ClusterSecretStore from approved namespaces.
+        foreach:
+          - list: request.object.spec.data || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.kind || '' }}` }}"
+                  operator: Equals
+                  value: ClusterSecretStore
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: {{ $storeName }}
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ request.namespace }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $allowedNamespaces }}
+                      - {{ . }}
+{{- end }}
+    - name: block-datafrom-store-outside-approved-namespaces
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret dataFrom entries may only use the shared 1Password ClusterSecretStore from approved namespaces.
+        foreach:
+          - list: request.object.spec.dataFrom || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.kind || '' }}` }}"
+                  operator: Equals
+                  value: ClusterSecretStore
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: {{ $storeName }}
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ request.namespace }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $allowedNamespaces }}
+                      - {{ . }}
+{{- end }}
+{{- range $namespace, $keys := .Values.clusterSecretStorePolicy.allowedNamespaces }}
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-onepassword-keys-{{ $namespace }}
+spec:
+  background: false
+  rules:
+    # Entries with no per-entry storeRef inherit this top-level shared ClusterSecretStore.
+    - name: restrict-inherited-data-keys
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+              namespaces:
+                - {{ $namespace }}
+      preconditions:
+        all:
+          - key: "{{ `{{ request.object.spec.secretStoreRef.kind || '' }}` }}"
+            operator: Equals
+            value: ClusterSecretStore
+          - key: "{{ `{{ request.object.spec.secretStoreRef.name || '' }}` }}"
+            operator: Equals
+            value: {{ $storeName }}
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret data entries using the shared 1Password ClusterSecretStore must read approved item keys.
+        foreach:
+          - list: request.object.spec.data || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: ""
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $keys }}
+                      - {{ . }}
+{{- end }}
+    # dataFrom entries with extract.key also inherit the top-level shared store unless they override storeRef.
+    - name: restrict-inherited-datafrom-keys
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+              namespaces:
+                - {{ $namespace }}
+      preconditions:
+        all:
+          - key: "{{ `{{ request.object.spec.secretStoreRef.kind || '' }}` }}"
+            operator: Equals
+            value: ClusterSecretStore
+          - key: "{{ `{{ request.object.spec.secretStoreRef.name || '' }}` }}"
+            operator: Equals
+            value: {{ $storeName }}
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret dataFrom entries using the shared 1Password ClusterSecretStore must read approved item keys.
+        foreach:
+          - list: request.object.spec.dataFrom || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: ""
+                - key: "{{ `{{ element.extract.key || '' }}` }}"
+                  operator: NotEquals
+                  value: ""
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ element.extract.key || '' }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $keys }}
+                      - {{ . }}
+{{- end }}
+    # Per-entry storeRef overrides can explicitly target the shared ClusterSecretStore.
+    - name: restrict-explicit-data-keys
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+              namespaces:
+                - {{ $namespace }}
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret data entries using the shared 1Password ClusterSecretStore must read approved item keys.
+        foreach:
+          - list: request.object.spec.data || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.kind || '' }}` }}"
+                  operator: Equals
+                  value: ClusterSecretStore
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: {{ $storeName }}
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $keys }}
+                      - {{ . }}
+{{- end }}
+    - name: restrict-explicit-datafrom-keys
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+              namespaces:
+                - {{ $namespace }}
+      validate:
+        failureAction: Enforce
+        message: ExternalSecret dataFrom entries using the shared 1Password ClusterSecretStore must read approved item keys.
+        foreach:
+          - list: request.object.spec.dataFrom || `[]`
+            preconditions:
+              all:
+                - key: "{{ `{{ element.sourceRef.storeRef.kind || '' }}` }}"
+                  operator: Equals
+                  value: ClusterSecretStore
+                - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
+                  operator: Equals
+                  value: {{ $storeName }}
+            deny:
+              conditions:
+                all:
+                  - key: "{{ `{{ element.extract.key || '' }}` }}"
+                    operator: AnyNotIn
+                    value:
+{{- range $keys }}
+                      - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -133,7 +133,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $keys }}
                       - {{ . }}

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -1,6 +1,11 @@
-{{- if and .Values.clusterSecretStorePolicy.enabled }}
+{{- if .Values.clusterSecretStorePolicy.enabled }}
 {{- $storeName := .Values.clusterSecretStorePolicy.storeName }}
 {{- $allowedNamespaces := keys .Values.clusterSecretStorePolicy.allowedNamespaces | sortAlpha }}
+{{- range $namespace, $keys := .Values.clusterSecretStorePolicy.allowedNamespaces }}
+  {{- if not $keys }}
+    {{- fail (printf "clusterSecretStorePolicy.allowedNamespaces.%s must include at least one allowed key" $namespace) }}
+  {{- end }}
+{{- end }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -27,7 +32,7 @@ spec:
                 operator: Equals
                 value: {{ $storeName }}
               - key: "{{ `{{ request.namespace }}` }}"
-                operator: AnyNotIn
+                operator: NotIn
                 value:
 {{- range $allowedNamespaces }}
                   - {{ . }}
@@ -55,7 +60,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ request.namespace }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $allowedNamespaces }}
                       - {{ . }}
@@ -83,7 +88,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ request.namespace }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $allowedNamespaces }}
                       - {{ . }}
@@ -160,14 +165,14 @@ spec:
                 - key: "{{ `{{ element.sourceRef.storeRef.name || '' }}` }}"
                   operator: Equals
                   value: ""
-                - key: "{{ `{{ element.extract.key || '' }}` }}"
-                  operator: NotEquals
-                  value: ""
             deny:
               conditions:
-                all:
+                any:
+                  - key: "{{ `{{ element.find || '' | to_string(@) }}` }}"
+                    operator: NotEquals
+                    value: ""
                   - key: "{{ `{{ element.extract.key || '' }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $keys }}
                       - {{ . }}
@@ -198,7 +203,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $keys }}
                       - {{ . }}
@@ -228,7 +233,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.extract.key || '' }}` }}"
-                    operator: AnyNotIn
+                    operator: NotIn
                     value:
 {{- range $keys }}
                       - {{ . }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -1,0 +1,34 @@
+name: kyverno-policy
+namespace: kyverno
+
+clusterSecretStorePolicy:
+  enabled: true
+  storeName: onepassword-secret-store
+  allowedNamespaces:
+    argocd:
+      - argocd-secret
+    atlantis:
+      - atlantis
+    blocky:
+      - blocky
+    changedetection:
+      - changedetection
+    cloudflare-tunnel:
+      - cloudflare-tunnel-credentials
+    gateway-api:
+      - cloudflare-acme-verification-secret
+      - heartbeats
+    home-assistant:
+      - heartbeats
+    jung2bot:
+      - jung2bot
+    longhorn-system:
+      - b2-secret
+      - longhorn-crypto
+    monitoring:
+      - grafana
+      - heartbeats
+    teslamate:
+      - b2-secret-cloudnative-pg
+      - heartbeats
+      - teslamate

--- a/helm-charts/kyverno/.helmignore
+++ b/helm-charts/kyverno/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/kyverno/Chart.lock
+++ b/helm-charts/kyverno/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kyverno
+  repository: https://kyverno.github.io/kyverno/
+  version: 3.7.1
+digest: sha256:74f00a98d714746404e1cb78812caac9f58f25cf5213087470f370badc678be7
+generated: "2026-04-26T21:33:43.397914+01:00"

--- a/helm-charts/kyverno/Chart.yaml
+++ b/helm-charts/kyverno/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kyverno
-description: A Helm chart for Kubernetes
+description: Kyverno policy engine
 type: application
 version: 0.1.0
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/kyverno/Chart.yaml
+++ b/helm-charts/kyverno/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: kyverno
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
+dependencies:
+- name: kyverno
+  version: 3.7.1
+  repository: https://kyverno.github.io/kyverno/

--- a/helm-charts/kyverno/values.yaml
+++ b/helm-charts/kyverno/values.yaml
@@ -1,0 +1,21 @@
+namespace: kyverno
+
+_shared:
+  resources: &resources
+    requests:
+      cpu: 50m
+      memory: 128Mi
+      ephemeral-storage: 64Mi
+    limits:
+      memory: 128Mi
+      ephemeral-storage: 64Mi
+
+kyverno:
+  admissionController:
+    resources: *resources
+  backgroundController:
+    resources: *resources
+  cleanupController:
+    resources: *resources
+  reportsController:
+    resources: *resources


### PR DESCRIPTION
## Summary
- add Kyverno as an Argo-managed security chart
- add a separate kyverno-policy chart for 1Password ClusterSecretStore restrictions
- restrict shared 1Password ClusterSecretStore use to approved namespaces and item keys, including per-entry storeRef overrides
- ignore local Air workspace metadata

## Test plan
- helm template kyverno helm-charts/kyverno -n kyverno --include-crds
- helm template kyverno-policy helm-charts/kyverno-policy -n kyverno
- make test