### PR TITLE
ci: simplify Claude review workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -28,219 +28,8 @@ on:
 permissions: {}
 
 jobs:
-  check-files:
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      should-review: ${{ steps.check.outputs.should-review }}
-    steps:
-      - name: Check if review is needed
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.url }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [ "$ACTOR" = "renovate[bot]" ] || [ "$ACTOR" = "otaru-ci[bot]" ]; then
-            echo "should-review=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          FILES=$(gh api "$PR_URL/files" --paginate --jq '.[].filename')
-          if echo "$FILES" | grep -qx '.github/workflows/claude.yaml'; then
-            echo "should-review=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if echo "$FILES" | grep -q .; then
-            echo "should-review=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should-review=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  authorize-write:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      can-write: ${{ steps.authorize.outputs.can-write }}
-    steps:
-      - name: Check write authorization
-        id: authorize
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          PERMISSION=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
-          case "$PERMISSION" in
-            admin|maintain|write)
-              echo "can-write=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-
-          LABELS=$(gh api "$PR_URL" --jq '.labels[].name')
-          if echo "$LABELS" | grep -qx 'claude-write'; then
-            echo "can-write=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can-write=false" >> "$GITHUB_OUTPUT"
-          fi
-
   claude-review:
-    needs:
-      - authorize-write
-      - check-files
-    if: |
-      always() &&
-      ((github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'issues' &&
-        contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.issue.author_association) &&
-        (contains(github.event.issue.body, '@claude') ||
-        contains(github.event.issue.title, '@claude'))))
-    runs-on: ubuntu-latest
-    environment: automation
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 'lts/*'
-
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
-
-      - name: Setup yq
-        uses: vegardit/gha-setup-yq@ab621a91ac86c67e5b68b9f191e70acc09ebc61b # 1.1.0
-
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
-
-      - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2
-        with:
-          tofu_version: '1.8.1'
-
-      - name: Setup Terragrunt
-        uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
-        with:
-          terragrunt-version: latest
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install editorconfig-checker
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
-          tar -xzf /tmp/ec.tar.gz -C /tmp
-          BINARY=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
-          chmod +x "$BINARY"
-          sudo mv "$BINARY" /usr/local/bin/ec
-
-      - name: Install zizmor
-        run: pip install zizmor
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: stable
-
-      - name: Install go-jsonnet
-        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-
-      - name: Update Helm dependencies
-        run: make update-helm-deps
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
-          claude_args: |
-            --model sonnet --allowedTools "Bash(make:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
-          prompt: |
-            Review only. Do not push commits, edit PR metadata, change labels, or write repository content.
-
-            Review the PR changes with focus on:
-            1. Code quality, readability, and best practices
-            2. Security vulnerabilities
-            3. Potential bugs or edge cases
-            4. Configuration correctness (Helm, Terraform, YAML)
-
-            Skip auto-generated files (CRDs, dashboard JSON, lock files).
-            Keep output short and concise. Use bullet points where possible.
-            Only comment on issues worth fixing. Skip praise and nitpicks.
-
-  claude-external-review:
-    needs:
-      - authorize-write
-      - check-files
-    if: |
-      always() &&
-      ((github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository)) &&
-      needs.check-files.outputs.should-review == 'true' &&
-      needs.authorize-write.outputs.can-write != 'true'
-    runs-on: ubuntu-latest
-    environment: automation
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      actions: read
-    steps:
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: '*'
-          track_progress: false
-          claude_args: |
-            --model sonnet --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
-          prompt: |
-            Review only. Do not push commits, edit PR metadata, change labels, write repository content, or run code from the PR.
-
-            Use only read-only GitHub CLI commands such as `gh pr view` and `gh pr diff`.
-            Review the PR changes with focus on:
-            1. Code quality, readability, and best practices
-            2. Security vulnerabilities
-            3. Potential bugs or edge cases
-            4. Configuration correctness (Helm, Terraform, YAML)
-
-            Skip auto-generated files (CRDs, dashboard JSON, lock files).
-            Keep output short and concise. Use bullet points where possible.
-            Only comment on issues worth fixing. Skip praise and nitpicks.
-
-  claude-maintainer:
-    needs:
-      - authorize-write
-      - check-files
-    if: |
-      always() &&
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      needs.check-files.outputs.should-review == 'true' &&
-      needs.authorize-write.outputs.can-write == 'true'
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     environment: automation
     permissions:
@@ -249,65 +38,134 @@ jobs:
       issues: write
       actions: read
     steps:
