### PR TITLE
fix(kyverno): ignore empty CRD metadata drift

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -29,12 +29,14 @@ local crdConversionCABundle(name) = [{
   ],
 }];
 
-local crdDefaultedConversion(crdNames) = [
+local kyvernoDefaultedCrdFields(crdNames) = [
   {
     group: 'apiextensions.k8s.io',
     kind: 'CustomResourceDefinition',
     name: crdName,
     jsonPointers: [
+      '/metadata/annotations',
+      '/metadata/labels',
       '/spec/conversion',
     ],
   }
@@ -71,7 +73,7 @@ local _ignoreDifferences = {
   },
   security: {
     // Re-check this list against rendered Kyverno CRDs when bumping the kyverno chart.
-    kyverno: crdDefaultedConversion([
+    kyverno: kyvernoDefaultedCrdFields([
       'deletingpolicies.policies.kyverno.io',
       'generatingpolicies.policies.kyverno.io',
       'imagevalidatingpolicies.policies.kyverno.io',


### PR DESCRIPTION
## Summary
- extend Kyverno CRD ignore rules to include empty metadata annotations and labels emitted by the chart but omitted live
- rename the helper to reflect all ignored defaulted fields

## Validation
- make test
- compared rendered vs live CRD; after excluding conversion/preserveUnknownFields, remaining drift was empty metadata maps