### PR TITLE
fix(argocd): run application controller as singleton

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -84,10 +84,10 @@ argo-cd:
   notifications:
     enabled: false
   controller:
-    replicas: 3
+    replicas: 1
     resources: *controllerResources
     readinessProbe: *readinessProbe
-    pdb: *haPdb
+    pdb: *singletonPdb
   server:
     autoscaling:
       enabled: true


### PR DESCRIPTION
## Summary
- reduce Argo CD application-controller replicas from 3 to 1
- switch the controller PDB to the singleton policy
- keep the larger controller memory from the previous PR while reducing total requested controller memory

This cluster currently manages only the in-cluster Kubernetes destination, so extra controller replicas do not meaningfully shard workload and mostly add memory pressure.

## Validation
- make test