### PR TITLE
Fix Envoy Gateway ambient authorization policy

### DIFF
--- a/helm-charts/envoy-gateway/templates/authorization-policy.yaml
+++ b/helm-charts/envoy-gateway/templates/authorization-policy.yaml
@@ -34,6 +34,17 @@ spec:
     matchLabels:
       app.kubernetes.io/name: envoy
   rules:
+    # Ambient mode enforces workload ALLOW policies on the Envoy listener ports.
+    # Keep these in sync with the Gateway Service targetPorts or cloudflared
+    # traffic can be rejected by ztunnel before it reaches Envoy.
+    - to:
+        - operation:
+            ports:
+              - "10443"
+              - "10080"
+              - "2022"
+              - "10053"
+              - "5683"
     - from:
         - source:
             principals:


### PR DESCRIPTION
## Summary
- allow Envoy Gateway workload listener ports in the ambient AuthorizationPolicy
- document why these ports must stay aligned with Gateway Service targetPorts
- keep Prometheus metrics access on port 19001

## Root cause
Istio ambient mode enforces workload ALLOW policies on the Envoy listener ports. The existing workload policy only allowed Prometheus metrics, so cloudflared traffic to the gateway listener was rejected by ztunnel before reaching Envoy.

## Validation
- make test
- live WebGazer monitors returned UP after applying the policy
- public checks returned 200 for otaru and jung2bot ping endpoints
