### PR TITLE
fix: require Codex thumbs up for connector gate

### DIFF
--- a/.github/workflows/codex-connector-gate.yaml
+++ b/.github/workflows/codex-connector-gate.yaml
@@ -70,22 +70,6 @@ jobs:
               new Date(createdAt) >= prUpdatedAt;
 
             while (Date.now() < deadline) {
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssue,
-                { owner, repo, issue_number: pull_number, per_page: 100 }
-              );
-
-              const thumbsUpAfterHead = reactions.some(reaction =>
-                isCodex(reaction.user) &&
-                reaction.content === "+1" &&
-                isCurrentPrUpdateSignal(reaction.created_at)
-              );
-
-              if (thumbsUpAfterHead) {
-                core.info(`Codex gave 👍 after PR update for HEAD ${headSha}`);
-                return;
-              }
-
               const reviews = await github.paginate(
                 github.rest.pulls.listReviews,
                 { owner, repo, pull_number, per_page: 100 }
@@ -123,13 +107,29 @@ jobs:
                 { owner, repo, issue_number: pull_number, per_page: 100 }
               );
 
-              const codexIssueCommentsAfterHead = issueComments.filter(comment =>
+              const codexIssueCommentsAfterPrUpdate = issueComments.filter(comment =>
                 isCodex(comment.user) &&
                 isCurrentPrUpdateSignal(comment.created_at)
               );
 
-              if (codexIssueCommentsAfterHead.length > 0) {
-                core.setFailed(`Codex left ${codexIssueCommentsAfterHead.length} PR comment(s) after HEAD ${headSha}; only a 👍 reaction passes this gate.`);
+              if (codexIssueCommentsAfterPrUpdate.length > 0) {
+                core.setFailed(`Codex left ${codexIssueCommentsAfterPrUpdate.length} PR comment(s) after PR update for HEAD ${headSha}; only a 👍 reaction passes this gate.`);
+                return;
+              }
+
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssue,
+                { owner, repo, issue_number: pull_number, per_page: 100 }
+              );
+
+              const thumbsUpAfterPrUpdate = reactions.some(reaction =>
+                isCodex(reaction.user) &&
+                reaction.content === "+1" &&
+                isCurrentPrUpdateSignal(reaction.created_at)
+              );
+
+              if (thumbsUpAfterPrUpdate) {
+                core.info(`Codex gave 👍 after PR update for HEAD ${headSha}`);
                 return;
               }
 

--- a/.github/workflows/codex-connector-gate.yaml
+++ b/.github/workflows/codex-connector-gate.yaml
@@ -63,16 +63,11 @@ jobs:
             const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
             const deadline = Date.now() + 20 * 60 * 1000;
 
-            const { data: headCommit } = await github.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: headSha,
-            });
-            const headCommittedAt = new Date(headCommit.commit.committer.date);
+            const prUpdatedAt = new Date(context.payload.pull_request.updated_at);
 
             const isCodex = user => botLogins.has(user?.login);
