### PR TITLE
Fix maintenance reboot unlock workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,11 @@ plain reboot until the initramfs unlock step runs.
 - For rolling maintenance, use `make maintenance` with
   `OTARU_LUKS_PASSWORD` available in the controller environment.
 - For workload-only restarts that do not reboot hosts, use `make restart`.
+- If a LUKS node is already waiting in initramfs after boot, unlock it with the
+  documented make target, for example `make unlock raspberrypi-01`.
 - For emergency single-node reboot work, first check whether the target is in
   the `luks_root_nodes` inventory group; if it is, do not proceed unless a
-  LUKS-aware playbook or unlock workflow is used.
+  LUKS-aware playbook or `make unlock <node-name>` workflow is used.
 
 ## Tool Selection
 

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -13,6 +13,8 @@
 - hosts: raspberrypi
   become: true
   serial: 1
+  vars:
+    local_kubeconfig: "{{ lookup('ansible.builtin.env', 'KUBECONFIG') | default(lookup('ansible.builtin.env', 'HOME') ~ '/.kube/config', true) }}"
 
   tasks:
     - name: Get node name by removing .local from inventory_hostname
@@ -44,6 +46,8 @@
       delegate_to: localhost
       become: false
       command: kubectl cordon {{ node_name }}
+      environment:
+        KUBECONFIG: "{{ local_kubeconfig }}"
       changed_when: false
       when: reboot_required_marker.stat.exists
 
@@ -51,6 +55,8 @@
       delegate_to: localhost
       become: false
       command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
+      environment:
+        KUBECONFIG: "{{ local_kubeconfig }}"
       register: drain_result
       changed_when: false
       retries: 5
@@ -121,5 +127,7 @@
       delegate_to: localhost
       become: false
       command: kubectl uncordon {{ node_name }}
+      environment:
+        KUBECONFIG: "{{ local_kubeconfig }}"
       changed_when: false
       when: reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -89,7 +89,7 @@
       become: false
       command: make LUKS_UNLOCK_PORT={{ luks_dropbear_port | string }} unlock {{ node_name }}
       args:
-        chdir: "{{ playbook_dir }}/../../.."
+        chdir: "{{ inventory_dir }}/.."
       register: luks_unlock_result
       retries: 3
       delay: 10

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -44,6 +44,7 @@
       delegate_to: localhost
       become: false
       command: kubectl cordon {{ node_name }}
+      changed_when: false
       when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
@@ -51,6 +52,7 @@
       become: false
       command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
+      changed_when: false
       retries: 5
       delay: 30
       until: drain_result.rc == 0
@@ -119,4 +121,5 @@
       delegate_to: localhost
       become: false
       command: kubectl uncordon {{ node_name }}
+      changed_when: false
       when: reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -87,7 +87,7 @@
     - name: Unlock LUKS node through initramfs passfifo
       delegate_to: localhost
       become: false
-      command: make unlock {{ node_name }}
+      command: make LUKS_UNLOCK_PORT={{ luks_dropbear_port | string }} unlock {{ node_name }}
       args:
         chdir: "{{ playbook_dir }}/../../.."
       register: luks_unlock_result

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -45,14 +45,14 @@
     - name: Cordon the node
       delegate_to: localhost
       become: false
-      command: kubectl --kubeconfig {{ local_kubeconfig }} cordon {{ node_name }}
+      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl cordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
       delegate_to: localhost
       become: false
-      command: kubectl --kubeconfig {{ local_kubeconfig }} drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
+      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
       changed_when: false
       retries: 5
@@ -122,6 +122,6 @@
     - name: Uncordon the node
       delegate_to: localhost
       become: false
-      command: kubectl --kubeconfig {{ local_kubeconfig }} uncordon {{ node_name }}
+      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl uncordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -13,8 +13,6 @@
 - hosts: raspberrypi
   become: true
   serial: 1
-  vars:
-    local_kubeconfig: "{{ lookup('ansible.builtin.env', 'KUBECONFIG') | default(lookup('ansible.builtin.env', 'HOME') ~ '/.kube/config', true) }}"
 
   tasks:
     - name: Get node name by removing .local from inventory_hostname
@@ -45,14 +43,14 @@
     - name: Cordon the node
       delegate_to: localhost
       become: false
-      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl cordon {{ node_name }}
+      shell: KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" kubectl cordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
       delegate_to: localhost
       become: false
-      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
+      shell: KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
       changed_when: false
       retries: 5
@@ -122,6 +120,6 @@
     - name: Uncordon the node
       delegate_to: localhost
       become: false
-      command: env KUBECONFIG={{ local_kubeconfig | quote }} kubectl uncordon {{ node_name }}
+      shell: KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" kubectl uncordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -13,13 +13,21 @@
 - hosts: raspberrypi
   become: true
   serial: 1
