### PR TITLE
Add Claude workflow status check

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -418,3 +418,28 @@ jobs:
       - name: Report skipped external review
         if: steps.check.outputs.should-run != 'true'
         run: echo "Claude external review skipped."
+
+  claude-status:
+    if: always()
+    needs:
+      - claude-review
+      - claude-maintainer
+      - claude-external-review
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check Claude workflow result
+        env:
+          REVIEW_RESULT: ${{ needs.claude-review.result }}
+          MAINTAINER_RESULT: ${{ needs.claude-maintainer.result }}
+          EXTERNAL_REVIEW_RESULT: ${{ needs.claude-external-review.result }}
+        run: |
+          if [ "$REVIEW_RESULT" = "failure" ] || [ "$REVIEW_RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          if [ "$MAINTAINER_RESULT" = "failure" ] || [ "$MAINTAINER_RESULT" = "cancelled" ]; then
+            exit 1
+          fi
+          if [ "$EXTERNAL_REVIEW_RESULT" = "failure" ] || [ "$EXTERNAL_REVIEW_RESULT" = "cancelled" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a final Claude workflow status job that always runs
- aggregate Claude review job results so skipped jobs do not block required checks
- mirror the Codex connector status check pattern

## Tests
- make test