### PR TITLE
fix: restrict barman objectstore usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,6 @@ cython_debug/
 
 # Local Air workspace metadata
 .air/
+
+# Local coordination notes
+FIX.md

--- a/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
@@ -24,6 +24,9 @@ spec:
           - resources:
               kinds:
                 - ObjectStore
+              operations:
+                - CREATE
+                - UPDATE
       validate:
         allowExistingViolations: true
         failureAction: Enforce
@@ -47,6 +50,9 @@ spec:
                 - ObjectStore
               namespaces:
                 - {{ $namespace }}
+              operations:
+                - CREATE
+                - UPDATE
       validate:
         allowExistingViolations: true
         failureAction: Enforce

--- a/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
@@ -22,6 +22,8 @@ spec:
       match:
         any:
           - resources:
+              apiGroups:
+                - barmancloud.cnpg.io
               kinds:
                 - ObjectStore
               operations:
@@ -46,6 +48,8 @@ spec:
       match:
         any:
           - resources:
+              apiGroups:
+                - barmancloud.cnpg.io
               kinds:
                 - ObjectStore
               namespaces:

--- a/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.barmanObjectStorePolicy.enabled }}
+{{- $allowedNamespaces := keys .Values.barmanObjectStorePolicy.allowedNamespaces | sortAlpha }}
+{{- range $namespace, $config := .Values.barmanObjectStorePolicy.allowedNamespaces }}
+  {{- if not $config.objectStores }}
+    {{- fail (printf "barmanObjectStorePolicy.allowedNamespaces.%s.objectStores must include at least one allowed ObjectStore" $namespace) }}
+  {{- end }}
+  {{- if not $config.credentialSecrets }}
+    {{- fail (printf "barmanObjectStorePolicy.allowedNamespaces.%s.credentialSecrets must include at least one allowed Secret" $namespace) }}
+  {{- end }}
+{{- end }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-barman-objectstores
+spec:
+  admission: true
+  background: false
+  emitWarning: false
+  rules:
+    - name: block-objectstores-outside-approved-namespaces
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - ObjectStore
+      validate:
+        allowExistingViolations: true
+        failureAction: Enforce
+        message: Barman ObjectStores may only be created in approved namespaces.
+        deny:
+          conditions:
+            all:
+              - key: "{{ `{{ request.namespace }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $allowedNamespaces }}
+                  - {{ . }}
+{{- end }}
+{{- range $namespace, $config := .Values.barmanObjectStorePolicy.allowedNamespaces }}
+    - name: restrict-objectstores-in-{{ $namespace }}
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - ObjectStore
+              namespaces:
+                - {{ $namespace }}
+      validate:
+        allowExistingViolations: true
+        failureAction: Enforce
+        message: Barman ObjectStores may only use approved names and credential Secrets in this namespace.
+        deny:
+          conditions:
+            any:
+              - key: "{{ `{{ request.object.metadata.name }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $config.objectStores }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.s3Credentials.accessKeyId.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.s3Credentials.secretAccessKey.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.s3Credentials.region.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.s3Credentials.sessionToken.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.endpointCA.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+{{- end }}
+  validationFailureAction: Audit
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
@@ -103,6 +103,47 @@ spec:
 {{- range $config.credentialSecrets }}
                   - {{ . }}
 {{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.azureCredentials.connectionString.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.azureCredentials.storageAccount.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.azureCredentials.storageKey.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.azureCredentials.storageSasToken.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.configuration.googleCredentials.applicationCredentials.name || '' }}` }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
+              - key: "{{ `{{ request.object.spec.instanceSidecarConfiguration.env[].valueFrom.secretKeyRef.name || [] }}` }}"
+                operator: AnyNotIn
+                value:
+{{- range $config.credentialSecrets }}
+                  - {{ . }}
+{{- end }}
 {{- end }}
   validationFailureAction: Audit
 {{- end }}

--- a/helm-charts/kyverno-policy/templates/barman-objectstore-reports-rbac.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-reports-rbac.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.barmanObjectStorePolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-reports-barman-objectstores
+rules:
+  - apiGroups:
+      - barmancloud.cnpg.io
+    resources:
+      - objectstores
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-reports-barman-objectstores
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-reports-barman-objectstores
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-reports-controller
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/cluster-secret-store-policy.yaml
@@ -36,7 +36,7 @@ spec:
                 operator: Equals
                 value: {{ $storeName }}
               - key: "{{ `{{ request.namespace }}` }}"
-                operator: NotIn
+                operator: AnyNotIn
                 value:
 {{- range $allowedNamespaces }}
                   - {{ . }}
@@ -66,7 +66,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ request.namespace }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $allowedNamespaces }}
                       - {{ . }}
@@ -96,7 +96,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ request.namespace }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $allowedNamespaces }}
                       - {{ . }}
@@ -147,7 +147,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $keys }}
                       - {{ . }}
@@ -188,7 +188,7 @@ spec:
                     operator: NotEquals
                     value: ""
                   - key: "{{ `{{ element.extract.key || '' }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $keys }}
                       - {{ . }}
@@ -221,7 +221,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.remoteRef.key || '' }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $keys }}
                       - {{ . }}
@@ -253,7 +253,7 @@ spec:
               conditions:
                 all:
                   - key: "{{ `{{ element.extract.key || '' }}` }}"
-                    operator: NotIn
+                    operator: AnyNotIn
                     value:
 {{- range $keys }}
                       - {{ . }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -38,3 +38,12 @@ workloadResourcesPolicy:
     - kube-public
     - kube-system
     - kyverno
+
+barmanObjectStorePolicy:
+  enabled: true
+  allowedNamespaces:
+    teslamate:
+      objectStores:
+        - b2-backup
+      credentialSecrets:
+        - b2-backup-credentials


### PR DESCRIPTION
## Summary

- add a Kyverno policy that only allows Barman ObjectStores in approved namespaces
- restrict the current `teslamate` ObjectStore to the expected `b2-backup` name and `b2-backup-credentials` Secret
- grant Kyverno reports-controller read access to the Barman ObjectStore kind
- update existing Kyverno policies from deprecated `NotIn` to `AnyNotIn`
- keep local `FIX.md` ignored

## Why

The CNPG Barman plugin uses upstream cluster-scoped RBAC so it can reconcile plugin-managed namespace Roles from ObjectStores. Instead of cutting that RBAC and risking the controller, this adds an admission boundary around the ObjectStore resources that exercise those permissions.

## Testing

- `make test`