### PR TITLE
Configure Kiali integrations and read-only mode

### DIFF
--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -33,6 +33,7 @@ spec:
                   - changedetection
                   - cyberchef
                   - excalidraw
+                  - gateway-api
                   - home-assistant
                   - httpbin
                   - istio-system
@@ -60,6 +61,7 @@ spec:
                   - changedetection
                   - cyberchef
                   - excalidraw
+                  - gateway-api
                   - home-assistant
                   - httpbin
                   - istio-system

--- a/helm-charts/kiali/templates/referencegrant.yaml
+++ b/helm-charts/kiali/templates/referencegrant.yaml
@@ -1,0 +1,16 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway-api" -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ .Values.name }}-gateway-backend
+  namespace: {{ .Values.namespace }}
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: {{ $gatewayNamespace }}
+  to:
+    - group: ""
+      kind: Service
+      name: kiali

--- a/helm-charts/kiali/templates/route-internal.yaml
+++ b/helm-charts/kiali/templates/route-internal.yaml
@@ -5,7 +5,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ .Values.name }}-internal
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $gatewayNamespace }}
 spec:
   hostnames:
     - {{ printf "%s.internal.siutsin.com" .Values.name }}
@@ -23,5 +23,6 @@ spec:
         - group: ""
           kind: Service
           name: kiali
+          namespace: {{ .Values.namespace }}
           port: 20001
           weight: 1

--- a/helm-charts/kiali/values.yaml
+++ b/helm-charts/kiali/values.yaml
@@ -10,6 +10,7 @@ kiali-server:
   deployment:
     accessible_namespaces:
       - "**"
+    view_only_mode: true
     resources:
       requests:
         cpu: 50m
@@ -19,5 +20,11 @@ kiali-server:
         memory: 256Mi
         ephemeral-storage: 64Mi
   external_services:
+    grafana:
+      enabled: true
+      internal_url: http://monitoring-grafana.monitoring.svc.cluster.local
+      external_url: https://grafana.internal.siutsin.com
     istio:
       root_namespace: istio-system
+    prometheus:
+      url: http://monitoring-prometheus-server.monitoring.svc.cluster.local


### PR DESCRIPTION
## Summary\n- point Kiali at the monitoring Prometheus service\n- enable Grafana integration with internal and external URLs\n- set Kiali to view-only mode for anonymous users\n\n## Testing\n- make test