### PR TITLE
fix: add home assistant startup probe

### DIFF
--- a/helm-charts/home-assistant/templates/deployment.yaml
+++ b/helm-charts/home-assistant/templates/deployment.yaml
@@ -46,6 +46,12 @@ spec:
             httpGet:
               path: /
               port: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 60
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /config
               name: config


### PR DESCRIPTION
## Summary
- add a startup probe to the Home Assistant deployment
- prevent slow Home Assistant startup from being treated as a liveness failure
- keep the existing liveness and readiness behavior once startup completes

## Testing
- make test
- verified live that Home Assistant recovered and reached `Healthy` after applying the startup probe