### PR TITLE
feat: harden monitoring chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ validate-helm-charts: ## Validate all Helm charts
 	@for chart in helm-charts/*/; do \
 		if [ -f "$$chart/Chart.yaml" ]; then \
 			helm dependency list "$$chart" | awk ' \
-				NR > 1 && NF > 0 && $$4 != "ok" { \
+				NR > 1 && NF > 0 && $$4 !~ /^(ok|unpacked)$$/ { \
 					print "Helm dependency not current in " chart ": " $$0; \
 					bad = 1 \
 				} \

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,13 @@ validate-helm-charts: ## Validate all Helm charts
 	@echo "$(GREEN)Validating Helm charts...$(NC)"
 	@for chart in helm-charts/*/; do \
 		if [ -f "$$chart/Chart.yaml" ]; then \
+			helm dependency list "$$chart" | awk ' \
+				NR > 1 && NF > 0 && $$4 != "ok" { \
+					print "Helm dependency not current in " chart ": " $$0; \
+					bad = 1 \
+				} \
+				END { exit bad } \
+			' chart="$$chart" || exit 1; \
 			helm lint "$$chart" --quiet || exit 1; \
 		fi; \
 	done

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -26,21 +26,58 @@ httpRoutes:
       port: 80
 
 prometheus:
+  configmapReload:
+    prometheus:
+      resources: *smallResources
   server:
     resources:
+      # Keep memory at 3Gi: Grafana dashboard queries pushed Prometheus close to the previous 2Gi limit.
       requests:
         cpu: 100m
-        memory: 2Gi
+        memory: 3Gi
         ephemeral-storage: 256Mi
       limits:
-        memory: 2Gi
+        memory: 3Gi
         ephemeral-storage: 256Mi
     persistentVolume:
       size: 50Gi
-    retentionSize: 10GB
-    retention: 1d
+    # One day currently uses about 2.3G; retain 7 days while leaving PVC headroom for WAL/head chunks and growth.
+    retentionSize: 45GB
+    retention: 7d
   alertmanager:
     enabled: false
+  kube-state-metrics:
+    resources: *smallResources
+  prometheus-node-exporter:
+    resources: *smallResources
+  prometheus-pushgateway:
+    resources: *smallResources
+  serverFiles:
+    recording_rules.yml:
+      groups:
+        - name: workload-resource-usage
+          interval: 30s
+          rules:
+            - record: namespace:workload_cpu_usage_cores:rate5m
+              expr: |
+                sum by (namespace) (
+                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!=""}[5m])
+                )
+            - record: namespace:workload_memory_working_set_bytes:sum
+              expr: |
+                sum by (namespace) (
+                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!=""}
+                )
+            - record: pod:workload_cpu_usage_cores:rate5m
+              expr: |
+                sum by (namespace, pod) (
+                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!=""}[5m])
+                )
+            - record: pod:workload_memory_working_set_bytes:sum
+              expr: |
+                sum by (namespace, pod) (
+                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!=""}
+                )
 
 grafana:
   resources:
@@ -71,7 +108,7 @@ grafana:
       providers:
         - name: default
           folder: ''
-          allowUiUpdates: true
+          allowUiUpdates: false
           options:
             path: /var/lib/grafana/dashboards
   grafana.ini:
@@ -80,6 +117,10 @@ grafana:
 
 loki:
   deploymentMode: SingleBinary
+  lokiCanary:
+    resources: *smallResources
+  gateway:
+    resources: *smallResources
   singleBinary:
     replicas: 1
     resources:
@@ -96,6 +137,18 @@ loki:
     enabled: false
   resultsCache:
     allocatedMemory: 128
+    resources:
+      requests:
+        cpu: 500m
+        memory: 154Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 154Mi
+        ephemeral-storage: 64Mi
+  memcachedExporter:
+    resources: *smallResources
+  sidecar:
+    resources: *smallResources
   memberlist:
     service:
       publishNotReadyAddresses: true

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -41,8 +41,8 @@ prometheus:
         ephemeral-storage: 256Mi
     persistentVolume:
       size: 50Gi
-    # One day currently uses about 2.3G; retain 7 days while leaving PVC headroom for WAL/head chunks and growth.
-    retentionSize: 45GB
+    # One day currently uses about 2.3G; cap at 40GB on the 50Gi PVC to leave WAL/headroom and growth space.
+    retentionSize: 40GB
     retention: 7d
   alertmanager:
     enabled: false
@@ -61,22 +61,22 @@ prometheus:
             - record: namespace:workload_cpu_usage_cores:rate5m
               expr: |
                 sum by (namespace) (
-                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!=""}[5m])
+                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}[5m])
                 )
             - record: namespace:workload_memory_working_set_bytes:sum
               expr: |
                 sum by (namespace) (
-                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!=""}
+                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
                 )
             - record: pod:workload_cpu_usage_cores:rate5m
               expr: |
                 sum by (namespace, pod) (
-                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!=""}[5m])
+                  rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}[5m])
                 )
             - record: pod:workload_memory_working_set_bytes:sum
               expr: |
                 sum by (namespace, pod) (
-                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!=""}
+                  container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
                 )
 
 grafana:
@@ -139,7 +139,7 @@ loki:
     allocatedMemory: 128
     resources:
       requests:
-        cpu: 500m
+        cpu: 100m
         memory: 154Mi
         ephemeral-storage: 64Mi
       limits:


### PR DESCRIPTION
## Summary
- raise Prometheus memory to 3Gi and set retention to 7d with a 45GB cap
- add workload CPU/memory recording rules for namespace and pod aggregates
- make Grafana dashboards Git-only by disabling UI updates
- add explicit resources for monitoring sidecars and bundled subcomponents
- fail Helm validation when local chart dependencies are stale

## Testing
- helm template monitoring helm-charts/monitoring -n monitoring
- promtool check rules using the live Prometheus container
- make test

## Notes
- Current Prometheus 1-day storage usage was measured at about 2.3G
- Loki is already configured for 7d retention and uses about 0.736Gi of its 10Gi PVC