### PR TITLE
Disable Claude CI review

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -20,15 +20,8 @@ jobs:
     steps:
       - name: Check PR author
         id: check
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          should_review=false
-          if [ "$PR_AUTHOR" = "$REPO_OWNER" ]; then
-            should_review=true
-          fi
-          echo "should-review=$should_review" >> "$GITHUB_OUTPUT"
+          echo "should-review=false" >> "$GITHUB_OUTPUT"
 
   claude:
     needs: check-author


### PR DESCRIPTION
## Summary
- disable the Claude CI review path by making the author check opt out of review
- keep the wrapper status job intact so the workflow can still report success when review is skipped

## Testing
- make test

Note: the first local test run hit ignored .scratchpad markdown files in this working copy; reran after temporarily moving that local directory aside and restored it afterward.