### PR TITLE
fix: use Fluent Bit Loki buffer key

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -241,7 +241,7 @@ fluent-bit:
           URI /loki/api/v1/push
           Labels job=fluent-bit
           Label_Map_Path /fluent-bit/etc/conf/loki-labels.json
-          Buffer_Size 1M
+          buffer_size 1M
           Retry_Limit False
 
     extraFiles:


### PR DESCRIPTION
## Summary\n- Use the Loki output plugin's documented  key so Fluent Bit applies the larger HTTP response buffer.\n\n## Validation\n- helm template monitoring helm-charts/monitoring --namespace monitoring\n- make test