### PR TITLE
Add next batch of authorisation policies

### DIFF
--- a/helm-charts/argocd-config/templates/authorization-policy.yaml
+++ b/helm-charts/argocd-config/templates/authorization-policy.yaml
@@ -21,3 +21,50 @@ spec:
         - operation:
             ports:
               - "80"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: argocd-repo-server
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: argocd-repo-server
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-application-controller
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-applicationset-controller
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-server
+      to:
+        - operation:
+            ports:
+              - "8081"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: argocd-redis
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: argocd-redis
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-application-controller
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-applicationset-controller
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-repo-server
+              - cluster.local/ns/{{ .Values.namespace }}/sa/argocd-server
+      to:
+        - operation:
+            ports:
+              - "6379"

--- a/helm-charts/blocky/templates/authorization-policy.yaml
+++ b/helm-charts/blocky/templates/authorization-policy.yaml
@@ -45,6 +45,27 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  name: {{ .Values.name }}-dns
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}-dns
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+      to:
+        - operation:
+            ports:
+              - "53"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
   name: {{ .Values.name }}-workload
   namespace: {{ .Values.namespace }}
 spec:

--- a/helm-charts/cert-manager/templates/authorization-policy.yaml
+++ b/helm-charts/cert-manager/templates/authorization-policy.yaml
@@ -1,0 +1,146 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusPrincipal := printf "cluster.local/ns/%s/sa/%s" $prometheusNamespace $prometheusServiceAccount -}}
+{{- $waypoint := .Values.waypoint | default dict -}}
+{{- $waypointServiceAccount := $waypoint.serviceAccount | default "waypoint" -}}
+{{- $waypointNamespace := $waypoint.namespace | default "istio-waypoints" -}}
+{{- $waypointPrincipal := printf "cluster.local/ns/%s/sa/%s" $waypointNamespace $waypointServiceAccount -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: cert-manager
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: cert-manager-cainjector
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: cert-manager-webhook
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+    - to:
+        - operation:
+            ports:
+              - "443"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager-workload
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+    - to:
+        - operation:
+            ports:
+              - "9403"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager-cainjector-workload
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cert-manager-webhook-workload
+  namespace: cert-manager
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9402"
+    - to:
+        - operation:
+            ports:
+              - "10250"
+              - "6080"

--- a/helm-charts/kyverno/templates/authorization-policy.yaml
+++ b/helm-charts/kyverno/templates/authorization-policy.yaml
@@ -1,0 +1,30 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusPrincipal := printf "cluster.local/ns/%s/sa/%s" $prometheusNamespace $prometheusServiceAccount -}}
+{{- $metricsServices := list "kyverno-background-controller-metrics" "kyverno-cleanup-controller-metrics" "kyverno-reports-controller-metrics" "kyverno-svc-metrics" -}}
+{{- range $index, $service := $metricsServices }}
+{{- if $index }}
+---
+{{- end }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $service }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ $service }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "8000"
+{{- end }}

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -3,6 +3,11 @@
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $gatewayPrincipal := printf "cluster.local/ns/%s/sa/%s" $gatewayNamespace $gatewayName -}}
 {{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
+{{- $prometheusPrincipal := printf "cluster.local/ns/%s/sa/monitoring-prometheus-server" .Values.namespace -}}
+{{- $grafanaPrincipal := printf "cluster.local/ns/%s/sa/monitoring-grafana" .Values.namespace -}}
+{{- $fluentBitPrincipal := printf "cluster.local/ns/%s/sa/monitoring-fluent-bit" .Values.namespace -}}
+{{- $lokiPrincipal := printf "cluster.local/ns/%s/sa/monitoring-loki" .Values.namespace -}}
+{{- $lokiCanaryPrincipal := printf "cluster.local/ns/%s/sa/loki-canary" .Values.namespace -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -41,7 +46,7 @@ spec:
         - source:
             principals:
               - {{ $gatewayPrincipal }}
-              - cluster.local/ns/monitoring/sa/monitoring-grafana
+              - {{ $grafanaPrincipal }}
               - cluster.local/ns/kiali/sa/kiali
               - {{ $heartbeatPrincipal }}
       to:
@@ -65,10 +70,211 @@ spec:
         - source:
             principals:
               - {{ $gatewayPrincipal }}
-              - cluster.local/ns/monitoring/sa/monitoring-grafana
-              - cluster.local/ns/monitoring/sa/monitoring-fluent-bit
+              - {{ $grafanaPrincipal }}
+              - {{ $fluentBitPrincipal }}
               - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:
               - "3100"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: loki-canary
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: loki-canary
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "3500"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-fluent-bit
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-fluent-bit
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "2020"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-kube-state-metrics
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-kube-state-metrics
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "8080"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-prometheus-node-exporter
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-prometheus-node-exporter
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9100"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-prometheus-pushgateway
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-prometheus-pushgateway
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9091"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: loki-headless
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: loki-headless
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $lokiPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "3100"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-loki-memberlist
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-loki-memberlist
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $lokiPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "7946"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-loki-results-cache
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-loki-results-cache
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $lokiPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "11211"
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9150"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-loki-gateway
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-loki-gateway
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $grafanaPrincipal }}
+              - {{ $fluentBitPrincipal }}
+              - {{ $prometheusPrincipal }}
+              - {{ $lokiCanaryPrincipal }}
+              - {{ $heartbeatPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "80"

--- a/helm-charts/onepassword-connect/templates/authorization-policy.yaml
+++ b/helm-charts/onepassword-connect/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $namespace := .Release.Namespace | default "onepassword" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: onepassword-connect
+  namespace: {{ $namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: onepassword-connect
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/external-secrets/sa/external-secrets
+              - cluster.local/ns/external-secrets/sa/external-secrets-cert-controller
+      to:
+        - operation:
+            ports:
+              - "8080"
+              - "8081"


### PR DESCRIPTION
## Summary
- add Blocky TCP DNS Service AuthorizationPolicy
- add cert-manager Service and workload AuthorizationPolicies for metrics, while keeping webhook admission and health ports reachable
- add Argo CD internal Service AuthorizationPolicies for repo-server and Redis
- add Kyverno metrics Service AuthorizationPolicies
- add monitoring metrics/internal Loki Service AuthorizationPolicies
- add 1Password Connect Service AuthorizationPolicy for External Secrets callers

## Live test with temporary APs
- TCP DNS lookup from a temporary gateway service-account pod succeeded through blocky-dns
- Prometheus reached cert-manager, cainjector, and webhook metrics through Services and by Pod IP
- cert-manager Certificate server-side dry-run succeeded through the webhook
- Argo CD stayed Synced/Healthy with repo-server and Redis temp APs in place
- Prometheus reached all Kyverno metrics Services with temp APs in place
- Prometheus reached monitoring metric endpoints for Loki canary, Fluent Bit, kube-state-metrics, node-exporter, pushgateway, and Loki results-cache
- External Secrets reached 1Password Connect health successfully, and all ExternalSecrets stayed SecretSynced during soak
- temporary APs were deleted after testing

## Skipped after temp testing
- k8s-cleaner metrics returned HTTPS 401, so it needs auth-aware handling before adding AP
- keda-operator metrics did not present as a clean scrape path in this test
- admission/API Services remain separate follow-up work

## Testing
- make test