### PR TITLE
Fix KEDA external metrics ambient handling

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -42,6 +42,7 @@ Connectivity roles:
 - `kiali`: ambient-enrolled observability namespace
 - `istio-waypoints`: hosts the shared waypoint and stays outside ambient
 - `envoy-gateway-system`: hosts the Envoy Gateway controller and stays outside ambient
+- `keda`: stays outside ambient because the Kubernetes aggregated external metrics API calls the KEDA metrics adapter directly
 - `longhorn-system`: stays outside ambient because Longhorn admission webhook, CSI, and storage control-plane paths must remain direct Kubernetes/Longhorn traffic
 
 Some platform namespaces stay outside ambient when they do not need the ambient traffic path.

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -251,6 +251,60 @@ kubectl -n longhorn-system get volumes.longhorn.io
 
 ---
 
+## KEDA External Metrics API Fails Through Ambient
+
+KEDA exposes `external.metrics.k8s.io` through a Kubernetes aggregated APIService. The kube-apiserver calls
+the KEDA metrics adapter directly on its HTTPS endpoint, and the adapter calls the KEDA operator gRPC metrics
+service.
+
+### Symptoms: KEDA External Metrics
+
+- The `keda` ArgoCD application stays `Progressing`.
+- The KEDA pods are `Running` and ready, but the APIService is unavailable:
+
+```shell
+kubectl get apiservice v1beta1.external.metrics.k8s.io
+```
+
+Typical failure:
+
+```text
+FailedDiscoveryCheck ... Get "https://<pod-ip>:6443/apis/external.metrics.k8s.io/v1beta1": EOF
+```
+
+The metrics adapter logs can also show gRPC handshake failures when it cannot reach `keda-operator:9666`.
+
+### Resolution: Keep KEDA Outside Ambient
+
+Keep `keda` out of the ambient mesh in `helm-charts/namespaces/values.yaml`:
+
+```yaml
+- name: keda
+  ambient: false
+```
+
+If ArgoCD has already applied ambient labels, remove them and restart the KEDA deployments:
+
+```shell
+kubectl label ns keda \
+  istio.io/dataplane-mode- \
+  istio.io/use-waypoint- \
+  istio.io/use-waypoint-namespace- \
+  istio.io/ingress-use-waypoint-
+kubectl -n keda rollout restart deploy/keda-admission-webhooks deploy/keda-operator deploy/keda-operator-metrics-apiserver
+kubectl -n keda rollout status deploy/keda-admission-webhooks
+kubectl -n keda rollout status deploy/keda-operator
+kubectl -n keda rollout status deploy/keda-operator-metrics-apiserver
+```
+
+After the restart, confirm the external metrics API is available:
+
+```shell
+kubectl get apiservice v1beta1.external.metrics.k8s.io
+```
+
+---
+
 ## Encrypted Longhorn Volumes Do Not Reclaim Space After Trim
 
 Encrypted Longhorn volumes can keep consuming backing storage after files are deleted, even when the

--- a/helm-charts/keda/templates/authorization-policy.yaml
+++ b/helm-charts/keda/templates/authorization-policy.yaml
@@ -17,6 +17,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+              - cluster.local/ns/keda/sa/keda-metrics-server
       to:
         - operation:
             ports:

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -28,6 +28,7 @@ namespaces:
   - name: jung2bot-dev
   - name: k8s-cleaner
   - name: keda
+    ambient: false
   - name: kiali
   - name: kubernetes-mcp-server
   - name: kyverno


### PR DESCRIPTION
## Summary
- keep the keda namespace out of ambient mesh because Kubernetes aggregated external metrics calls the metrics adapter directly
- allow the KEDA metrics adapter service account to call the KEDA operator metrics gRPC port
- document the KEDA external metrics ambient failure mode and recovery

## Test
- make test

## Live validation
- make maintenance completed end to end
- v1beta1.external.metrics.k8s.io is Available=True after applying the live recovery