### PR TITLE
Remove heartbeats workflow Helm version pin

### DIFF
--- a/.github/workflows/auto-update-heartbeats.yaml
+++ b/.github/workflows/auto-update-heartbeats.yaml
@@ -42,8 +42,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: '3.18.4' # Pending on bugfix: https://github.com/helm/helm/issues/31148
 
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2


### PR DESCRIPTION
## Summary
- remove the explicit `3.18.4` Helm version pin from the heartbeats auto-update workflow
- let `azure/setup-helm@v5` install its default latest Helm version
- drop the stale inline comment referencing helm/helm#31148

## Rationale
The referenced Helm regression is about the Go API type validation path, not the Helm CLI usage in this workflow. This workflow uses the Helm binary, and the repo currently renders successfully with newer Helm.

## Validation
- `make test`
