### PR TITLE
fix: increase Fluent Bit Kubernetes buffer

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -231,6 +231,7 @@ fluent-bit:
           Keep_Log Off
           K8S-Logging.Parser On
           K8S-Logging.Exclude On
+          buffer_size 128k
 
     outputs: |
       [OUTPUT]


### PR DESCRIPTION
## Summary
- Increase the Fluent Bit Kubernetes filter API response buffer to avoid `http_client` 32K buffer warnings while enriching pod metadata.

## Validation
- `helm template monitoring helm-charts/monitoring --namespace monitoring`
- `make test`