-  vars:
-    k3s_kubeconfig: /etc/rancher/k3s/k3s.yaml
 
   tasks:
     - name: Get node name by removing .local from inventory_hostname
       set_fact:
         node_name: "{{ inventory_hostname | regex_replace('\\.local$', '') }}"
+
+    - name: Check if reboot is required
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required_marker
+
+    - name: Skip reboot when not required
+      debug:
+        msg: "Skipping {{ node_name }} because /var/run/reboot-required is absent."
+      when: not reboot_required_marker.stat.exists
 
     - name: Assert LUKS reboot passphrase is provided locally
       delegate_to: localhost
@@ -28,33 +36,41 @@
         that:
           - lookup('ansible.builtin.env', 'OTARU_LUKS_PASSWORD') | length > 0
         fail_msg: "Set OTARU_LUKS_PASSWORD in the controller environment before rebooting a LUKS node."
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Cordon the node
+      delegate_to: localhost
+      become: false
       command: kubectl cordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
+      delegate_to: localhost
+      become: false
       command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
       retries: 5
       delay: 30
       until: drain_result.rc == 0
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists
 
     - name: Reboot the system
       reboot:
         reboot_command: systemctl reboot --job-mode=replace-irreversibly
-      when: not (luks_enabled | default(false))
+      when:
+        - reboot_required_marker.stat.exists
+        - not (luks_enabled | default(false))
 
     - name: Reboot the LUKS system
       command: systemctl reboot --job-mode=replace-irreversibly
       async: 1
       poll: 0
       failed_when: false
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Wait for initramfs dropbear on LUKS node
       delegate_to: localhost
@@ -64,22 +80,24 @@
         port: "{{ luks_dropbear_port }}"
         delay: 5
         timeout: 600
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Unlock LUKS node through initramfs passfifo
       delegate_to: localhost
       become: false
-      shell: >-
-        {{ playbook_dir }}/../../hack/luks-cryptroot-unlock.sh
-        {{ ansible_host | default(inventory_hostname, true) }}
-        {{ luks_dropbear_port | string }}
-        --env-passfifo
+      command: make unlock {{ node_name }}
+      args:
+        chdir: "{{ playbook_dir }}/../../.."
       register: luks_unlock_result
       retries: 3
       delay: 10
       until: luks_unlock_result.rc == 0
       no_log: true
-      when: luks_enabled | default(false)
+      when:
+        - reboot_required_marker.stat.exists
+        - luks_enabled | default(false)
 
     - name: Wait for system to become reachable
       delegate_to: localhost
@@ -89,13 +107,16 @@
         port: 22
         delay: 10
         timeout: 600
+      when: reboot_required_marker.stat.exists
 
     - name: Wait for SSH connection to recover
       wait_for_connection:
         delay: 5
         timeout: 300
+      when: reboot_required_marker.stat.exists
 
     - name: Uncordon the node
+      delegate_to: localhost
+      become: false
       command: kubectl uncordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ k3s_kubeconfig }}"
+      when: reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -24,7 +24,7 @@
         path: /var/run/reboot-required
       register: reboot_required_marker
 
-    - name: Skip reboot when not required
+    - name: Node reboot not required
       debug:
         msg: "Skipping {{ node_name }} because /var/run/reboot-required is absent."
       when: not reboot_required_marker.stat.exists

--- a/ansible/playbooks/maintenance/000-packages.yaml
+++ b/ansible/playbooks/maintenance/000-packages.yaml
@@ -45,18 +45,14 @@
     - name: Cordon the node
       delegate_to: localhost
       become: false
-      command: kubectl cordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ local_kubeconfig }}"
+      command: kubectl --kubeconfig {{ local_kubeconfig }} cordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists
 
     - name: Drain the node, ignoring PDBs
       delegate_to: localhost
       become: false
-      command: kubectl drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
-      environment:
-        KUBECONFIG: "{{ local_kubeconfig }}"
+      command: kubectl --kubeconfig {{ local_kubeconfig }} drain {{ node_name }} --ignore-daemonsets --force --delete-emptydir-data --disable-eviction
       register: drain_result
       changed_when: false
       retries: 5
@@ -126,8 +122,6 @@
     - name: Uncordon the node
       delegate_to: localhost
       become: false
-      command: kubectl uncordon {{ node_name }}
-      environment:
-        KUBECONFIG: "{{ local_kubeconfig }}"
+      command: kubectl --kubeconfig {{ local_kubeconfig }} uncordon {{ node_name }}
       changed_when: false
       when: reboot_required_marker.stat.exists


### PR DESCRIPTION
## Summary
- skip node reboot flow when /var/run/reboot-required is absent
- run cordon, drain, and uncordon from the controller instead of target nodes
- unlock LUKS nodes via the documented make unlock target

## Validation
- ansible-playbook --syntax-check -i ansible/inventory.yaml ansible/playbooks/maintenance/000-packages.yaml
- make test