### PR TITLE
Discover Helm repos for chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,29 +28,14 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+        with:
+          version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
 
-      - name: add repos
-        run: |
-          helm repo add argo https://argoproj.github.io/argo-helm
-          helm repo add atlantis https://runatlantis.github.io/helm-charts
-          helm repo add cert-manager https://charts.jetstack.io
-          helm repo add cilium https://helm.cilium.io/
-          helm repo add descheduler https://kubernetes-sigs.github.io/descheduler/
-          helm repo add external-secrets-operator https://charts.external-secrets.io/
-          helm repo add fluent https://fluent.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo add istio https://istio-release.storage.googleapis.com/charts
-          helm repo add jkroepke https://jkroepke.github.io/helm-charts/
-          helm repo add kedacore https://kedacore.github.io/charts
-          helm repo add kyverno https://kyverno.github.io/kyverno/
-          helm repo add kiali https://kiali.org/helm-charts
-          helm repo add longhorn https://charts.longhorn.io
-          helm repo add metallb https://metallb.github.io/metallb
-          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-          helm repo add onepassword-connect https://1password.github.io/connect-helm-charts
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo add siutsin https://siutsin.github.io/otaru
-          helm repo add stakater https://stakater.github.io/stakater-charts
+      - name: Setup yq
+        uses: vegardit/gha-setup-yq@ab621a91ac86c67e5b68b9f191e70acc09ebc61b # 1.1.0
+
+      - name: Add Helm repositories
+        run: make add-helm-repos
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(MAGENTA)Development & Infrastructure:$(NC)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		grep -E "^(atlantis|clean-terragrunt-cache|update-helm-deps|delete-git-tags|clean-all|generate-diagrams):" | \
+		grep -E "^(atlantis|clean-terragrunt-cache|add-helm-repos|update-helm-deps|delete-git-tags|clean-all|generate-diagrams):" | \
 		sort | awk 'BEGIN {FS = ":.*?## "}; {gsub(/\(DANGEROUS!\)/, "$(RED)(DANGEROUS!)$(NC)"); printf "  $(YELLOW)%-25s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(GREEN)Validation & Quality:$(NC)"
@@ -124,6 +124,12 @@ atlantis: ## Generate Atlantis configuration file
 clean-terragrunt-cache: ## Clean up all .terragrunt-cache folders in infrastructure directory
 	@echo "$(GREEN)Cleaning Terragrunt cache...$(NC)"
 	bash $(HACK_DIR)/remove-terragrunt-cache.sh $(INFRASTRUCTURE_DIR)
+
+.PHONY: add-helm-repos
+add-helm-repos: ## Add Helm repositories declared by chart dependencies
+	@echo "$(GREEN)Adding Helm repositories from chart dependencies...$(NC)"
+	bash $(HACK_DIR)/add-helm-repos.sh helm-charts
+	@echo "$(GREEN)Helm repositories added successfully!$(NC)"
 
 .PHONY: update-helm-deps
 update-helm-deps: ## Update all Helm chart dependencies

--- a/hack/add-helm-repos.sh
+++ b/hack/add-helm-repos.sh
@@ -32,7 +32,7 @@ find "$CHARTS_DIR" -name 'Chart.yaml' -print0 \
         yq -r '.dependencies[]?.repository // ""' "$chart"
     done \
     | sed '/^$/d' \
-    | grep -E '^https?://' \
+    | { grep -E '^https?://' || true; } \
     | sort -u > "$REPOS_FILE"
 
 if [ ! -s "$REPOS_FILE" ]; then

--- a/hack/add-helm-repos.sh
+++ b/hack/add-helm-repos.sh
@@ -7,6 +7,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 
 CHARTS_DIR="${1:-./helm-charts}"
 TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/helm-repos.XXXXXX")
