### PR TITLE
Add mesh authorization policy guardrail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,4 +300,4 @@ cython_debug/
 .air/
 
 # Local coordination notes
-FIX.md
+planning/

--- a/helm-charts/httpbin/templates/authorization-policy.yaml
+++ b/helm-charts/httpbin/templates/authorization-policy.yaml
@@ -1,3 +1,6 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -13,7 +16,7 @@ spec:
     - from:
         - source:
             principals:
-              - cluster.local/ns/gateway/sa/gateway
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
       to:
         - operation:
             ports:

--- a/helm-charts/httpbin/templates/authorization-policy.yaml
+++ b/helm-charts/httpbin/templates/authorization-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/gateway/sa/gateway
+      to:
+        - operation:
+            ports:
+              - "80"

--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/gateway/sa/gateway
+      to:
+        - operation:
+            ports:
+              - "3000"

--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -1,3 +1,6 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -13,7 +16,7 @@ spec:
     - from:
         - source:
             principals:
-              - cluster.local/ns/gateway/sa/gateway
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
       to:
         - operation:
             ports:

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -29,8 +29,8 @@ spec:
           apiCall:
             urlPath: "/apis/security.istio.io/v1/namespaces/{{ `{{ request.namespace }}` }}/authorizationpolicies"
             jmesPath: >-
-              items[?spec.targetRefs[?group == '' && kind == 'Service' &&
-              name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
+              items[?spec.targetRefs[?(group == '' || group == 'core') &&
+              kind == 'Service' && name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
             default: 0
       validate:
         allowExistingViolations: true

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.meshAuthorizationPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-mesh-authorization-policy
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-authorization-policy-for-ambient-services
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+{{- toYaml .Values.meshAuthorizationPolicy.namespaceSelector | nindent 16 }}
+      preconditions:
+        all:
+          - key: {{ printf "{{ (request.object.spec.selector || `{}`) | length(@) }}" | quote }}
+            operator: GreaterThan
+            value: 0
+      context:
+        - name: authorizationPolicyCount
+          apiCall:
+            urlPath: "/apis/security.istio.io/v1/namespaces/{{ `{{ request.namespace }}` }}/authorizationpolicies"
+            jmesPath: >-
+              items[?spec.targetRefs[?group == '' && kind == 'Service' &&
+              name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
+            default: 0
+      validate:
+        allowExistingViolations: true
+        failureAction: {{ .Values.meshAuthorizationPolicy.failureAction }}
+        message: >-
+          Selector-backed Services in ambient mesh namespaces must have an
+          AuthorizationPolicy in the same namespace with targetRefs pointing at
+          that Service.
+        deny:
+          conditions:
+            all:
+              - key: "{{ `{{ authorizationPolicyCount }}` }}"
+                operator: Equals
+                value: 0
+  validationFailureAction: {{ .Values.meshAuthorizationPolicy.failureAction }}
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -39,6 +39,13 @@ workloadResourcesPolicy:
     - kube-system
     - kyverno
 
+meshAuthorizationPolicy:
+  enabled: true
+  failureAction: Audit
+  namespaceSelector:
+    matchLabels:
+      istio.io/dataplane-mode: ambient
+
 barmanObjectStorePolicy:
   enabled: true
   allowedNamespaces:


### PR DESCRIPTION
## Summary
- add a Kyverno audit policy requiring selector-backed Services in ambient namespaces to have a matching Istio AuthorizationPolicy targetRef
- add initial app-owned AuthorizationPolicies for public httpbin and jung2bot routes
- ignore the local planning directory instead of only FIX.md

## Test plan
- make test
- helm template kyverno-policy helm-charts/kyverno-policy --namespace kyverno --show-only templates/mesh-authorization-policy.yaml | kubectl apply --dry-run=server -f -
- helm template httpbin helm-charts/httpbin --namespace httpbin | kubectl apply --dry-run=server -f -
- helm template jung2bot helm-charts/jung2bot --namespace jung2bot | kubectl apply --dry-run=server -f -
- helm template jung2bot-dev helm-charts/jung2bot --namespace jung2bot-dev -f helm-charts/jung2bot/value/dev.yaml | kubectl apply --dry-run=server -f -