### PR TITLE
Allow heartbeat operator through service authorization policies

### DIFF
--- a/helm-charts/home-assistant/templates/authorization-policy.yaml
+++ b/helm-charts/home-assistant/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -17,6 +18,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -2,6 +2,7 @@
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $gatewayPrincipal := printf "cluster.local/ns/%s/sa/%s" $gatewayNamespace $gatewayName -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -42,6 +43,7 @@ spec:
               - {{ $gatewayPrincipal }}
               - cluster.local/ns/monitoring/sa/monitoring-grafana
               - cluster.local/ns/kiali/sa/kiali
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:
@@ -65,6 +67,7 @@ spec:
               - {{ $gatewayPrincipal }}
               - cluster.local/ns/monitoring/sa/monitoring-grafana
               - cluster.local/ns/monitoring/sa/monitoring-fluent-bit
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
## Summary
- allow the heartbeat operator principal through Home Assistant, Prometheus, and Loki service AuthorizationPolicies
- preserves the existing gateway/Grafana/Kiali/Fluent Bit intents while restoring heartbeat checks after service AP enforcement

## Validation
- helm template monitoring helm-charts/monitoring
- helm template home-assistant helm-charts/home-assistant
- make test
- live heartbeat checks restored to 200 via emergency additive APs