+      - name: Decide Claude mode
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          PR_URL: ${{ github.event.pull_request.url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_ASSOCIATION: ${{ github.event.issue.author_association }}
+        run: |
+          should_run=false
+          mode=skip
+
+          case "$EVENT_NAME" in
+            pull_request)
+              if [ "$ACTOR" = "renovate[bot]" ] || [ "$ACTOR" = "otaru-ci[bot]" ]; then
+                :
+              elif [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
+                :
+              else
+                files=$(gh api "$PR_URL/files" --paginate --jq '.[].filename')
+                if echo "$files" | grep -qx '.github/workflows/claude.yaml'; then
+                  :
+                elif echo "$files" | grep -q .; then
+                  permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
+                  labels=$(gh api "$PR_URL" --jq '.labels[].name')
+                  if [ "$permission" = "admin" ] || [ "$permission" = "maintain" ] || [ "$permission" = "write" ] || echo "$labels" | grep -qx 'claude-write'; then
+                    should_run=true
+                    mode=maintainer
+                  else
+                    should_run=true
+                    mode=review
+                  fi
+                fi
+              fi
+              ;;
+            issue_comment)
+              if echo "$COMMENT_BODY" | grep -q '@claude' && echo 'COLLABORATOR MEMBER OWNER' | grep -qw "$COMMENT_ASSOCIATION"; then
+                should_run=true
+                mode=requested-review
+              fi
+              ;;
+            issues)
+              if { echo "$ISSUE_TITLE"; echo "$ISSUE_BODY"; } | grep -q '@claude' && echo 'COLLABORATOR MEMBER OWNER' | grep -qw "$ISSUE_ASSOCIATION"; then
+                should_run=true
+                mode=requested-review
+              fi
+              ;;
+            workflow_dispatch)
+              should_run=true
+              mode=requested-review
+              ;;
+          esac
+
+          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Setup Node.js
+      - name: Setup review tools
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+      - name: Install review tools
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm install -g markdownlint-cli2
+          pip install zizmor
+          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
+          tar -xzf /tmp/ec.tar.gz -C /tmp
+          binary=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
+          chmod +x "$binary"
+          sudo mv "$binary" /usr/local/bin/ec
 
       - name: Setup yq
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: vegardit/gha-setup-yq@ab621a91ac86c67e5b68b9f191e70acc09ebc61b # 1.1.0
 
       - name: Install Helm
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
 
       - name: Setup OpenTofu
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2
         with:
           tofu_version: '1.8.1'
 
       - name: Setup Terragrunt
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
         with:
           terragrunt-version: latest
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install editorconfig-checker
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
-          tar -xzf /tmp/ec.tar.gz -C /tmp
-          BINARY=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
-          chmod +x "$BINARY"
-          sudo mv "$BINARY" /usr/local/bin/ec
-
-      - name: Install zizmor
-        run: pip install zizmor
-
       - name: Setup Go
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
 
       - name: Install go-jsonnet
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
       - name: Update Helm dependencies
+        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
         run: make update-helm-deps
 
-      - name: Run Claude Code
-        id: claude
+      - name: Run Claude maintainer review
+        if: steps.decide.outputs.mode == 'maintainer'
         uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -330,27 +188,109 @@ jobs:
             Keep output short and concise. Use bullet points where possible.
             Only comment on issues worth fixing. Skip praise and nitpicks.
 
-  claude-status:
-    if: always()
-    needs:
-      - authorize-write
-      - check-files
-      - claude-review
-      - claude-external-review
-      - claude-maintainer
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Check claude result
+      - name: Run Claude read-only review
+        if: steps.decide.outputs.mode == 'review'
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: '*'
+          track_progress: false
+          claude_args: |
+            --model sonnet --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
+          prompt: |
+            Review only. Do not push commits, edit PR metadata, change labels, write repository content, or run code from the PR.
+
+            Use only read-only GitHub CLI commands such as `gh pr view` and `gh pr diff`.
+            Review the PR changes with focus on:
+            1. Code quality, readability, and best practices
+            2. Security vulnerabilities
+            3. Potential bugs or edge cases
+            4. Configuration correctness (Helm, Terraform, YAML)
+
+            Skip auto-generated files (CRDs, dashboard JSON, lock files).
+            Keep output short and concise. Use bullet points where possible.
+            Only comment on issues worth fixing. Skip praise and nitpicks.
+
+      - name: Run requested Claude review
+        if: steps.decide.outputs.mode == 'requested-review'
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          claude_args: |
+            --model sonnet --allowedTools "Bash(make:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
+          prompt: |
+            Review only. Do not push commits, edit PR metadata, change labels, or write repository content.
+
+            Review the PR changes with focus on:
+            1. Code quality, readability, and best practices
+            2. Security vulnerabilities
+            3. Potential bugs or edge cases
+            4. Configuration correctness (Helm, Terraform, YAML)
+
+            Skip auto-generated files (CRDs, dashboard JSON, lock files).
+            Keep output short and concise. Use bullet points where possible.
+            Only comment on issues worth fixing. Skip praise and nitpicks.
+
+      - name: Report skipped Claude review
+        if: steps.decide.outputs.should-run != 'true'
+        run: echo "Claude review skipped (${mode})."
         env:
