### PR TITLE
Fix TeslaMate database authorization policy validation

### DIFF
--- a/helm-charts/teslamate/templates/authorization-policy.yaml
+++ b/helm-charts/teslamate/templates/authorization-policy.yaml
@@ -63,7 +63,6 @@ spec:
             principals:
               - cluster.local/ns/{{ $.Values.namespace }}/sa/default
               - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $.Values.name }}-grafana
-              - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $.Values.name }}-verify-pitr
               - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $databaseName }}
       to:
         - operation:


### PR DESCRIPTION
## Summary
- remove the PITR verification CronJob service account from TeslaMate database AuthorizationPolicies
- keep DB access scoped to the app, Grafana, and CNPG cluster service accounts

## Why
Kiali reports the three CNPG database AuthorizationPolicies as invalid with KIA0106 on the PITR verification principal. The PITR verification job uses kubectl exec into database pods rather than opening PostgreSQL traffic from its own pod, so this principal is unnecessary.

## Test
- make test