### PR TITLE
Add Kyverno workload resource audit policy

### DIFF
--- a/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
@@ -14,6 +14,15 @@ spec:
           - resources:
               kinds:
                 - Pod
+{{- with .Values.workloadResourcesPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+{{- end }}
       validate:
         failureAction: Audit
         message: Containers must set resource requests for cpu, memory, and ephemeral-storage, plus limits for memory and ephemeral-storage.

--- a/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.workloadResourcesPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-workload-resources
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-container-resource-requests-and-limits
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        failureAction: Audit
+        message: Containers must set resource requests for cpu, memory, and ephemeral-storage, plus limits for memory and ephemeral-storage.
+        pattern:
+          spec:
+            =(initContainers):
+              - resources:
+                  requests:
+                    cpu: ?*
+                    memory: ?*
+                    ephemeral-storage: ?*
+                  limits:
+                    memory: ?*
+                    ephemeral-storage: ?*
+            containers:
+              - resources:
+                  requests:
+                    cpu: ?*
+                    memory: ?*
+                    ephemeral-storage: ?*
+                  limits:
+                    memory: ?*
+                    ephemeral-storage: ?*
+  validationFailureAction: Audit
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -35,3 +35,8 @@ clusterSecretStorePolicy:
 
 workloadResourcesPolicy:
   enabled: true
+  excludedNamespaces:
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - kyverno

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -32,3 +32,6 @@ clusterSecretStorePolicy:
       - b2-secret-cloudnative-pg
       - heartbeats
       - teslamate
+
+workloadResourcesPolicy:
+  enabled: true


### PR DESCRIPTION
## Summary
- add a Kyverno ClusterPolicy requiring workload containers to define resource requests for cpu, memory, and ephemeral-storage
- require memory and ephemeral-storage limits while leaving CPU limits optional
- keep the policy in Audit mode for now

## Tests
- make test