### PR TITLE
Add a shared ambient waypoint

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -207,6 +207,7 @@ local serviceMesh = [
   { wave: '03', name: 'istio-cni', namespace: 'kube-system' },
   { wave: '04', name: 'istiod', namespace: 'istio-system', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.serviceMesh.istiod },
   { wave: '05', name: 'ztunnel', namespace: 'istio-system' },
+  { wave: '06', name: 'waypoints', namespace: 'argocd' },
 ];
 
 [

--- a/helm-charts/envoy-gateway/templates/namespace.yaml
+++ b/helm-charts/envoy-gateway/templates/namespace.yaml
@@ -5,4 +5,6 @@ metadata:
     argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint
+    istio.io/ingress-use-waypoint: "true"
   name: {{ .Values.namespace }}

--- a/helm-charts/heartbeats/templates/namespace-heartbeats-operator-system.yaml
+++ b/helm-charts/heartbeats/templates/namespace-heartbeats-operator-system.yaml
@@ -8,4 +8,7 @@ metadata:
     app.kubernetes.io/name: heartbeats-operator
     control-plane: controller-manager
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint
+    istio.io/use-waypoint-namespace: gateway-api
+    istio.io/ingress-use-waypoint: "true"
   name: heartbeats-operator-system

--- a/helm-charts/istiod/values.yaml
+++ b/helm-charts/istiod/values.yaml
@@ -3,6 +3,8 @@ namespace: istio-system
 istiod:
   profile: ambient
   pilot:
+    env:
+      ENABLE_INGRESS_WAYPOINT_ROUTING: "true"
     resources:
       requests:
         cpu: 100m

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/namespace-k3s-apiserver-loadbalancer-system.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/namespace-k3s-apiserver-loadbalancer-system.yaml
@@ -7,4 +7,7 @@ metadata:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
     control-plane: controller-manager
     istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint
+    istio.io/use-waypoint-namespace: gateway-api
+    istio.io/ingress-use-waypoint: "true"
   name: k3s-apiserver-loadbalancer-system

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -1,5 +1,8 @@
 labels:
   istio.io/dataplane-mode: ambient
+  istio.io/use-waypoint: waypoint
+  istio.io/use-waypoint-namespace: gateway-api
+  istio.io/ingress-use-waypoint: "true"
 
 namespaces:
   # Intentional: managed workload namespaces are enrolled in ambient mesh so

--- a/helm-charts/waypoints/Chart.yaml
+++ b/helm-charts/waypoints/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: waypoints
+description: Deploy Istio ambient waypoints for managed namespaces
+type: application
+version: 0.1.0

--- a/helm-charts/waypoints/templates/configmap.yaml
+++ b/helm-charts/waypoints/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.waypoint.name }}-options
+  namespace: {{ .Values.waypoint.namespace }}
+data:
+  deployment: |
+    spec:
+      replicas: {{ .Values.waypoint.deployment.replicas }}
+  podDisruptionBudget: |
+    spec:
+      minAvailable: {{ .Values.waypoint.podDisruptionBudget.minAvailable }}

--- a/helm-charts/waypoints/templates/gateway.yaml
+++ b/helm-charts/waypoints/templates/gateway.yaml
@@ -6,6 +6,11 @@ metadata:
   labels:
     istio.io/waypoint-for: {{ $.Values.waypoint.for | quote }}
 spec:
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: {{ $.Values.waypoint.name }}-options
   gatewayClassName: istio-waypoint
   listeners:
     - name: mesh

--- a/helm-charts/waypoints/templates/gateway.yaml
+++ b/helm-charts/waypoints/templates/gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $.Values.waypoint.name }}
+  namespace: {{ $.Values.waypoint.namespace }}
+  labels:
+    istio.io/waypoint-for: {{ $.Values.waypoint.for | quote }}
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+      allowedRoutes:
+        namespaces:
+          from: {{ $.Values.waypoint.allowedRoutesFrom }}

--- a/helm-charts/waypoints/values.yaml
+++ b/helm-charts/waypoints/values.yaml
@@ -3,3 +3,7 @@ waypoint:
   for: service
   namespace: gateway-api
   allowedRoutesFrom: All
+  deployment:
+    replicas: 2
+  podDisruptionBudget:
+    minAvailable: 1

--- a/helm-charts/waypoints/values.yaml
+++ b/helm-charts/waypoints/values.yaml
@@ -1,0 +1,5 @@
+waypoint:
+  name: waypoint
+  for: service
+  namespace: gateway-api
+  allowedRoutesFrom: All


### PR DESCRIPTION
## Summary
- add a shared Istio ambient waypoint in `gateway-api`
- enrol ambient namespaces to use that shared waypoint for L7 processing
- enable ingress-to-waypoint routing in istiod

## Testing
- make test