### PR TITLE
Add remaining service authorization policies

### DIFF
--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/authorization-policy.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/authorization-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: barman-cloud
+  namespace: cnpg-system
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: barman-cloud
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/cnpg-system/sa/cloudnative-pg
+              - cluster.local/ns/cnpg-system/sa/plugin-barman-cloud
+      to:
+        - operation:
+            ports:
+              - "9090"

--- a/helm-charts/heartbeats/templates/authorization-policy.yaml
+++ b/helm-charts/heartbeats/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: heartbeats-operator-controller-manager-metrics-service
+  namespace: heartbeats-operator-system
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: heartbeats-operator-controller-manager-metrics-service
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+      to:
+        - operation:
+            ports:
+              - "8443"

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/authorization-policy.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: k3s-apiserver-loadbalancer-controller-manager-metrics-service
+  namespace: k3s-apiserver-loadbalancer-system
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: k3s-apiserver-loadbalancer-controller-manager-metrics-service
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+      to:
+        - operation:
+            ports:
+              - "8443"

--- a/helm-charts/k8s-cleaner/templates/authorization-policy.yaml
+++ b/helm-charts/k8s-cleaner/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: k8s-cleaner-metrics
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: k8s-cleaner-metrics
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+      to:
+        - operation:
+            ports:
+              - "8081"

--- a/helm-charts/keda/templates/authorization-policy.yaml
+++ b/helm-charts/keda/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: keda-operator
+  namespace: keda
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: keda-operator
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+      to:
+        - operation:
+            ports:
+              - "9666"

--- a/helm-charts/longhorn/templates/authorization-policy.yaml
+++ b/helm-charts/longhorn/templates/authorization-policy.yaml
@@ -21,3 +21,46 @@ spec:
         - operation:
             ports:
               - "80"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: longhorn-backend
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}-backend
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/longhorn-service-account
+              - cluster.local/ns/{{ .Values.namespace }}/sa/longhorn-ui-service-account
+      to:
+        - operation:
+            ports:
+              - "9500"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: longhorn-recovery-backend
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}-recovery-backend
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/longhorn-service-account
+      to:
+        - operation:
+            ports:
+              - "9503"

--- a/helm-charts/teslamate/templates/authorization-policy.yaml
+++ b/helm-charts/teslamate/templates/authorization-policy.yaml
@@ -64,6 +64,7 @@ spec:
               - cluster.local/ns/{{ $.Values.namespace }}/sa/default
               - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $.Values.name }}-grafana
               - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $.Values.name }}-verify-pitr
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $databaseName }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
## Summary

- add service-targeted AuthorizationPolicies for remaining low-risk internal services
- allow Prometheus to reach selected controller metrics services
- allow Longhorn UI/manager and CNPG Barman Cloud internal service traffic
- fix TeslaMate CNPG database AuthorizationPolicy by allowing the database service account for replica/internal DB traffic

## Validation

- `make test`
- server-side dry-run for rendered AuthorizationPolicies
- temporary live AP tests for the new policies
- TeslaMate CNPG replica recovered after temp AP: replica resumed streaming WAL from primary

## Operational note

A temporary live AP remains in the cluster to keep TeslaMate healthy until this PR is merged and Argo syncs the permanent AP change:

`teslamate/teslamate-cnpg-db-internal-temp-test`

Delete it after the permanent `teslamate` AP update is applied.
