### PR TITLE
Tune Argo CD repo-server stability

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -48,8 +48,12 @@ argo-cd:
     cm:
       url: https://argocd.internal.siutsin.com/argocd/
     params:
-      # Keep repo-server concurrency low; this repo's Helm renders can OOM during cold-cache bursts.
-      reposerver.parallelism.limit: 1
+      # Keep repo-server concurrency bounded; Helm renders can spike memory during cold-cache bursts.
+      reposerver.parallelism.limit: 2
+      # Allow cold-cache manifest generation queues to drain before controllers mark comparison as Unknown.
+      controller.repo.server.timeout.seconds: 180
+      server.repo.server.timeout.seconds: 180
+      applicationsetcontroller.repo.server.timeout.seconds: 180
       server.insecure: true
       server.basehref: /argocd/
       server.rootpath: /argocd
@@ -114,11 +118,11 @@ argo-cd:
     resources:
       requests:
         cpu: 250m
-        memory: 1Gi
-        ephemeral-storage: 256Mi
+        memory: 2Gi
+        ephemeral-storage: 512Mi
       limits:
-        memory: 1Gi
-        ephemeral-storage: 256Mi
+        memory: 2Gi
+        ephemeral-storage: 512Mi
     readinessProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -201,11 +205,11 @@ argo-cd:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
-            ephemeral-storage: 128Mi
+            memory: 256Mi
+            ephemeral-storage: 256Mi
           limits:
-            memory: 128Mi
-            ephemeral-storage: 128Mi
+            memory: 256Mi
+            ephemeral-storage: 256Mi
         volumeMounts:
           - mountPath: /var/run/argocd
             name: var-files


### PR DESCRIPTION
## Summary
- increase Argo CD repo-server manifest generation timeout knobs to 180 seconds
- raise repo-server memory and ephemeral-storage headroom for cold-cache Helm render spikes
- raise jsonnet-with-secret sidecar memory and ephemeral-storage headroom
- increase repo-server per-pod parallelism from 1 to 2 now that per-pod render headroom is higher

## Test plan
- helm template argocd helm-charts/argocd -n argocd
- make test