### PR TITLE
Allow Argo CD private repo token item

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -7,6 +7,7 @@ clusterSecretStorePolicy:
   allowedNamespaces:
     argocd:
       - argocd-secret
+      - Otaru - GitHub Private
     blocky:
       - blocky
     changedetection:


### PR DESCRIPTION
## Summary
- allow the argocd namespace to read the new 1Password item used for the private repo token
- keeps the ExternalSecret policy aligned with the already-updated private repo credential reference

## Testing
- make test

## Notes
- Private repo source was updated and pushed separately as 592919c (otaru-private).
- A temporary live Kyverno policy patch was applied during recovery; this PR makes that change GitOps-owned.