### PR TITLE
fix: increase Fluent Bit Loki buffer

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -241,6 +241,7 @@ fluent-bit:
           URI /loki/api/v1/push
           Labels job=fluent-bit
           Label_Map_Path /fluent-bit/etc/conf/loki-labels.json
+          Buffer_Size 1M
           Retry_Limit False
 
     extraFiles:


### PR DESCRIPTION
## Summary\n- Increase Fluent Bit Loki output buffer size to avoid HTTP client buffer warnings from larger Loki responses.\n\n## Validation\n- helm template monitoring helm-charts/monitoring --namespace monitoring\n- make test