-            const isCurrentHeadSignal = createdAt =>
-              new Date(createdAt) >= headCommittedAt;
+            const isCurrentPrUpdateSignal = createdAt =>
+              new Date(createdAt) >= prUpdatedAt;
 
             while (Date.now() < deadline) {
               const reactions = await github.paginate(
@@ -83,11 +78,11 @@ jobs:
               const thumbsUpAfterHead = reactions.some(reaction =>
                 isCodex(reaction.user) &&
                 reaction.content === "+1" &&
-                isCurrentHeadSignal(reaction.created_at)
+                isCurrentPrUpdateSignal(reaction.created_at)
               );
 
               if (thumbsUpAfterHead) {
-                core.info(`Codex gave 👍 after HEAD ${headSha}`);
+                core.info(`Codex gave 👍 after PR update for HEAD ${headSha}`);
                 return;
               }
 
@@ -130,7 +125,7 @@ jobs:
 
               const codexIssueCommentsAfterHead = issueComments.filter(comment =>
                 isCodex(comment.user) &&
-                isCurrentHeadSignal(comment.created_at)
+                isCurrentPrUpdateSignal(comment.created_at)
               );
 
               if (codexIssueCommentsAfterHead.length > 0) {
@@ -138,7 +133,7 @@ jobs:
                 return;
               }
 
-              core.info("Waiting for Codex connector 👍...");
+              core.info("Waiting for Codex connector 👍 after current PR update...");
               await sleep(60 * 1000);
             }
 

--- a/.github/workflows/codex-connector-gate.yaml
+++ b/.github/workflows/codex-connector-gate.yaml
@@ -55,7 +55,6 @@ jobs:
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
-            const updatedAt = new Date(context.payload.pull_request.updated_at);
             const botLogins = new Set([
               "chatgpt-codex-connector[bot]",
               "chatgpt-codex-connector",
@@ -64,59 +63,86 @@ jobs:
             const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
             const deadline = Date.now() + 20 * 60 * 1000;
 
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner,
+              repo,
+              ref: headSha,
+            });
+            const headCommittedAt = new Date(headCommit.commit.committer.date);
+
+            const isCodex = user => botLogins.has(user?.login);
+            const isCurrentHeadSignal = createdAt =>
+              new Date(createdAt) >= headCommittedAt;
+
             while (Date.now() < deadline) {
-              const reviews = await github.paginate(
-                github.rest.pulls.listReviews,
-                { owner, repo, pull_number, per_page: 100 }
-              );
-
-              const latestCodexReviews = reviews.filter(review =>
-                botLogins.has(review.user?.login) &&
-                review.commit_id === headSha
-              );
-
-              if (latestCodexReviews.length > 0) {
-                const reviewComments = await github.paginate(
-                  github.rest.pulls.listReviewComments,
-                  { owner, repo, pull_number, per_page: 100 }
-                );
-
-                const latestCodexComments = reviewComments.filter(comment =>
-                  botLogins.has(comment.user?.login) &&
-                  comment.commit_id === headSha &&
-                  !comment.in_reply_to_id
-                );
-
-                if (latestCodexComments.length > 0) {
-                  core.setFailed(`Codex left ${latestCodexComments.length} review comment(s) on HEAD ${headSha}.`);
-                  return;
-                }
-
-                core.info(`Codex reviewed HEAD ${headSha}`);
-                return;
-              }
-
               const reactions = await github.paginate(
                 github.rest.reactions.listForIssue,
                 { owner, repo, issue_number: pull_number, per_page: 100 }
               );
 
-              const thumbsUpAfterUpdate = reactions.some(reaction =>
-                botLogins.has(reaction.user?.login) &&
+              const thumbsUpAfterHead = reactions.some(reaction =>
+                isCodex(reaction.user) &&
                 reaction.content === "+1" &&
-                new Date(reaction.created_at) >= updatedAt
+                isCurrentHeadSignal(reaction.created_at)
               );
 
-              if (thumbsUpAfterUpdate) {
-                core.info("Codex gave 👍 after latest PR update");
+              if (thumbsUpAfterHead) {
+                core.info(`Codex gave 👍 after HEAD ${headSha}`);
                 return;
               }
 
-              core.info("Waiting for Codex connector review or 👍...");
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                { owner, repo, pull_number, per_page: 100 }
+              );
+
+              const codexReviewsOnHead = reviews.filter(review =>
+                isCodex(review.user) &&
+                review.commit_id === headSha &&
+                review.state !== "DISMISSED"
+              );
+
+              if (codexReviewsOnHead.length > 0) {
+                core.setFailed(`Codex left ${codexReviewsOnHead.length} review(s) on HEAD ${headSha}; only a 👍 reaction passes this gate.`);
+                return;
+              }
+
+              const reviewComments = await github.paginate(
+                github.rest.pulls.listReviewComments,
+                { owner, repo, pull_number, per_page: 100 }
+              );
+
+              const codexReviewCommentsOnHead = reviewComments.filter(comment =>
+                isCodex(comment.user) &&
+                comment.commit_id === headSha &&
+                !comment.in_reply_to_id
+              );
+
+              if (codexReviewCommentsOnHead.length > 0) {
+                core.setFailed(`Codex left ${codexReviewCommentsOnHead.length} review comment(s) on HEAD ${headSha}; only a 👍 reaction passes this gate.`);
+                return;
+              }
+
+              const issueComments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: pull_number, per_page: 100 }
+              );
+
+              const codexIssueCommentsAfterHead = issueComments.filter(comment =>
+                isCodex(comment.user) &&
+                isCurrentHeadSignal(comment.created_at)
+              );
+
+              if (codexIssueCommentsAfterHead.length > 0) {
+                core.setFailed(`Codex left ${codexIssueCommentsAfterHead.length} PR comment(s) after HEAD ${headSha}; only a 👍 reaction passes this gate.`);
+                return;
+              }
+
+              core.info("Waiting for Codex connector 👍...");
               await sleep(60 * 1000);
             }
 
-            core.setFailed("Timed out waiting for Codex connector review signal.");
+            core.setFailed("Timed out waiting for Codex connector 👍.");
 
   codex-connector-status:
     if: always()


### PR DESCRIPTION
## Summary
- require a Codex 👍 reaction after the current HEAD commit for the connector gate to pass
- fail the gate when Codex leaves a PR review, review comment, or PR comment for the current HEAD
- fail on timeout instead of treating a comment-only review as success

## Testing
- make test

## Notes
- actionlint is not installed locally, so workflow-specific lint was not run