### PR TITLE
ci: disable Claude review workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,16 +1,8 @@
 name: Claude Code
 
+# Disabled to avoid exhausting Claude review limits.
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Disable automatic Claude review workflow triggers to avoid hitting usage limits
- Keep the workflow available for manual dispatch

## Validation
- make test