### PR TITLE
tune: reduce argocd repo-server scale churn

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -114,14 +114,19 @@ argo-cd:
     autoscaling:
       enabled: true
       minReplicas: 1
-      maxReplicas: 2
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 60
     resources:
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 768Mi
         ephemeral-storage: 512Mi
       limits:
-        memory: 1Gi
+        memory: 768Mi
         ephemeral-storage: 512Mi
     readinessProbe:
       initialDelaySeconds: 10


### PR DESCRIPTION
## Summary
- raise the argocd repo-server HPA thresholds and allow one more burst replica
- shorten HPA scale-down stabilization to return to one pod faster after transient spikes
- reduce repo-server memory request and limit to match observed usage

## Rationale
- the last 24h metrics showed repeated short CPU bursts above the current HPA trigger
- memory stayed well below the previous 1Gi request, so memory was not the scaling pressure

## Testing
- make test