-          AUTHORIZE_RESULT: ${{ needs.authorize-write.result }}
-          CHECK_FILES_RESULT: ${{ needs.check-files.result }}
-          CLAUDE_REVIEW_RESULT: ${{ needs.claude-review.result }}
-          CLAUDE_EXTERNAL_REVIEW_RESULT: ${{ needs.claude-external-review.result }}
-          CLAUDE_MAINTAINER_RESULT: ${{ needs.claude-maintainer.result }}
+          mode: ${{ steps.decide.outputs.mode }}
+
+  claude-external-review:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    environment: automation
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      actions: read
+    steps:
+      - name: Check if review is needed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.url }}
+          ACTOR: ${{ github.actor }}
         run: |
-          for result in "$AUTHORIZE_RESULT" "$CHECK_FILES_RESULT" "$CLAUDE_REVIEW_RESULT" "$CLAUDE_EXTERNAL_REVIEW_RESULT" "$CLAUDE_MAINTAINER_RESULT"; do
-            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
-              exit 1
+          should_run=false
+          if [ "$ACTOR" != "renovate[bot]" ] && [ "$ACTOR" != "otaru-ci[bot]" ]; then
+            files=$(gh api "$PR_URL/files" --paginate --jq '.[].filename')
+            if ! echo "$files" | grep -qx '.github/workflows/claude.yaml' && echo "$files" | grep -q .; then
+              should_run=true
             fi
-          done
+          fi
+          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude external review
+        if: steps.check.outputs.should-run == 'true'
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: '*'
+          track_progress: false
+          claude_args: |
+            --model sonnet --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
+          prompt: |
+            Review only. Do not push commits, edit PR metadata, change labels, write repository content, or run code from the PR.
+
+            Use only read-only GitHub CLI commands such as `gh pr view` and `gh pr diff`.
+            Review the PR changes with focus on:
+            1. Code quality, readability, and best practices
+            2. Security vulnerabilities
+            3. Potential bugs or edge cases
+            4. Configuration correctness (Helm, Terraform, YAML)
+
+            Skip auto-generated files (CRDs, dashboard JSON, lock files).
+            Keep output short and concise. Use bullet points where possible.
+            Only comment on issues worth fixing. Skip praise and nitpicks.
+
+      - name: Report skipped external review
+        if: steps.check.outputs.should-run != 'true'
+        run: echo "Claude external review skipped."

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -62,7 +62,8 @@ jobs:
               if [ "$ACTOR" = "renovate[bot]" ] || [ "$ACTOR" = "otaru-ci[bot]" ]; then
                 :
               elif [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
-                :
+                should_run=true
+                mode=wait-external
               else
                 files=$(gh api "$PR_URL/files" --paginate --jq '.[].filename')
                 if echo "$files" | grep -qx '.github/workflows/claude.yaml'; then
@@ -99,6 +100,32 @@ jobs:
 
           echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for external review
+        if: steps.decide.outputs.mode == 'wait-external'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          deadline=$((SECONDS + 1200))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            result=$(gh pr checks "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json name,state,workflow \
+              --jq '.[] | select(.name == "claude-external-review" and .workflow == "Claude Code") | .state' \
+              | head -n 1)
+            case "$result" in
+              SUCCESS|SKIPPED)
+                exit 0
+                ;;
+              FAILURE|CANCELLED|TIMED_OUT)
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "Timed out waiting for claude-external-review." >&2
+          exit 1
 
       - name: Checkout repository
         if: steps.decide.outputs.mode == 'requested-review'

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
+      pull-requests: read
+      issues: read
       actions: read
     steps:
       - name: Decide Claude mode
@@ -71,8 +71,7 @@ jobs:
                   permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
                   labels=$(gh api "$PR_URL" --jq '.labels[].name')
                   if [ "$permission" = "admin" ] || [ "$permission" = "maintain" ] || [ "$permission" = "write" ] || echo "$labels" | grep -qx 'claude-write'; then
-                    should_run=true
-                    mode=maintainer
+                    mode=skip-maintainer
                   else
                     should_run=true
                     mode=review
