### PR TITLE
Fix ExternalSecret nullBytePolicy drift

### DIFF
--- a/helm-charts/argocd-config/templates/external-secret.yaml
+++ b/helm-charts/argocd-config/templates/external-secret.yaml
@@ -14,6 +14,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: github-webhook-secret
@@ -21,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: secretkey
@@ -28,6 +30,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: password

--- a/helm-charts/argocd/templates/external-secret.yaml
+++ b/helm-charts/argocd/templates/external-secret.yaml
@@ -16,6 +16,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: AWS_ACCOUNT_ID
@@ -23,6 +24,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: CNPG_BACKUP_BUCKET
@@ -30,6 +32,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: CNPG_BACKUP_ENDPOINT
@@ -37,6 +40,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: LONGHORN_BACKUP_TARGET
@@ -44,6 +48,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: argocd-secret
         metadataPolicy: None
         property: HOME_ASSISTANT_VOLUME_FROM_BACKUP

--- a/helm-charts/atlantis/templates/external-secret-aws.yaml
+++ b/helm-charts/atlantis/templates/external-secret-aws.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: AWS_ACCESS_KEY_ID
@@ -22,6 +23,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: AWS_SECRET_ACCESS_KEY

--- a/helm-charts/atlantis/templates/external-secret-b2.yaml
+++ b/helm-charts/atlantis/templates/external-secret-b2.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: B2_APPLICATION_KEY
@@ -22,6 +23,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: B2_APPLICATION_KEY_ID

--- a/helm-charts/atlantis/templates/external-secret-cloudflare.yaml
+++ b/helm-charts/atlantis/templates/external-secret-cloudflare.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_ACCOUNT_ID
@@ -22,6 +23,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_API_TOKEN
@@ -29,6 +31,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_TUNNEL_SECRET
@@ -36,6 +39,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_ZONE
@@ -43,6 +47,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_ZONE_ID
@@ -50,6 +55,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_ZONE_SUBDOMAIN
@@ -57,6 +63,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: CLOUDFLARE_ZONE_TUNNEL_IP_LIST

--- a/helm-charts/atlantis/templates/external-secret-github-webhook.yaml
+++ b/helm-charts/atlantis/templates/external-secret-github-webhook.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: github_token_webhook
@@ -22,6 +23,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: github_secret_webhook

--- a/helm-charts/atlantis/templates/external-secret-github.yaml
+++ b/helm-charts/atlantis/templates/external-secret-github.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: GITHUB_TOKEN

--- a/helm-charts/atlantis/templates/external-secret-unifi.yaml
+++ b/helm-charts/atlantis/templates/external-secret-unifi.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_USERNAME
@@ -22,6 +23,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_PASSWORD
@@ -29,6 +31,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_API_URL
@@ -38,6 +41,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN01_PASSWORD
@@ -45,6 +49,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN01_SSID
@@ -53,6 +58,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN02_PASSWORD
@@ -60,6 +66,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN02_SSID
@@ -68,6 +75,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN03_PASSWORD
@@ -75,6 +83,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN03_SSID
@@ -83,6 +92,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN04_PASSWORD
@@ -90,6 +100,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UNIFI_LHR_WLAN04_SSID

--- a/helm-charts/atlantis/templates/external-secret-uptime-robot.yaml
+++ b/helm-charts/atlantis/templates/external-secret-uptime-robot.yaml
@@ -15,6 +15,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: atlantis
         metadataPolicy: None
         property: UPTIME_ROBOT_API_KEY

--- a/helm-charts/blocky/templates/config.yaml
+++ b/helm-charts/blocky/templates/config.yaml
@@ -22,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: blocky
         metadataPolicy: None
         property: config.yml

--- a/helm-charts/changedetection/templates/config.yaml
+++ b/helm-charts/changedetection/templates/config.yaml
@@ -22,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.onepassword.key }}
         metadataPolicy: None
         property: {{ .Values.onepassword.property }}

--- a/helm-charts/cloudflare-tunnel/templates/external-secret.yaml
+++ b/helm-charts/cloudflare-tunnel/templates/external-secret.yaml
@@ -14,6 +14,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: cloudflare-tunnel-credentials
         metadataPolicy: None
         property: password

--- a/helm-charts/cloudnative-pg-clusters/templates/external-secret.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/external-secret.yaml
@@ -74,6 +74,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: b2-secret-cloudnative-pg
         metadataPolicy: None
         property: AWS_ACCESS_KEY_ID
