### PR TITLE
fix(k8s-cleaner): clean Longhorn recurring job pods

### DIFF
--- a/helm-charts/k8s-cleaner/templates/cleaner-longhorn-recurring-job-pods.yaml
+++ b/helm-charts/k8s-cleaner/templates/cleaner-longhorn-recurring-job-pods.yaml
@@ -1,8 +1,9 @@
+{{- range .Values.longhornRecurringJobPods.jobs }}
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:
-  name: longhorn-trim-pods
-  namespace: {{ .Values.namespace }}
+  name: longhorn-{{ . }}-pods
+  namespace: {{ $.Values.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
@@ -12,11 +13,11 @@ spec:
       - kind: Pod
         group: ""
         version: v1
-        namespace: {{ .Values.longhornTrimJobs.namespace }}
+        namespace: {{ $.Values.longhornRecurringJobPods.namespace }}
         labelFilters:
           - key: recurring-job.longhorn.io
             operation: Equal
-            value: trim
+            value: {{ . }}
         evaluate: |
           function evaluate()
             local result = {}
@@ -33,3 +34,5 @@ spec:
             return result
           end
   action: Delete
+---
+{{- end }}

--- a/helm-charts/k8s-cleaner/values.yaml
+++ b/helm-charts/k8s-cleaner/values.yaml
@@ -14,8 +14,11 @@ repave:
 failedPods:
   excludeNamespaces: *excludeNamespaces
 
-longhornTrimJobs:
+longhornRecurringJobPods:
   namespace: longhorn-system
+  jobs:
+    - backup
+    - trim
 
 kyvernoHookJobs:
   namespace: kyverno


### PR DESCRIPTION
## Summary
- template Longhorn recurring-job Pod cleanup from a single k8s-cleaner Cleaner template
- clean completed/failed Pods for Longhorn backup and trim recurring jobs
- keep Longhorn Job lifecycle under Longhorn/CronJob control

## Validation
- helm template k8s-cleaner helm-charts/k8s-cleaner
- make test