### PR TITLE
ci: fail Codex gate on review comments

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -171,7 +171,6 @@ jobs:
         uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           claude_args: |
             --model sonnet --allowedTools "Bash(make:*),Bash(gh pr view:*),Bash(gh pr diff:*)"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -171,6 +171,7 @@ jobs:
         uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           claude_args: |
             --model sonnet --allowedTools "Bash(make:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
@@ -311,6 +312,7 @@ jobs:
         uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           claude_args: |
             --model sonnet --allowedTools "Bash(make:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh pr diff:*)"

--- a/.github/workflows/codex-connector-gate.yaml
+++ b/.github/workflows/codex-connector-gate.yaml
@@ -70,12 +70,28 @@ jobs:
                 { owner, repo, pull_number, per_page: 100 }
               );
 
-              const reviewedHead = reviews.some(review =>
+              const latestCodexReviews = reviews.filter(review =>
                 botLogins.has(review.user?.login) &&
                 review.commit_id === headSha
               );
 
-              if (reviewedHead) {
+              if (latestCodexReviews.length > 0) {
+                const reviewComments = await github.paginate(
+                  github.rest.pulls.listReviewComments,
+                  { owner, repo, pull_number, per_page: 100 }
+                );
+
+                const latestCodexComments = reviewComments.filter(comment =>
+                  botLogins.has(comment.user?.login) &&
+                  comment.commit_id === headSha &&
+                  !comment.in_reply_to_id
+                );
+
+                if (latestCodexComments.length > 0) {
+                  core.setFailed(`Codex left ${latestCodexComments.length} review comment(s) on HEAD ${headSha}.`);
+                  return;
+                }
+
                 core.info(`Codex reviewed HEAD ${headSha}`);
                 return;
               }


### PR DESCRIPTION
## Summary
- fail the Codex connector gate immediately when Codex leaves review comments on the current HEAD
- keep the existing success path for Codex review with no comments or a latest 👍 reaction

## Validation
- make test