### PR TITLE
Document LUKS-aware node reboot policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,23 @@ Set explicit ephemeral-storage requests and limits with suitable values for the 
 
 **Markdown**: fix linting violations directly, never disable markdownlint rules.
 
+## Node Reboot Policy
+
+Some Raspberry Pi nodes use LUKS encrypted root disks and do not return from a
+plain reboot until the initramfs unlock step runs.
+
+- Never reboot a node directly with `reboot`, `shutdown`, `systemctl reboot`,
+  `kubectl debug`, or Ansible's generic `reboot` module.
+- Use the repository's LUKS-aware Ansible playbooks for planned node reboots so
+  they can cordon/drain, wait for initramfs dropbear, unlock LUKS, wait for SSH,
+  and uncordon safely.
+- For rolling maintenance, use `make maintenance` with
+  `OTARU_LUKS_PASSWORD` available in the controller environment.
+- For workload-only restarts that do not reboot hosts, use `make restart`.
+- For emergency single-node reboot work, first check whether the target is in
+  the `luks_root_nodes` inventory group; if it is, do not proceed unless a
+  LUKS-aware playbook or unlock workflow is used.
+
 ## Tool Selection
 
 | File Type   | Tool                  | Purpose                   |


### PR DESCRIPTION
## Summary
- document that LUKS-root Raspberry Pi nodes must not be rebooted directly
- point future agents to the repository's LUKS-aware Ansible maintenance/unlock workflow

## Tests
- make test