### PR TITLE
fix(resources): tune Argo CD and jung2bot scaling

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -7,10 +7,10 @@ argo-cd:
     controllerResources: &controllerResources
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 2Gi
         ephemeral-storage: 256Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi
         ephemeral-storage: 256Mi
     componentResources: &componentResources
       requests:

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -13,3 +13,4 @@ app:
     stage: dev
   autoscaling:
     min: 2
+    max: 4

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -22,7 +22,7 @@ app:
     stage: prod
   autoscaling:
     min: 6
-    max: 18
+    max: 10
 
 cron:
   image:


### PR DESCRIPTION
## Summary
- increase Argo CD application-controller memory to reduce OOM risk during large syncs
- lower jung2bot prod KEDA max scale from 18 to 10
- cap jung2bot dev KEDA max scale at 4

## Validation
- make test