### PR TITLE
Add openclaw namespace to cluster policies

### DIFF
--- a/helm-charts/envoy-gateway/Chart.lock
+++ b/helm-charts/envoy-gateway/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: oci://docker.io/envoyproxy
   version: 1.7.3
 digest: sha256:d817b5e2516151b8ff317e1c011bfc3667b88f54e19d896b1bafc55c4f27acfb
-generated: "2026-05-17T01:15:47.742723361Z"
+generated: "2026-05-18T04:03:33.630364+01:00"

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -26,6 +26,8 @@ clusterSecretStorePolicy:
     monitoring:
       - grafana
       - heartbeats
+    openclaw:
+      - openclaw
     teslamate:
       - b2-secret-cloudnative-pg
       - heartbeats

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -35,6 +35,7 @@ namespaces:
   - name: longhorn-system
     ambient: false
   - name: monitoring
+  - name: openclaw
   - name: onepassword
   - name: reloader
   - name: teslamate


### PR DESCRIPTION
## Summary
- allow the `openclaw` namespace to use the shared 1Password ClusterSecretStore
- add `openclaw` to the managed namespaces chart so it receives the standard ambient mesh labels
- refresh the `envoy-gateway` lockfile so the vendored dependency state matches the declared chart version and `make test` passes

## Testing
- make test