### PR TITLE
fix: restore heartbeat mesh labels and verify resources

### DIFF
--- a/helm-charts/heartbeats/templates/namespace-heartbeats-operator-system.yaml
+++ b/helm-charts/heartbeats/templates/namespace-heartbeats-operator-system.yaml
@@ -6,4 +6,8 @@ metadata:
     app.kubernetes.io/name: heartbeats-operator
     app.kubernetes.io/version: v0.156.0
     control-plane: controller-manager
+    istio.io/dataplane-mode: ambient
+    istio.io/use-waypoint: waypoint
+    istio.io/use-waypoint-namespace: istio-waypoints
+    istio.io/ingress-use-waypoint: "true"
   name: heartbeats-operator-system

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -116,11 +116,11 @@ backup:
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
-      ephemeral-storage: 256Mi
+      memory: 256Mi
+      ephemeral-storage: 2Gi
     limits:
-      memory: 128Mi
-      ephemeral-storage: 256Mi
+      memory: 256Mi
+      ephemeral-storage: 2Gi
   schedule: "0 10 * * *"
   verify:
     schedule: "0 12 * * *"


### PR DESCRIPTION
## Summary
- restore ambient mesh and shared waypoint labels on the heartbeats operator namespace
- raise Teslamate pg_dump verify job memory and ephemeral-storage limits so restore verification can complete

## Verification
- make test
- manual Teslamate pg_dump verification job completed and WebGazer heartbeat returned UP