### PR TITLE
fix: raise Blocky memory limit

### DIFF
--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -16,12 +16,13 @@ deployment:
   ports:
     http: 4000
   resources:
+    # Keep memory at 512Mi: Blocky spikes during denylist refresh/import and was OOMKilled at 192Mi.
     requests:
       cpu: 100m
-      memory: 192Mi
+      memory: 512Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 192Mi
+      memory: 512Mi
       ephemeral-storage: 100Mi
 
 hpa:


### PR DESCRIPTION
## Summary
- raise Blocky memory request/limit from 192Mi to 512Mi
- document why right-sizing should not reduce it again

## Testing
- make test