@@ -81,6 +82,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: b2-secret-cloudnative-pg
         metadataPolicy: None
         property: AWS_SECRET_ACCESS_KEY

--- a/helm-charts/envoy-gateway/templates/external-secret.yaml
+++ b/helm-charts/envoy-gateway/templates/external-secret.yaml
@@ -15,6 +15,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: cloudflare-acme-verification-secret
         metadataPolicy: None
         property: password

--- a/helm-charts/envoy-gateway/templates/heartbeat.yaml
+++ b/helm-charts/envoy-gateway/templates/heartbeat.yaml
@@ -17,6 +17,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: heartbeats
         metadataPolicy: None
         property: {{ $.Values.name }}-{{ . }}-endpoint

--- a/helm-charts/home-assistant/templates/heartbeat.yaml
+++ b/helm-charts/home-assistant/templates/heartbeat.yaml
@@ -16,6 +16,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: heartbeats
         metadataPolicy: None
         property: {{ $.Values.name }}-{{ . }}-endpoint

--- a/helm-charts/jung2bot/templates/external-secret.yaml
+++ b/helm-charts/jung2bot/templates/external-secret.yaml
@@ -14,6 +14,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: TELEGRAM_BOT_TOKEN
@@ -21,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: EVENT_QUEUE_URL
@@ -28,6 +30,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: OFF_FROM_WORK_URL
@@ -35,6 +38,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: SCALE_UP_URL

--- a/helm-charts/longhorn/templates/external-secret.yaml
+++ b/helm-charts/longhorn/templates/external-secret.yaml
@@ -14,6 +14,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_KEY_VALUE
@@ -21,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_KEY_PROVIDER
@@ -28,6 +30,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_KEY_CIPHER
@@ -35,6 +38,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_KEY_HASH
@@ -42,6 +46,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_KEY_SIZE
@@ -49,6 +54,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.encryption.secretName }}
         metadataPolicy: None
         property: CRYPTO_PBKDF
@@ -69,6 +75,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.backup.secretName }}
         metadataPolicy: None
         property: AWS_ACCESS_KEY_ID
@@ -76,6 +83,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.backup.secretName }}
         metadataPolicy: None
         property: AWS_SECRET_ACCESS_KEY
@@ -83,6 +91,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.backup.secretName }}
         metadataPolicy: None
         property: AWS_ENDPOINTS

--- a/helm-charts/monitoring/templates/external-secret.yaml
+++ b/helm-charts/monitoring/templates/external-secret.yaml
@@ -14,6 +14,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: grafana
         metadataPolicy: None
         property: admin-user
@@ -21,6 +22,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: grafana
         metadataPolicy: None
         property: admin-password

--- a/helm-charts/monitoring/templates/heartbeat.yaml
+++ b/helm-charts/monitoring/templates/heartbeat.yaml
@@ -16,6 +16,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: heartbeats
         metadataPolicy: None
         property: loki-{{ . }}-endpoint
@@ -55,6 +56,7 @@ spec:
       remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: heartbeats
         metadataPolicy: None
         property: prometheus-{{ . }}-endpoint

--- a/helm-charts/teslamate/templates/external-secret.yaml
+++ b/helm-charts/teslamate/templates/external-secret.yaml
@@ -16,6 +16,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: ENCRYPTION_KEY
@@ -39,6 +40,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: GRAFANA_ADMIN_USER
@@ -46,6 +48,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: GRAFANA_ADMIN_PASSWORD
@@ -68,6 +71,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: BACKUP_HEARTBEAT
@@ -75,6 +79,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: VERIFY_PG_DUMP_HEARTBEAT
@@ -82,6 +87,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: VERIFY_PITR_HEARTBEAT
@@ -89,6 +95,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: BUCKET
@@ -96,6 +103,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: ENDPOINT
@@ -103,6 +111,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: AWS_DEFAULT_REGION
@@ -110,6 +119,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: {{ .Values.name }}
         metadataPolicy: None
         property: S3_PATH
@@ -132,6 +142,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: b2-secret-cloudnative-pg
         metadataPolicy: None
         property: AWS_ACCESS_KEY_ID
@@ -139,6 +150,7 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
+        nullBytePolicy: Ignore
         key: b2-secret-cloudnative-pg
         metadataPolicy: None
         property: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- set `nullBytePolicy: Ignore` on ExternalSecret remote refs to match ESO defaulting
- prevents Argo CD out-of-sync drift from defaulted ExternalSecret specs

## Tests
- `make test`