### PR TITLE
fix: remove legacy gateway-api secret allowance

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -18,9 +18,6 @@ clusterSecretStorePolicy:
     gateway:
       - cloudflare-acme-verification-secret
       - heartbeats
-    gateway-api:
-      - cloudflare-acme-verification-secret
-      - heartbeats
     home-assistant:
       - heartbeats
     jung2bot:


### PR DESCRIPTION
## Summary
- remove the temporary `gateway-api` ClusterSecretStore allow-list exception after the ingress runtime cleanup was completed manually

## Testing
- `make test`