### PR TITLE
Allow Loki gateway to reach Loki

### DIFF
--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -72,6 +72,7 @@ spec:
               - {{ $gatewayPrincipal }}
               - {{ $grafanaPrincipal }}
               - {{ $fluentBitPrincipal }}
+              - {{ $lokiPrincipal }}
               - {{ $heartbeatPrincipal }}
       to:
         - operation:


### PR DESCRIPTION
## Summary
- allow the monitoring-loki service account to reach the monitoring-loki Service on port 3100
- fixes Loki canary 403/RBAC failures after the monitoring AuthorizationPolicy rollout

## Live validation
- temporary AP with the same allow rule restored Loki canary pushes from 403 to 204
- Loki canary logs were clean for a fresh interval after the temp AP

## Testing
- make test

Note: temporary AP monitoring/monitoring-loki-gateway-to-loki-temp-test is intentionally left active until this PR is merged and applied.