### PR TITLE
Fix maintenance reboot unlock workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,11 @@ plain reboot until the initramfs unlock step runs.
 - For rolling maintenance, use `make maintenance` with
   `OTARU_LUKS_PASSWORD` available in the controller environment.
 - For workload-only restarts that do not reboot hosts, use `make restart`.
+- If a LUKS node is already waiting in initramfs after boot, unlock it with the
+  documented make target, for example `make unlock raspberrypi-01`.
 - For emergency single-node reboot work, first check whether the target is in
   the `luks_root_nodes` inventory group; if it is, do not proceed unless a
-  LUKS-aware playbook or unlock workflow is used.
+  LUKS-aware playbook or `make unlock <node-name>` workflow is used.
 
 ## Tool Selection
 

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -13,13 +13,21 @@
 - hosts: raspberrypi
   become: true
   serial: 1
-  vars:
-    k3s_kubeconfig: /etc/rancher/k3s/k3s.yaml
 
   tasks:
     - name: Get node name by removing .local from inventory_hostname
       set_fact:
         node_name: "{{ inventory_hostname | regex_replace('\\.local$', '') }}"
+
+    - name: Check if reboot is required
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required_marker
+
+    - name: Skip reboot when not required
+      debug:
+        msg: "Skipping {{ node_name }} because /var/run/reboot-required is absent."
+      when: not reboot_required_marker.stat.exists
 
     - name: Assert LUKS reboot passphrase is provided locally
       delegate_to: localhost
@@ -28,33 +36,41 @@
         that:
           - lookup('ansible.builtin.env', 'OTARU_LUKS_PASSWORD') | length > 0
         fail_msg: "Set OTARU_LUKS_PASSWORD in the controller environment before rebooting a LUKS node."
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Cordon the node
+      delegate_to: localhost
+      become: false
       command: kubectl cordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
+      delegate_to: localhost
+      become: false
       command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
       retries: 5
       delay: 30
       until: drain_result.rc == 0
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists
 
     - name: Reboot the system
       reboot:
         reboot_command: systemctl reboot --job-mode=replace-irreversibly
-      when: not (luks_enabled | default(false))
+      when:
+        - reboot_required_marker.stat.exists
+        - not (luks_enabled | default(false))
 
     - name: Reboot the LUKS system
       command: systemctl reboot --job-mode=replace-irreversibly
       async: 1
       poll: 0
       failed_when: false
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Wait for initramfs dropbear on LUKS node
       delegate_to: localhost
@@ -64,22 +80,24 @@
         port: "{{ luks_dropbear_port }}"
         delay: 5
         timeout: 600
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Unlock LUKS node through initramfs passfifo
       delegate_to: localhost
       become: false
-      shell: >-
-        {{ playbook_dir }}/../../hack/luks-cryptroot-unlock.sh
-        {{ ansible_host | default(inventory_hostname, true) }}
-        {{ luks_dropbear_port | string }}
-        --env-passfifo
+      command: make unlock {{ node_name }}
+      args:
+        chdir: "{{ playbook_dir }}/../../.."
       register: luks_unlock_result
       retries: 3
       delay: 10
       until: luks_unlock_result.rc == 0
       no_log: true
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Wait for system to become reachable
       delegate_to: localhost
@@ -89,13 +107,16 @@
         port: 22
         delay: 10
         timeout: 600
+      when: reboot_required_marker.stat.exists
 
     - name: Wait for SSH connection to recover
       wait_for_connection:
         delay: 5
         timeout: 300
+      when: reboot_required_marker.stat.exists
 
     - name: Uncordon the node
+      delegate_to: localhost
+      become: false
       command: kubectl uncordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists


### PR DESCRIPTION
## Summary
- skip maintenance reboots when /var/run/reboot-required is absent
- run cordon, drain, and uncordon from the controller instead of target nodes
- unlock LUKS nodes through the documented make unlock target

## Test
- make test