### PR TITLE
fix: keep envoy gateway out of ambient mesh

### DIFF
--- a/helm-charts/envoy-gateway/README.md
+++ b/helm-charts/envoy-gateway/README.md
@@ -1,0 +1,16 @@
+# envoy-gateway
+
+`gateway-api` must stay out of the Istio ambient dataplane.
+
+This chart explicitly sets `istio.io/dataplane-mode: none` on the
+`gateway-api` namespace and on the generated Envoy Gateway pods. The shared
+ambient waypoint is for application services behind the gateway, not for the
+gateway proxy itself.
+
+If Envoy Gateway is ambient-enrolled, ingress traffic can fail with `503
+upstream_reset_before_response_started{connection_termination}` even when the
+backend services are healthy. In-cluster traffic to the services will still
+work, but external requests through the ingress VIP can break.
+
+Keep `gateway-api` outside ambient unless the ingress design is changed and
+re-validated end to end.

--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -7,5 +7,9 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      envoyDeployment:
+        pod:
+          labels:
+            istio.io/dataplane-mode: none
       envoyService:
         name: {{ .Values.service.name }}

--- a/helm-charts/envoy-gateway/templates/namespace.yaml
+++ b/helm-charts/envoy-gateway/templates/namespace.yaml
@@ -4,7 +4,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
-    istio.io/dataplane-mode: ambient
-    istio.io/use-waypoint: waypoint
-    istio.io/ingress-use-waypoint: "true"
+    istio.io/dataplane-mode: none
   name: {{ .Values.namespace }}


### PR DESCRIPTION
## Summary
- keep the `gateway-api` namespace out of the ambient dataplane
- label generated Envoy Gateway pods with `istio.io/dataplane-mode=none`
- document why Envoy Gateway must not be waypoint-enrolled

## Testing
- make test
- verified live recovery of `/jung2bot/prod/ping`, `/jung2bot/dev/ping`, and `/httpbin/` through the ingress VIP after patching the cluster