### PR TITLE
Fix Kyverno mesh policy AP context

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -49,6 +49,9 @@ Connectivity roles:
 The mesh AuthorizationPolicy guard checks ambient Services, but it skips explicitly annotated Services whose
 currently selected pods all opt out with `istio.io/dataplane-mode=none`. This covers pod-level platform
 exceptions such as `metrics-server` without requiring a misleading Service policy for non-ambient endpoints.
+The Kyverno admission, background, and reports controllers need read access to Istio `AuthorizationPolicy`
+resources so the guard can count existing Service `targetRefs` and workload selector policies during admission
+and reports scans.
 
 Some platform namespaces stay outside ambient when they do not need the ambient traffic path.
 Non-ambient platform namespaces still rely on Kubernetes RBAC, service-specific TLS where applicable, and Flannel `wireguard-native` for inter-node transport protection.

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy-rbac.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy-rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.meshAuthorizationPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-mesh-authorization-policy-context
+rules:
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - authorizationpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-mesh-authorization-policy-context
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-mesh-authorization-policy-context
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: kyverno-background-controller
+    namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: kyverno-reports-controller
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -33,8 +33,8 @@ spec:
             method: GET
             urlPath: "/apis/security.istio.io/v1/namespaces/{{ `{{ request.namespace }}` }}/authorizationpolicies"
             jmesPath: >-
-              items[?spec.targetRefs[?(group == null || group == '' || group == 'core') &&
-              kind == 'Service' && name == '{{ `{{ request.object.metadata.name }}` }}']] | length(@)
+              items[?length((spec.targetRefs || `[]`)[?(group == null || group == '' || group == 'core') &&
+              kind == 'Service' && name == '{{ `{{ request.object.metadata.name }}` }}']) > `0`] | length(@)
             default: 0
       skipBackgroundRequests: true
       validate:


### PR DESCRIPTION
## Summary
- grant Kyverno admission/background controllers read access to Istio AuthorizationPolicies used by mesh policy apiCall context
- make the Service targetRef count use an explicit non-empty targetRefs predicate
- document the RBAC dependency for mesh AuthorizationPolicy reports

## Test
- make test