### PR TITLE
fix(kyverno): mitigate sync drift from defaulted fields

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -29,6 +29,14 @@ local crdConversionCABundle(name) = [{
   ],
 }];
 
+local crdDefaultedConversion = [{
+  group: 'apiextensions.k8s.io',
+  kind: 'CustomResourceDefinition',
+  jsonPointers: [
+    '/spec/conversion',
+  ],
+}];
+
 local cleanerExcludeDeleted = [{
   group: 'apps.projectsveltos.io',
   kind: 'Cleaner',
@@ -56,6 +64,9 @@ local _ignoreDifferences = {
   serviceMesh: {
     'istio-base': webhookCaBundleAndFailurePolicy('istiod-default-validator'),
     istiod: webhookCaBundleAndFailurePolicy('istio-validator-istio-system'),
+  },
+  security: {
+    kyverno: crdDefaultedConversion,
   },
 };
 
@@ -158,7 +169,7 @@ local scheduling = [
 
 local security = [
   { wave: '02', name: 'cert-manager', namespace: 'cert-manager' },
-  { wave: '03', name: 'kyverno', namespace: 'kyverno' },
+  { wave: '03', name: 'kyverno', namespace: 'kyverno', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.security.kyverno },
   { wave: '04', name: 'kyverno-policy', namespace: 'kyverno' },
   { wave: '10', name: 'oidc-provider', namespace: 'default' },
   { wave: '20', name: 'amazon-eks-pod-identity-webhook', namespace: 'default' },

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -29,16 +29,16 @@ local crdConversionCABundle(name) = [{
   ],
 }];
 
-local crdDefaultedConversion(names) = [
+local crdDefaultedConversion(crdNames) = [
   {
     group: 'apiextensions.k8s.io',
     kind: 'CustomResourceDefinition',
-    name: name,
+    name: crdName,
     jsonPointers: [
       '/spec/conversion',
     ],
   }
-  for name in names
+  for crdName in crdNames
 ];
 
 local cleanerExcludeDeleted = [{

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -29,13 +29,17 @@ local crdConversionCABundle(name) = [{
   ],
 }];
 
-local crdDefaultedConversion = [{
-  group: 'apiextensions.k8s.io',
-  kind: 'CustomResourceDefinition',
-  jsonPointers: [
-    '/spec/conversion',
-  ],
-}];
+local crdDefaultedConversion(names) = [
+  {
+    group: 'apiextensions.k8s.io',
+    kind: 'CustomResourceDefinition',
+    name: name,
+    jsonPointers: [
+      '/spec/conversion',
+    ],
+  }
+  for name in names
+];
 
 local cleanerExcludeDeleted = [{
   group: 'apps.projectsveltos.io',
@@ -66,7 +70,19 @@ local _ignoreDifferences = {
     istiod: webhookCaBundleAndFailurePolicy('istio-validator-istio-system'),
   },
   security: {
-    kyverno: crdDefaultedConversion,
+    kyverno: crdDefaultedConversion([
+      'deletingpolicies.policies.kyverno.io',
+      'generatingpolicies.policies.kyverno.io',
+      'imagevalidatingpolicies.policies.kyverno.io',
+      'mutatingpolicies.policies.kyverno.io',
+      'namespaceddeletingpolicies.policies.kyverno.io',
+      'namespacedgeneratingpolicies.policies.kyverno.io',
+      'namespacedimagevalidatingpolicies.policies.kyverno.io',
+      'namespacedmutatingpolicies.policies.kyverno.io',
+      'namespacedvalidatingpolicies.policies.kyverno.io',
+      'policyexceptions.policies.kyverno.io',
+      'validatingpolicies.policies.kyverno.io',
+    ]),
   },
 };
 

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -70,6 +70,7 @@ local _ignoreDifferences = {
     istiod: webhookCaBundleAndFailurePolicy('istio-validator-istio-system'),
   },
   security: {
+    // Re-check this list against rendered Kyverno CRDs when bumping the kyverno chart.
     kyverno: crdDefaultedConversion([
       'deletingpolicies.policies.kyverno.io',
       'generatingpolicies.policies.kyverno.io',

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -99,8 +99,9 @@ spec:
                     operator: NotIn
                     value:
 {{- range $allowedNamespaces }}
-                    - {{ . }}
+                      - {{ . }}
 {{- end }}
+  # Kyverno defaults this spec-level field to Audit; per-rule failureAction: Enforce takes precedence.
   validationFailureAction: Audit
 {{- range $namespace, $keys := .Values.clusterSecretStorePolicy.allowedNamespaces }}
 ---
@@ -257,6 +258,7 @@ spec:
 {{- range $keys }}
                       - {{ . }}
 {{- end }}
+  # Kyverno defaults this spec-level field to Audit; per-rule failureAction: Enforce takes precedence.
   validationFailureAction: Audit
 {{- end }}
 {{- end }}

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -11,15 +11,19 @@ kind: ClusterPolicy
 metadata:
   name: restrict-onepassword-cluster-secret-store
 spec:
+  admission: true
   background: false
+  emitWarning: false
   rules:
     - name: block-top-level-store-outside-approved-namespaces
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
               kinds:
                 - ExternalSecret
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecrets may only use the shared 1Password ClusterSecretStore from approved namespaces.
         deny:
@@ -38,12 +42,14 @@ spec:
                   - {{ . }}
 {{- end }}
     - name: block-data-store-outside-approved-namespaces
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
               kinds:
                 - ExternalSecret
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret data entries may only use the shared 1Password ClusterSecretStore from approved namespaces.
         foreach:
@@ -66,12 +72,14 @@ spec:
                       - {{ . }}
 {{- end }}
     - name: block-datafrom-store-outside-approved-namespaces
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
               kinds:
                 - ExternalSecret
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret dataFrom entries may only use the shared 1Password ClusterSecretStore from approved namespaces.
         foreach:
@@ -91,8 +99,9 @@ spec:
                     operator: NotIn
                     value:
 {{- range $allowedNamespaces }}
-                      - {{ . }}
+                    - {{ . }}
 {{- end }}
+  validationFailureAction: Audit
 {{- range $namespace, $keys := .Values.clusterSecretStorePolicy.allowedNamespaces }}
 ---
 apiVersion: kyverno.io/v1
@@ -100,10 +109,13 @@ kind: ClusterPolicy
 metadata:
   name: restrict-onepassword-keys-{{ $namespace }}
 spec:
+  admission: true
   background: false
+  emitWarning: false
   rules:
     # Entries with no per-entry storeRef inherit this top-level shared ClusterSecretStore.
     - name: restrict-inherited-data-keys
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -120,6 +132,7 @@ spec:
             operator: Equals
             value: {{ $storeName }}
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret data entries using the shared 1Password ClusterSecretStore must read approved item keys.
         foreach:
@@ -140,6 +153,7 @@ spec:
 {{- end }}
     # dataFrom entries with extract.key also inherit the top-level shared store unless they override storeRef.
     - name: restrict-inherited-datafrom-keys
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -156,6 +170,7 @@ spec:
             operator: Equals
             value: {{ $storeName }}
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret dataFrom entries using the shared 1Password ClusterSecretStore must read approved item keys.
         foreach:
@@ -179,6 +194,7 @@ spec:
 {{- end }}
     # Per-entry storeRef overrides can explicitly target the shared ClusterSecretStore.
     - name: restrict-explicit-data-keys
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -187,6 +203,7 @@ spec:
               namespaces:
                 - {{ $namespace }}
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret data entries using the shared 1Password ClusterSecretStore must read approved item keys.
         foreach:
@@ -209,6 +226,7 @@ spec:
                       - {{ . }}
 {{- end }}
     - name: restrict-explicit-datafrom-keys
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -217,6 +235,7 @@ spec:
               namespaces:
                 - {{ $namespace }}
       validate:
+        allowExistingViolations: true
         failureAction: Enforce
         message: ExternalSecret dataFrom entries using the shared 1Password ClusterSecretStore must read approved item keys.
         foreach:
@@ -238,5 +257,6 @@ spec:
 {{- range $keys }}
                       - {{ . }}
 {{- end }}
+  validationFailureAction: Audit
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- ignore Kubernetes-defaulted CRD conversion fields for the Kyverno Argo CD app
- render Kyverno ClusterPolicy default fields explicitly so kyverno-policy stays in sync

## Validation
- make test