@@ -102,20 +101,20 @@ jobs:
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup review tools
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
       - name: Install review tools
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -128,65 +127,41 @@ jobs:
           sudo mv "$binary" /usr/local/bin/ec
 
       - name: Setup yq
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: vegardit/gha-setup-yq@ab621a91ac86c67e5b68b9f191e70acc09ebc61b # 1.1.0
 
       - name: Install Helm
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
 
       - name: Setup OpenTofu
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2
         with:
           tofu_version: '1.8.1'
 
       - name: Setup Terragrunt
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
         with:
           terragrunt-version: latest
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
 
       - name: Install go-jsonnet
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
       - name: Update Helm dependencies
-        if: steps.decide.outputs.mode == 'maintainer' || steps.decide.outputs.mode == 'requested-review'
+        if: steps.decide.outputs.mode == 'requested-review'
         run: make update-helm-deps
-
-      - name: Run Claude maintainer review
-        if: steps.decide.outputs.mode == 'maintainer'
-        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          track_progress: true
-          claude_args: |
-            --model sonnet --allowedTools "Bash(make:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
-          prompt: |
-            If the PR title or description does not meaningfully describe the changes, update them.
-            Use conventional commit style for the title, under 72 characters.
-            Keep the description short with bullet points summarising the changes.
-
-            Review the PR changes with focus on:
-            1. Code quality, readability, and best practices
-            2. Security vulnerabilities
-            3. Potential bugs or edge cases
-            4. Configuration correctness (Helm, Terraform, YAML)
-
-            Skip auto-generated files (CRDs, dashboard JSON, lock files).
-            Keep output short and concise. Use bullet points where possible.
-            Only comment on issues worth fixing. Skip praise and nitpicks.
 
       - name: Run Claude read-only review
         if: steps.decide.outputs.mode == 'review'
@@ -238,6 +213,128 @@ jobs:
         run: echo "Claude review skipped (${mode})."
         env:
           mode: ${{ steps.decide.outputs.mode }}
+
+  claude-maintainer:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment: automation
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Check maintainer authorization
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          should_run=false
+          if [ "$ACTOR" != "renovate[bot]" ] && [ "$ACTOR" != "otaru-ci[bot]" ]; then
+            files=$(gh api "$PR_URL/files" --paginate --jq '.[].filename')
+            if ! echo "$files" | grep -qx '.github/workflows/claude.yaml' && echo "$files" | grep -q .; then
+              permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
+              labels=$(gh api "$PR_URL" --jq '.labels[].name')
+              if [ "$permission" = "admin" ] || [ "$permission" = "maintain" ] || [ "$permission" = "write" ] || echo "$labels" | grep -qx 'claude-write'; then
+                should_run=true
+              fi
+            fi
+          fi
+          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install review tools
+        if: steps.authorize.outputs.should-run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm install -g markdownlint-cli2
+          pip install zizmor
+          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
+          tar -xzf /tmp/ec.tar.gz -C /tmp
+          binary=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
+          chmod +x "$binary"
+          sudo mv "$binary" /usr/local/bin/ec
+
+      - name: Setup yq
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: vegardit/gha-setup-yq@ab621a91ac86c67e5b68b9f191e70acc09ebc61b # 1.1.0
+
+      - name: Install Helm
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
+
+      - name: Setup OpenTofu
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2
+        with:
+          tofu_version: '1.8.1'
+
+      - name: Setup Terragrunt
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
+        with:
+          terragrunt-version: latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Install go-jsonnet
+        if: steps.authorize.outputs.should-run == 'true'
+        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+
+      - name: Update Helm dependencies
+        if: steps.authorize.outputs.should-run == 'true'
+        run: make update-helm-deps
+
+      - name: Run Claude maintainer review
+        if: steps.authorize.outputs.should-run == 'true'
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: true
+          claude_args: |
+            --model sonnet --allowedTools "Bash(make:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
+          prompt: |
+            If the PR title or description does not meaningfully describe the changes, update them.
+            Use conventional commit style for the title, under 72 characters.
+            Keep the description short with bullet points summarising the changes.
+
+            Review the PR changes with focus on:
+            1. Code quality, readability, and best practices
+            2. Security vulnerabilities
+            3. Potential bugs or edge cases
+            4. Configuration correctness (Helm, Terraform, YAML)
+
+            Skip auto-generated files (CRDs, dashboard JSON, lock files).
+            Keep output short and concise. Use bullet points where possible.
+            Only comment on issues worth fixing. Skip praise and nitpicks.
+
+      - name: Report skipped maintainer review
+        if: steps.authorize.outputs.should-run != 'true'
+        run: echo "Claude maintainer review skipped."
 
   claude-external-review:
     if: |


### PR DESCRIPTION
## Summary

- Collapse Claude helper/status jobs into the review jobs
- Remove the synthetic `claude-status` job so the check cannot pass before Claude finishes
- Keep external fork reviews read-only via `pull_request_target`

## Tests

- `make test`
