### PR TITLE
Allow openclaw routes on shared gateway

### DIFF
--- a/helm-charts/envoy-gateway/Chart.lock
+++ b/helm-charts/envoy-gateway/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: oci://docker.io/envoyproxy
   version: 1.7.3
 digest: sha256:d817b5e2516151b8ff317e1c011bfc3667b88f54e19d896b1bafc55c4f27acfb
-generated: "2026-05-17T01:15:47.742723361Z"
+generated: "2026-05-18T04:03:33.630364+01:00"

--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -44,6 +44,7 @@ spec:
                   - kubernetes-mcp-server
                   - longhorn-system
                   - monitoring
+                  - openclaw
                   - teslamate
     - name: http
       protocol: HTTP
@@ -71,6 +72,7 @@ spec:
                   - kubernetes-mcp-server
                   - longhorn-system
                   - monitoring
+                  - openclaw
                   - teslamate
     - name: jellyfin-sftp
       protocol: TCP

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -26,6 +26,8 @@ clusterSecretStorePolicy:
     monitoring:
       - grafana
       - heartbeats
+    openclaw:
+      - openclaw
     teslamate:
       - b2-secret-cloudnative-pg
       - heartbeats

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -35,6 +35,7 @@ namespaces:
   - name: longhorn-system
     ambient: false
   - name: monitoring
+  - name: openclaw
   - name: onepassword
   - name: reloader
   - name: teslamate


### PR DESCRIPTION
## Summary
- add `openclaw` to the shared Envoy Gateway HTTPS listener allow-list
- add `openclaw` to the shared Envoy Gateway HTTP listener allow-list

## Testing
- make test