### PR TITLE
fix: raise Grafana memory limit

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -43,7 +43,15 @@ prometheus:
     enabled: false
 
 grafana:
-  resources: *smallResources
+  resources:
+    # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
+    requests:
+      cpu: 50m
+      memory: 512Mi
+      ephemeral-storage: 64Mi
+    limits:
+      memory: 512Mi
+      ephemeral-storage: 64Mi
   admin:
     existingSecret: grafana
   datasources:


### PR DESCRIPTION
## Summary
- raise Grafana memory request/limit from 128Mi to 512Mi
- add a comment documenting dashboard-driven probe failures to prevent right-sizing regressions

## Testing
- make test