### PR TITLE
Fix ambient authorization policy gaps

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -46,6 +46,10 @@ Connectivity roles:
 - `metrics-server`: pods stay outside ambient because the Kubernetes aggregated resource metrics API calls metrics-server directly
 - `longhorn-system`: stays outside ambient because Longhorn admission webhook, CSI, and storage control-plane paths must remain direct Kubernetes/Longhorn traffic
 
+The mesh AuthorizationPolicy guard checks ambient Services, but it skips explicitly annotated Services whose
+currently selected pods all opt out with `istio.io/dataplane-mode=none`. This covers pod-level platform
+exceptions such as `metrics-server` without requiring a misleading Service policy for non-ambient endpoints.
+
 Some platform namespaces stay outside ambient when they do not need the ambient traffic path.
 Non-ambient platform namespaces still rely on Kubernetes RBAC, service-specific TLS where applicable, and Flannel `wireguard-native` for inter-node transport protection.
 

--- a/helm-charts/amazon-eks-pod-identity-webhook/templates/authorization-policy.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/templates/authorization-policy.yaml
@@ -1,0 +1,19 @@
+{{- if .Capabilities.APIVersions.Has "security.istio.io/v1/AuthorizationPolicy" }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: amazon-eks-pod-identity-webhook
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "8443"
+              - "9999"
+{{- end }}

--- a/helm-charts/argocd-config/templates/authorization-policy.yaml
+++ b/helm-charts/argocd-config/templates/authorization-policy.yaml
@@ -68,3 +68,20 @@ spec:
         - operation:
             ports:
               - "6379"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: argocd-applicationset-controller
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: argocd-applicationset-controller
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "7000"

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/authorization-policy.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/authorization-policy.yaml
@@ -19,3 +19,20 @@ spec:
         - operation:
             ports:
               - "9090"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: cnpg-webhook-service
+  namespace: cnpg-system
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: cnpg-webhook-service
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"

--- a/helm-charts/envoy-gateway/templates/authorization-policy.yaml
+++ b/helm-charts/envoy-gateway/templates/authorization-policy.yaml
@@ -1,0 +1,45 @@
+{{- if .Capabilities.APIVersions.Has "security.istio.io/v1/AuthorizationPolicy" }}
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+{{- $prometheusPrincipal := printf "cluster.local/ns/%s/sa/%s" $prometheusNamespace $prometheusServiceAccount -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: gateway
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.service.name }}
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"
+              - "80"
+              - "2022"
+              - "53"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: gateway-envoy-workload
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: envoy
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "19001"
+{{- end }}

--- a/helm-charts/external-secrets/templates/authorization-policy.yaml
+++ b/helm-charts/external-secrets/templates/authorization-policy.yaml
@@ -1,0 +1,18 @@
+{{- if .Capabilities.APIVersions.Has "security.istio.io/v1/AuthorizationPolicy" }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: external-secrets-webhook
+  namespace: external-secrets
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: external-secrets-webhook
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"
+{{- end }}

--- a/helm-charts/istio-base/values.yaml
+++ b/helm-charts/istio-base/values.yaml
@@ -37,6 +37,14 @@ peerAuthentication:
           app.kubernetes.io/component: admission-controller
           app.kubernetes.io/instance: kyverno
           app.kubernetes.io/part-of: kyverno
+    - name: kyverno-cleanup-controller
+      namespace: kyverno
+      mtlsMode: PERMISSIVE
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: cleanup-controller
+          app.kubernetes.io/instance: kyverno
+          app.kubernetes.io/part-of: kyverno
     - name: amazon-eks-pod-identity-webhook
       namespace: default
       mtlsMode: PERMISSIVE
@@ -44,6 +52,14 @@ peerAuthentication:
         matchLabels:
           app.kubernetes.io/instance: amazon-eks-pod-identity-webhook
           app.kubernetes.io/name: pod-identity-webhook
+    - name: metallb-webhook
+      namespace: metallb-system
+      mtlsMode: PERMISSIVE
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: metallb
+          app.kubernetes.io/name: metallb
     - name: cloudnative-pg-webhook
       namespace: cnpg-system
       mtlsMode: PERMISSIVE

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -33,7 +33,7 @@ spec:
             method: GET
             urlPath: "/apis/security.istio.io/v1/namespaces/{{ `{{ request.namespace }}` }}/authorizationpolicies"
             jmesPath: >-
-              items[?spec.targetRefs[?(group == '' || group == 'core') &&
+              items[?spec.targetRefs[?(group == null || group == '' || group == 'core') &&
               kind == 'Service' && name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
             default: 0
       skipBackgroundRequests: true
@@ -43,13 +43,17 @@ spec:
         message: >-
           Selector-backed Services with TCP ports in ambient mesh namespaces must
           have an AuthorizationPolicy in the same namespace with targetRefs
-          pointing at that Service.
+          pointing at that Service unless explicitly annotated as a
+          non-ambient endpoint Service.
         deny:
           conditions:
             all:
               - key: "{{ `{{ authorizationPolicyCount }}` }}"
                 operator: Equals
                 value: 0
+              - key: {{ printf "{{ request.object.metadata.annotations.\"mesh.otaru.io/non-ambient-endpoints\" || '' }}" | quote }}
+                operator: NotEquals
+                value: "true"
     - name: require-workload-authorization-policy-for-prometheus-scrapes
       match:
         any:
@@ -92,6 +96,44 @@ spec:
             all:
               - key: "{{ `{{ workloadAuthorizationPolicyCount }}` }}"
                 operator: Equals
+                value: 0
+    - name: require-non-ambient-pods-for-non-ambient-service-opt-outs
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+{{- toYaml .Values.meshAuthorizationPolicy.namespaceSelector | nindent 16 }}
+      preconditions:
+        all:
+          - key: {{ printf "{{ request.object.metadata.labels.\"istio.io/dataplane-mode\" || '' }}" | quote }}
+            operator: NotEquals
+            value: none
+      context:
+        - name: selectedNonAmbientEndpointServiceCount
+          apiCall:
+            method: GET
+            urlPath: "/api/v1/namespaces/{{ `{{ request.namespace }}` }}/services"
+            jmesPath: >-
+              items[?metadata.annotations."mesh.otaru.io/non-ambient-endpoints" == 'true' &&
+              label_match(spec.selector, `{{ "{{" }} request.object.metadata.labels || `{}` {{ "}}" }}`)] | length(@)
+            default: 0
+      skipBackgroundRequests: true
+      validate:
+        allowExistingViolations: true
+        failureAction: {{ .Values.meshAuthorizationPolicy.failureAction }}
+        message: >-
+          Services annotated as non-ambient endpoint Services may only select
+          pods with istio.io/dataplane-mode=none.
+        deny:
+          conditions:
+            all:
+              - key: "{{ `{{ selectedNonAmbientEndpointServiceCount }}` }}"
+                operator: GreaterThan
                 value: 0
   validationFailureAction: {{ .Values.meshAuthorizationPolicy.failureAction }}
 {{- end }}

--- a/helm-charts/kyverno/templates/authorization-policy.yaml
+++ b/helm-charts/kyverno/templates/authorization-policy.yaml
@@ -28,3 +28,37 @@ spec:
             ports:
               - "8000"
 {{- end }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: kyverno-svc
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: kyverno-svc
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: kyverno-cleanup-controller
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: kyverno-cleanup-controller
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"

--- a/helm-charts/metallb/templates/authorization-policy.yaml
+++ b/helm-charts/metallb/templates/authorization-policy.yaml
@@ -1,0 +1,18 @@
+{{- if .Capabilities.APIVersions.Has "security.istio.io/v1/AuthorizationPolicy" }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: metallb-webhook-service
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: metallb-webhook-service
+  rules:
+    - to:
+        - operation:
+            ports:
+              - "443"
+{{- end }}

--- a/helm-charts/metrics-server/values.yaml
+++ b/helm-charts/metrics-server/values.yaml
@@ -1,6 +1,9 @@
 metrics-server:
   podLabels:
     istio.io/dataplane-mode: none
+  service:
+    annotations:
+      mesh.otaru.io/non-ambient-endpoints: "true"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary
- add missing Istio AuthorizationPolicies for webhook, gateway, and applicationset Services
- add PeerAuthentication exceptions for MetalLB and Kyverno cleanup webhook paths
- update the Kyverno mesh AP policy to count null Service targetRef groups and skip Services whose selected pods are all pod-level non-ambient
- document the pod-level non-ambient Service policy exception

## Tests
- make test
- rendered touched Helm charts
- server dry-run for MetalLB IPAddressPool webhook path