+ALL_REPOS_FILE="${TEMP_DIR}/all-repos"
 REPOS_FILE="${TEMP_DIR}/repos"
 
 cleanup() {
@@ -31,9 +32,9 @@ find "$CHARTS_DIR" -name 'Chart.yaml' -print0 \
     | while IFS= read -r -d '' chart; do
         yq -r '.dependencies[]?.repository // ""' "$chart"
     done \
-    | sed '/^$/d' \
-    | awk '/^https?:\/\//' \
-    | sort -u > "$REPOS_FILE"
+    | sed '/^$/d' > "$ALL_REPOS_FILE"
+
+awk '/^https?:\/\//' "$ALL_REPOS_FILE" | sort -u > "$REPOS_FILE"
 
 if [ ! -s "$REPOS_FILE" ]; then
     log_warning "No HTTP Helm repositories found in $CHARTS_DIR"

--- a/hack/add-helm-repos.sh
+++ b/hack/add-helm-repos.sh
@@ -32,7 +32,7 @@ find "$CHARTS_DIR" -name 'Chart.yaml' -print0 \
         yq -r '.dependencies[]?.repository // ""' "$chart"
     done \
     | sed '/^$/d' \
-    | { grep -E '^https?://' || true; } \
+    | awk '/^https?:\/\//' \
     | sort -u > "$REPOS_FILE"
 
 if [ ! -s "$REPOS_FILE" ]; then

--- a/hack/add-helm-repos.sh
+++ b/hack/add-helm-repos.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/common.sh"
+
+CHARTS_DIR="${1:-./helm-charts}"
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/helm-repos.XXXXXX")
+REPOS_FILE="${TEMP_DIR}/repos"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+if ! command_exists helm; then
+    exit_with_error "Helm is not installed or not in PATH"
+fi
+
+if ! command_exists yq; then
+    exit_with_error "yq is not installed or not in PATH"
+fi
+
+if ! directory_exists "$CHARTS_DIR"; then
+    exit_with_error "Charts directory '$CHARTS_DIR' does not exist"
+fi
+
+find "$CHARTS_DIR" -name 'Chart.yaml' -print0 \
+    | while IFS= read -r -d '' chart; do
+        yq -r '.dependencies[]?.repository // ""' "$chart"
+    done \
+    | sed '/^$/d' \
+    | grep -E '^https?://' \
+    | sort -u > "$REPOS_FILE"
+
+if [ ! -s "$REPOS_FILE" ]; then
+    log_warning "No HTTP Helm repositories found in $CHARTS_DIR"
+    exit 0
+fi
+
+log_info "Adding Helm repositories from chart dependencies..."
+
+while IFS= read -r repo; do
+    repo_name=$(
+        echo "$repo" \
+            | sed -E 's#^https?://##; s#/$##; s#[^A-Za-z0-9]+#-#g; s#^-##; s#-$##' \
+            | tr '[:upper:]' '[:lower:]'
+    )
+    helm repo add "$repo_name" "$repo" --force-update >/dev/null
+    log_success "Added Helm repository: $repo_name"
+done < "$REPOS_FILE"
+
+helm repo update >/dev/null
+log_success "Helm repositories are up to date"

--- a/hack/update-all-helm-dependency.sh
+++ b/hack/update-all-helm-dependency.sh
@@ -27,8 +27,7 @@ if ! directory_exists "$CHARTS_DIR"; then
 fi
 
 ensure_helm_repos() {
-    helm repo add fluent https://fluent.github.io/helm-charts --force-update >/dev/null
-    helm repo update fluent >/dev/null
+    "${SCRIPT_DIR}/add-helm-repos.sh" "$CHARTS_DIR"
 }
 
 log_info "Ensuring Helm repositories are configured..."


### PR DESCRIPTION
## Summary
- add a shared make target that discovers HTTP Helm repositories from chart dependencies
- use the shared repo setup in the chart dependency update script
- update the release workflow to use the same make target, including VictoriaMetrics repositories

## Tests
- make add-helm-repos
- make test