### PR TITLE
chore: remove VictoriaMetrics from monitoring chart

### DIFF
--- a/helm-charts/monitoring/Chart.lock
+++ b/helm-charts/monitoring/Chart.lock
@@ -2,15 +2,6 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 29.2.1
-- name: victoria-metrics-cluster
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.41.2
-- name: victoria-metrics-agent
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.38.0
-- name: victoria-metrics-alert
-  repository: https://victoriametrics.github.io/helm-charts
-  version: 0.39.0
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 7.0.0
@@ -20,5 +11,5 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 10.5.15
-digest: sha256:687f949a006cdedee7878aa70e565b31e6d5968cbb9fb49c9f98b1beecaea411
-generated: "2026-05-02T13:03:47.613899+01:00"
+digest: sha256:968773bc49afb96da20b2b2344f0d99be90860196d6d5e56e1ac4dccad56f91e
+generated: "2026-05-02T17:01:21.745693+01:00"

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -8,15 +8,6 @@ dependencies:
 - name: prometheus
   version: 29.2.1
   repository: https://prometheus-community.github.io/helm-charts
-- name: victoria-metrics-cluster
-  version: 0.41.2
-  repository: https://victoriametrics.github.io/helm-charts
-- name: victoria-metrics-agent
-  version: 0.38.0
-  repository: https://victoriametrics.github.io/helm-charts
-- name: victoria-metrics-alert
-  version: 0.39.0
-  repository: https://victoriametrics.github.io/helm-charts
 - name: loki
   version: 7.0.0
   repository: https://grafana.github.io/helm-charts

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -16,11 +16,6 @@ httpRoutes:
     service:
       name: monitoring-prometheus-server
       port: 80
-  victoriametrics:
-    path: /select
-    service:
-      name: monitoring-vmselect
-      port: 8481
   loki:
     service:
       name: monitoring-loki
@@ -84,124 +79,6 @@ prometheus:
                   container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
                 )
 
-victoria-metrics-cluster:
-  vmselect:
-    fullnameOverride: monitoring-vmselect
-    replicaCount: 2
-    extraArgs:
-      dedup.minScrapeInterval: 30s
-      replicationFactor: 2
-    resources:
-      requests:
-        cpu: 50m
-        memory: 256Mi
-        ephemeral-storage: 128Mi
-      limits:
-        memory: 256Mi
-        ephemeral-storage: 128Mi
-  vminsert:
-    fullnameOverride: monitoring-vminsert
-    replicaCount: 2
-    extraArgs:
-      replicationFactor: 2
-    resources:
-      requests:
-        cpu: 50m
-        memory: 768Mi
-        ephemeral-storage: 128Mi
-      limits:
-        memory: 768Mi
-        ephemeral-storage: 128Mi
-  vmstorage:
-    fullnameOverride: monitoring-vmstorage
-    replicaCount: 3
-    retentionPeriod: 30d
-    persistentVolume:
-      size: 25Gi
-    resources:
-      requests:
-        cpu: 100m
-        memory: 1Gi
-        ephemeral-storage: 256Mi
-      limits:
-        memory: 1Gi
-        ephemeral-storage: 256Mi
-
-victoria-metrics-agent:
-  fullnameOverride: monitoring-vmagent
-  replicaCount: 2
-  mode: statefulSet
-  statefulSet:
-    clusterMode: true
-    replicationFactor: 2
-  remoteWrite:
-    - url: http://monitoring-vminsert.monitoring.svc.cluster.local:8480/insert/0/prometheus/
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-      ephemeral-storage: 256Mi
-    limits:
-      memory: 256Mi
-      ephemeral-storage: 256Mi
-  persistentVolume:
-    enabled: true
-    size: 2Gi
-  config:
-    # Scrape configs are inherited from victoria-metrics-agent 0.38.0 chart defaults.
-    # Review rendered scrape_configs deliberately when changing the chart version.
-    # Keep these timings aligned with vmselect dedup.minScrapeInterval above.
-    global:
-      scrape_interval: 30s
-      scrape_timeout: 10s
-
-victoria-metrics-alert:
-  server:
-    fullnameOverride: monitoring-vmalert
-    # Recording-rules-only for now; add a notifier before introducing alerting rules.
-    datasource:
-      url: http://monitoring-vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus/
-    remoteWrite:
-      url: http://monitoring-vminsert.monitoring.svc.cluster.local:8480/insert/0/prometheus/
-    remoteRead:
-      url: http://monitoring-vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus/
-    resources:
-      requests:
-        cpu: 50m
-        memory: 128Mi
-        ephemeral-storage: 64Mi
-      limits:
-        memory: 128Mi
-        ephemeral-storage: 64Mi
-    config:
-      # Duplicated from prometheus.serverFiles.recording_rules.yml while both stacks
-      # run side-by-side; keep them in sync until Prometheus is removed.
-      alerts:
-        groups:
-          - name: workload-resource-usage
-            interval: 30s
-            rules:
-              - record: namespace:workload_cpu_usage_cores:rate5m
-                expr: |
-                  sum by (namespace) (
-                    rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}[5m])
-                  )
-              - record: namespace:workload_memory_working_set_bytes:sum
-                expr: |
-                  sum by (namespace) (
-                    container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
-                  )
-              - record: pod:workload_cpu_usage_cores:rate5m
-                expr: |
-                  sum by (namespace, pod) (
-                    rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}[5m])
-                  )
-              - record: pod:workload_memory_working_set_bytes:sum
-                expr: |
-                  sum by (namespace, pod) (
-                    container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
-                  )
-
 grafana:
   resources:
     # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
@@ -222,9 +99,6 @@ grafana:
           type: prometheus
           url: http://monitoring-prometheus-server.monitoring.svc.cluster.local
           isDefault: true
-        - name: VictoriaMetrics
-          type: prometheus
-          url: http://monitoring-vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus/
         - name: Loki
           type: loki
           url: http://monitoring-loki.monitoring.svc.cluster.local:3100


### PR DESCRIPTION
## Summary
- remove VictoriaMetrics chart dependencies from the monitoring chart
- remove VictoriaMetrics routes, values, and Grafana datasource
- refresh the monitoring chart lockfile