### PR TITLE
fix: disable chart-managed argocd secret

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -47,6 +47,8 @@ argo-cd:
   configs:
     cm:
       url: https://argocd.internal.siutsin.com/argocd/
+    secret:
+      createSecret: false
     params:
       # Keep repo-server concurrency bounded; Helm renders can spike memory during cold-cache bursts.
       reposerver.parallelism.limit: 2


### PR DESCRIPTION
## Summary
- disable `argo-cd.configs.secret.createSecret` in the Argo CD chart
- keep `argocd-config`'s `ExternalSecret` as the only owner of `argocd-secret`
- fix the live `argocd` app drift caused by dual ownership of the same Secret

## Why
The `argocd` application was rendering its own `argocd-secret`, while the live cluster already had `argocd-secret` managed by `argocd-config` through `ExternalSecret`.

That left the `argocd` app `OutOfSync` on `Secret/argocd-secret` even though the cluster was otherwise healthy.

## Expected Effect
After this merges and syncs, the `argocd` app should stop diffing on `argocd-secret` and return to normal reconciliation.

## Testing
- `make test`
