### PR TITLE
fix: allow Envoy Gateway namespace migration

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -18,6 +18,9 @@ clusterSecretStorePolicy:
     gateway:
       - cloudflare-acme-verification-secret
       - heartbeats
+    gateway-api:
+      - cloudflare-acme-verification-secret
+      - heartbeats
     home-assistant:
       - heartbeats
     jung2bot:


### PR DESCRIPTION
## Summary
- temporarily allow both `gateway` and `gateway-api` in the Kyverno ClusterSecretStore allow-list
- unblock the merged Envoy Gateway namespace migration while old ingress-owned `ExternalSecret` resources are still being reconciled from `gateway-api`

## Notes
- this is a migration compatibility fix
- the new runtime namespace remains `gateway`
- `gateway-api` is retained here only so Argo can finish the transition cleanly

## Testing
- make test
