### PR TITLE
fix: set CNPG Barman sidecar resources

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/objectstore-b2-backup.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/objectstore-b2-backup.yaml
@@ -18,6 +18,8 @@ spec:
         name: b2-backup-credentials
         key: "AWS_SECRET_ACCESS_KEY"
       inheritFromIAMRole: false
+  instanceSidecarConfiguration:
+    resources: {{ toYaml $.Values.defaults.objectStore.instanceSidecarResources | nindent 6 }}
   retentionPolicy: {{ $.Values.defaults.objectStore.retentionPolicy | quote }}
 {{- end }}
 {{- end }}

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -26,7 +26,7 @@ defaults:
       enablePodMonitor: false
     postgresGID: 26
     postgresUID: 26
-    primaryUpdateMethod: restart
+    primaryUpdateMethod: switchover
     primaryUpdateStrategy: unsupervised
     replicationSlots:
       highAvailability:
@@ -95,6 +95,14 @@ defaults:
     schedule: "0 0 */3 * * *"
   objectStore:
     retentionPolicy: 1d
+    instanceSidecarResources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+        ephemeral-storage: 256Mi
+      limits:
+        memory: 128Mi
+        ephemeral-storage: 256Mi
 
 clusters:
   # https://cloudnative-pg.io/documentation/current/recovery/#restoring-into-a-cluster-with-a-backup-section


### PR DESCRIPTION
## Summary
- set resources for the Barman ObjectStore instance sidecar injected into CNPG Postgres pods
- switch CNPG primary rolling updates to switchover to avoid restarting the active primary in place

## Validation
- make test
- git diff --check
- helm template cloudnative-pg-clusters ... | kubectl apply --dry-run=server -f -