### PR TITLE
fix: align kyverno policy defaults

### DIFF
--- a/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
@@ -9,6 +9,7 @@ spec:
   emitWarning: false
   rules:
     - name: require-container-resource-requests-and-limits
+      skipBackgroundRequests: true
       match:
         any:
           - resources:
@@ -24,6 +25,7 @@ spec:
 {{- end }}
 {{- end }}
       validate:
+        allowExistingViolations: true
         failureAction: Audit
         message: Containers must set resource requests for cpu, memory, and ephemeral-storage, plus limits for memory and ephemeral-storage.
         pattern:


### PR DESCRIPTION
## Summary
- render Kyverno defaulted rule fields explicitly in `require-workload-resources`
- align the chart with the live `ClusterPolicy` shape Kyverno persists
- remove Argo CD drift for `kyverno-policy` without changing policy behavior

## Testing
- make test
- verified the live out-of-sync resource is `ClusterPolicy/require-workload-resources`
- verified the rendered manifest now includes the same defaulted fields present live