### PR TITLE
Increase vminsert startup memory headroom

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -107,10 +107,10 @@ victoria-metrics-cluster:
     resources:
       requests:
         cpu: 50m
-        memory: 512Mi
+        memory: 768Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 512Mi
+        memory: 768Mi
         ephemeral-storage: 128Mi
   vmstorage:
     fullnameOverride: monitoring-vmstorage


### PR DESCRIPTION
## Summary
- bump VictoriaMetrics vminsert memory request and limit from 512Mi to 768Mi
- keep the change scoped to vminsert after observing a startup OOM during rollout

## Tests
- make test