### PR TITLE
fix(resources): right-size memory requests

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -15,10 +15,10 @@ argo-cd:
     componentResources: &componentResources
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 128Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 256Mi
+        memory: 128Mi
         ephemeral-storage: 128Mi
     redisResources: &redisResources
       requests:
@@ -113,15 +113,15 @@ argo-cd:
   repoServer:
     autoscaling:
       enabled: true
-      minReplicas: 2
-      maxReplicas: 3
+      minReplicas: 1
+      maxReplicas: 2
     resources:
       requests:
         cpu: 250m
-        memory: 2Gi
+        memory: 1Gi
         ephemeral-storage: 512Mi
       limits:
-        memory: 2Gi
+        memory: 1Gi
         ephemeral-storage: 512Mi
     readinessProbe:
       initialDelaySeconds: 10
@@ -133,7 +133,7 @@ argo-cd:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 6
-    pdb: *haPdb
+    pdb: *singletonPdb
     containerSecurityContext:
       runAsUser: 999
     rbac:
@@ -205,10 +205,10 @@ argo-cd:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 128Mi
             ephemeral-storage: 256Mi
           limits:
-            memory: 256Mi
+            memory: 128Mi
             ephemeral-storage: 256Mi
         volumeMounts:
           - mountPath: /var/run/argocd

--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -18,10 +18,10 @@ deployment:
   resources:
     requests:
       cpu: 100m
-      memory: 512Mi
+      memory: 192Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 512Mi
+      memory: 192Mi
       ephemeral-storage: 100Mi
 
 hpa:

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -13,10 +13,10 @@ deployment:
   resources:
     requests:
       cpu: 100m
-      memory: 500Mi
+      memory: 256Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 500Mi
+      memory: 256Mi
       ephemeral-storage: 100Mi
 
 service:

--- a/helm-charts/coredns/values.yaml
+++ b/helm-charts/coredns/values.yaml
@@ -9,10 +9,10 @@ deployment:
   resources:
     requests:
       cpu: 100m
-      memory: 170Mi
+      memory: 128Mi
       ephemeral-storage: 64Mi
     limits:
-      memory: 170Mi
+      memory: 128Mi
       ephemeral-storage: 64Mi
 
 config:

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -41,10 +41,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 128Mi
               ephemeral-storage: 100Mi
             limits:
-              memory: 300Mi
+              memory: 128Mi
               ephemeral-storage: 100Mi
       affinity:
         podAntiAffinity:

--- a/helm-charts/istiod/values.yaml
+++ b/helm-charts/istiod/values.yaml
@@ -6,8 +6,8 @@ istiod:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 256Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 512Mi
+        memory: 256Mi
         ephemeral-storage: 128Mi

--- a/helm-charts/jsoncrack/values.yaml
+++ b/helm-charts/jsoncrack/values.yaml
@@ -10,10 +10,10 @@ deployment:
   resources:
     requests:
       cpu: 100m
-      memory: 300Mi
+      memory: 128Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 300Mi
+      memory: 128Mi
       ephemeral-storage: 100Mi
 
 service:

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -45,10 +45,10 @@ spec:
           resources:
             requests:
               cpu: "0.1"
-              memory: "300Mi"
+              memory: "192Mi"
               ephemeral-storage: "100Mi"
             limits:
-              memory: "300Mi"
+              memory: "192Mi"
               ephemeral-storage: "100Mi"
           env:
             - name: PROFILE

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -77,15 +77,17 @@ loki:
     resources:
       requests:
         cpu: 100m
-        memory: 1Gi
+        memory: 768Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 1Gi
+        memory: 768Mi
         ephemeral-storage: 128Mi
   minio:
     enabled: false
   chunksCache:
     enabled: false
+  resultsCache:
+    allocatedMemory: 128
   memberlist:
     service:
       publishNotReadyAddresses: true

--- a/helm-charts/teslamate/templates/deployment.yaml
+++ b/helm-charts/teslamate/templates/deployment.yaml
@@ -44,8 +44,8 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 500Mi
+              memory: 384Mi
               ephemeral-storage: 100Mi
             limits:
-              memory: 500Mi
+              memory: 384Mi
               ephemeral-storage: 100Mi


### PR DESCRIPTION
## Summary
- reduce over-provisioned memory requests/limits for Argo CD repo-server, app components, and CMP sidecar
- lower Loki single-binary and results-cache memory allocation
- right-size several app/control-plane workloads based on current observed usage: blocky, changedetection, jsoncrack, excalidraw, jung2bot, teslamate, istiod, and coredns

## Impact
- keeps memory requests equal to limits per repo guidance
- reduces steady-state requested memory by roughly 8Gi based on current replica counts and rendered resources
- reduces Argo CD repo-server HPA min from 2 to 1 and max from 3 to 2 to avoid idle memory reservation

## Validation
- make test