### PR TITLE
Avoid mesh policy checks on ReplicaSet history

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -52,6 +52,8 @@ exceptions such as `metrics-server` without requiring a misleading Service polic
 The Kyverno admission, background, and reports controllers need read access to Istio `AuthorizationPolicy`
 resources so the guard can count existing Service `targetRefs` and workload selector policies during admission
 and reports scans.
+Generated workload checks intentionally skip ReplicaSet history; live Pods and desired-state controllers still
+carry the pod-level opt-out validation without reporting old zero-replica rollout templates.
 
 Some platform namespaces stay outside ambient when they do not need the ambient traffic path.
 Non-ambient platform namespaces still rely on Kubernetes RBAC, service-specific TLS where applicable, and Flannel `wireguard-native` for inter-node transport protection.

--- a/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/mesh-authorization-policy.yaml
@@ -3,6 +3,8 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-mesh-authorization-policy
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,Job,StatefulSet,CronJob
 spec:
   admission: true
   background: true


### PR DESCRIPTION
## Summary
- skip Kyverno autogen for historical ReplicaSet/ReplicationController templates on the mesh AuthorizationPolicy guard
- keep live Pod and desired-state controller validation for pod-level non-ambient opt-outs
- document why ReplicaSet history is skipped

## Test
- make test