### PR TITLE
chore: bump heartbeats and k3s-apiserver-loadbalancer releases

### DIFF
--- a/helm-charts/heartbeats/templates/deployment-heartbeats-operator-controller-manager.yaml
+++ b/helm-charts/heartbeats/templates/deployment-heartbeats-operator-controller-manager.yaml
@@ -29,7 +29,7 @@ spec:
             - --health-probe-bind-address=:8081
           command:
             - /manager
-          image: ghcr.io/siutsin/heartbeats:v0.154.0
+          image: ghcr.io/siutsin/heartbeats:v0.155.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/deployment-k3s-apiserver-loadbalancer-controller-manager.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/deployment-k3s-apiserver-loadbalancer-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
             - --health-probe-bind-address=:8081
           command:
             - /manager
-          image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.229.0
+          image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.238.0
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
- bump `heartbeats` to `v0.155.0`
- bump `k3s-apiserver-loadbalancer` to `v1.238.0`
- consume the upstream releases now that both images are published

## Verification
- `make test`