### PR TITLE
feat: expose blocky DoH endpoint

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -71,6 +71,10 @@ These are also the main cases that can still be plaintext in transit. The
 remaining non-ambient infrastructure paths are outside ambient mTLS, but
 inter-node traffic there is still covered by Flannel `wireguard-native`.
 
+For DNS clients that need an encrypted client-to-cluster path, Blocky also
+serves a DoH endpoint over the internal HTTPS ingress path. Plain DNS on
+`53/TCP` and `53/UDP` still remains available for clients that do not use DoH.
+
 ### Mitigations
 
 - inter-node DNS traffic is still encrypted on the wire by Flannel `wireguard-native`

--- a/helm-charts/blocky/templates/route-doh.yaml
+++ b/helm-charts/blocky/templates/route-doh.yaml
@@ -1,0 +1,28 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}-internal-doh
+  namespace: {{ .Values.namespace }}
+spec:
+  hostnames:
+    - {{ printf "%s.internal.siutsin.com" .Values.name }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayName }}
+      namespace: {{ $gatewayNamespace }}
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /dns-query
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.name }}
+          port: {{ .Values.deployment.ports.http }}
+          weight: 1

--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -29,6 +29,7 @@ spec:
                 operator: In
                 values:
                   - argocd
+                  - blocky
                   - changedetection
                   - cyberchef
                   - excalidraw
@@ -56,7 +57,6 @@ spec:
                 operator: In
                 values:
                   - argocd
-                  - blocky
                   - changedetection
                   - cyberchef
                   - excalidraw

--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -56,6 +56,7 @@ spec:
                 operator: In
                 values:
                   - argocd
+                  - blocky
                   - changedetection
                   - cyberchef
                   - excalidraw


### PR DESCRIPTION
## Summary
- allow the `blocky` namespace to attach routes to the gateway `https` listener
- add an HTTPS-only Blocky DoH route at `blocky.internal.siutsin.com/dns-query`

## Why
Blocky already uses encrypted DoH upstreams, but clients on the LAN still reach it over plain DNS on `53`. This adds an encrypted client-to-cluster option without changing the existing DNS TCP/UDP listeners.

## Expected Effect
After this merges and syncs, clients that support DoH can use:
- `https://blocky.internal.siutsin.com/dns-query`

The existing DNS listeners on `53/TCP` and `53/UDP` remain in place.

## Testing
- `make test`
