### PR TITLE
Configure Kiali for Envoy GatewayClass

### DIFF
--- a/helm-charts/kiali/values.yaml
+++ b/helm-charts/kiali/values.yaml
@@ -25,6 +25,9 @@ kiali-server:
       internal_url: http://monitoring-grafana.monitoring.svc.cluster.local
       external_url: https://grafana.internal.siutsin.com
     istio:
+      gateway_api_classes:
+        - name: Envoy Gateway
+          class_name: eg
       root_namespace: istio-system
     prometheus:
       url: http://monitoring-prometheus-server.monitoring.svc.cluster.local


### PR DESCRIPTION
## Summary
- declare the Envoy Gateway GatewayClass in Kiali config
- align Kiali validation with the repo's `eg` GatewayClass

## Testing
- make test