### PR TITLE
fix: use Kyverno GVK match for Barman ObjectStore

### DIFF
--- a/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/barman-objectstore-policy.yaml
@@ -22,10 +22,8 @@ spec:
       match:
         any:
           - resources:
-              apiGroups:
-                - barmancloud.cnpg.io
               kinds:
-                - ObjectStore
+                - barmancloud.cnpg.io/v1/ObjectStore
               operations:
                 - CREATE
                 - UPDATE
@@ -48,10 +46,8 @@ spec:
       match:
         any:
           - resources:
-              apiGroups:
-                - barmancloud.cnpg.io
               kinds:
-                - ObjectStore
+                - barmancloud.cnpg.io/v1/ObjectStore
               namespaces:
                 - {{ $namespace }}
               operations:


### PR DESCRIPTION
## Summary
- replace unsupported Kyverno match.resources.apiGroups with fully-qualified GVK kind entries
- keep Barman ObjectStore policy scoped to barmancloud.cnpg.io/v1 ObjectStore resources

## Validation
- make test
- helm template kyverno-policy helm-charts/kyverno-policy | kubectl apply --dry-run=server -f -