### PR TITLE
fix: allow kyverno webhook under strict mtls

### DIFF
--- a/helm-charts/istio-base/values.yaml
+++ b/helm-charts/istio-base/values.yaml
@@ -29,6 +29,14 @@ peerAuthentication:
         matchLabels:
           app.kubernetes.io/instance: external-secrets
           app.kubernetes.io/name: external-secrets-webhook
+    - name: kyverno-admission-controller
+      namespace: kyverno
+      mtlsMode: PERMISSIVE
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: admission-controller
+          app.kubernetes.io/instance: kyverno
+          app.kubernetes.io/part-of: kyverno
     - name: amazon-eks-pod-identity-webhook
       namespace: default
       mtlsMode: PERMISSIVE


### PR DESCRIPTION
## Summary

- add a narrow PERMISSIVE PeerAuthentication exception for Kyverno admission controller
- keep mesh-wide STRICT as the default while allowing kube-apiserver admission calls to reach kyverno-svc

## Why

After the Argo CD patch merged, Argo could not finish syncing because hook resources were denied by Kyverno admission failing with EOF. The Kyverno admission service is called by kube-apiserver, which is outside the ambient mesh path, so it needs the same explicit carveout pattern as the other admission webhooks.

## Testing

- make test