### PR TITLE
Fix chart release repository setup

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,16 +35,17 @@ jobs:
           helm repo add atlantis https://runatlantis.github.io/helm-charts
           helm repo add cert-manager https://charts.jetstack.io
           helm repo add cilium https://helm.cilium.io/
-          helm repo add descheduler https://kubernetes-sigs.github.io/descheduler
-          helm repo add external-secrets-operator https://charts.external-secrets.io
+          helm repo add descheduler https://kubernetes-sigs.github.io/descheduler/
+          helm repo add external-secrets-operator https://charts.external-secrets.io/
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add istio https://istio-release.storage.googleapis.com/charts
-          helm repo add jkroepke https://jkroepke.github.io/helm-charts
+          helm repo add jkroepke https://jkroepke.github.io/helm-charts/
           helm repo add kedacore https://kedacore.github.io/charts
+          helm repo add kyverno https://kyverno.github.io/kyverno/
           helm repo add kiali https://kiali.org/helm-charts
           helm repo add longhorn https://charts.longhorn.io
           helm repo add metallb https://metallb.github.io/metallb
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           helm repo add onepassword-connect https://1password.github.io/connect-helm-charts
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add siutsin https://siutsin.github.io/otaru


### PR DESCRIPTION
## Summary
- add the missing Kyverno Helm repository before chart-releaser packages charts
- align repo-add URLs with chart dependency repository URLs that include trailing slashes
- prevents chart-releaser from failing with `no repository definition for https://kyverno.github.io/kyverno/`

## Tests
- `helm dependency build helm-charts/kyverno`
- `helm package helm-charts/kyverno --destination /tmp/otaru-chart-packages`
- `make test`

Fixes failed run: https://github.com/siutsin/otaru/actions/runs/24968626955/job/73107650138