### PR TITLE
Match Kyverno policy defaulted fields

### DIFF
--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -27,11 +27,13 @@ spec:
       context:
         - name: authorizationPolicyCount
           apiCall:
+            method: GET
             urlPath: "/apis/security.istio.io/v1/namespaces/{{ `{{ request.namespace }}` }}/authorizationpolicies"
             jmesPath: >-
               items[?spec.targetRefs[?(group == '' || group == 'core') &&
               kind == 'Service' && name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
             default: 0
+      skipBackgroundRequests: true
       validate:
         allowExistingViolations: true
         failureAction: {{ .Values.meshAuthorizationPolicy.failureAction }}


### PR DESCRIPTION
## Summary
- explicitly set Kyverno apiCall method to GET
- explicitly set skipBackgroundRequests to match Kyverno's live defaulting

## Validation
- make test
- helm template kyverno-policy helm-charts/kyverno-policy --namespace kyverno --show-only templates/mesh-authorization-policy.yaml | kubectl apply --dry-run=server -f -