### PR TITLE
fix: restore CNPG backup and resource policy health

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -55,16 +55,6 @@ local _ignoreDifferences = {
   bootstrap: {
     metallb: crdConversionCABundle('bgppeers.metallb.io'),
   },
-  database: {
-    'cloudnative-pg-clusters': [{
-      group: 'postgresql.cnpg.io',
-      kind: 'Cluster',
-      name: 'teslamate-20260412-0619',
-      jqPathExpressions: [
-        '.spec.resources',
-      ],
-    }],
-  },
   scheduling: {
     'k8s-cleaner': resourceFieldRefDivisor('k8s-cleaner') + cleanerExcludeDeleted,
     reloader: resourceFieldRefDivisor('reloader-reloader'),
@@ -100,6 +90,22 @@ local _grafanaDashboards = [
 ];
 
 local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };
+local cnpgHelm = {
+  releaseName: 'cloudnative-pg',
+  valuesObject: {
+    resources: {
+      requests: {
+        cpu: '100m',
+        memory: '128Mi',
+        'ephemeral-storage': '128Mi',
+      },
+      limits: {
+        memory: '128Mi',
+        'ephemeral-storage': '128Mi',
+      },
+    },
+  },
+};
 local cnpgClustersHelm = { parameters: [
   { name: 'backup.b2.bucket', value: std.extVar('CNPG_BACKUP_BUCKET') },
   { name: 'backup.b2.endpoint', value: std.extVar('CNPG_BACKUP_ENDPOINT') },
@@ -157,7 +163,7 @@ local database = [
       repoURL: 'https://cloudnative-pg.io/charts/',
       chart: s.name,
       targetRevision: '0.23.2',
-      helm: { releaseName: s.name },
+      helm: cnpgHelm,
     },
   },
   { wave: '04', name: 'cloudnative-pg-plugin-barman-cloud', namespace: 'cnpg-system' },
@@ -166,8 +172,6 @@ local database = [
     name: 'cloudnative-pg-clusters',
     namespace: 'cnpg-system',
     helm: cnpgClustersHelm,
-    syncOptions: ['RespectIgnoreDifferences=true'],
-    ignoreDifferences: _ignoreDifferences.database['cloudnative-pg-clusters'],
   },
 ];
 

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -35,7 +35,14 @@ defaults:
       synchronizeReplicas:
         enabled: true
       updateInterval: 30
-    resources: {}
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+        ephemeral-storage: 512Mi
+      limits:
+        memory: 512Mi
+        ephemeral-storage: 512Mi
     smartShutdownTimeout: 180
     startDelay: 3600
     stopDelay: 1800

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
@@ -43,7 +43,14 @@ spec:
             periodSeconds: 10
             tcpSocket:
               port: 9090
-          resources: {}
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+              ephemeral-storage: 128Mi
+            limits:
+              memory: 128Mi
+              ephemeral-storage: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/helm-charts/istio-base/values.yaml
+++ b/helm-charts/istio-base/values.yaml
@@ -44,3 +44,10 @@ peerAuthentication:
         matchLabels:
           app.kubernetes.io/instance: amazon-eks-pod-identity-webhook
           app.kubernetes.io/name: pod-identity-webhook
+    - name: cloudnative-pg-webhook
+      namespace: cnpg-system
+      mtlsMode: PERMISSIVE
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: cloudnative-pg
+          app.kubernetes.io/name: cloudnative-pg

--- a/helm-charts/teslamate/templates/backup.yaml
+++ b/helm-charts/teslamate/templates/backup.yaml
@@ -65,4 +65,5 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.backup.database.secretName }}
                       key: dbname
+              resources: {{ toYaml .Values.backup.resources | nindent 16 }}
           restartPolicy: OnFailure

--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -105,6 +105,7 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.backup.database.secretName }}
                       key: dbname
+              resources: {{ toYaml .Values.backup.resources | nindent 16 }}
 
             - name: postgres-sidecar
               image: postgres:{{ .Values.backup.database.postgresVersion }}-alpine
@@ -124,5 +125,6 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.backup.database.secretName }}
                       key: dbname
+              resources: {{ toYaml .Values.backup.resources | nindent 16 }}
 
           restartPolicy: OnFailure

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -158,6 +158,14 @@ spec:
                     namespace: ${VERIFY_NAMESPACE}
                   spec:
                     instances: 1
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 512Mi
+                        ephemeral-storage: 512Mi
+                      limits:
+                        memory: 512Mi
+                        ephemeral-storage: 512Mi
                     storage:
                       size: {{ .Values.backup.verifyPitr.restore.storage.size }}
                       storageClass: {{ .Values.backup.verifyPitr.restore.storage.storageClass }}

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -51,11 +51,23 @@ service:
   port: 4000
 
 grafana:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+      ephemeral-storage: 128Mi
+    limits:
+      memory: 128Mi
+      ephemeral-storage: 128Mi
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
           podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: teslamate
+                app.kubernetes.io/name: grafana
             topologyKey: kubernetes.io/hostname
   annotations:
     reloader.stakater.com/auto: "true"
@@ -101,6 +113,14 @@ grafana:
     existingSecret: teslamate-grafana
 
 backup:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 128Mi
+      ephemeral-storage: 256Mi
   schedule: "0 10 * * *"
   verify:
     schedule: "0 12 * * *"


### PR DESCRIPTION
## Summary
- add a narrow CNPG webhook PERMISSIVE exception so kube-apiserver webhook calls are not blocked by mesh-wide STRICT
- add missing resource requests/limits for CNPG, Barman plugin, Teslamate Grafana, backup, and verification workloads
- stop Argo from ignoring CNPG Cluster resources so the chart-owned resource spec reconciles

## Validation
- make test
- git diff --check