### PR TITLE
Add NUC worker node setup

### DIFF
--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -20,12 +20,27 @@ all:
       hosts:
         raspberrypi-03.local:
           ansible_host: 192.168.10.63
+    node20:
+      hosts:
+        nuc-00.local:
+          ansible_host: 192.168.10.80
+          ansible_ssh_user: ubuntu
+          luks_root_disk: /dev/sda
+          luks_boot_partition: /dev/sda2
+          luks_root_partition: /dev/sda3
+          luks_mapper_name: dm_crypt-0
+          luks_initramfs_iface: eno1
+          luks_initramfs_ip: 192.168.10.80
+          luks_unlock_authorized_keys_src: /home/ubuntu/.ssh/authorized_keys
     # Groups
     master:
       children:
         node00: { }
         node01: { }
         node02: { }
+    rpi4:
+      children:
+        node03: { }
     rpi5:
       children:
         node00: { }
@@ -34,9 +49,11 @@ all:
     worker:
       children:
         node03: { }
-    waveshare_poe_hat:
+        node20: { }
+    k3s_cluster:
       children:
-        node03: { }
+        master: { }
+        worker: { }
     luks_root_nodes:
       vars:
         luks_enabled: true
@@ -55,9 +72,10 @@ all:
         node00: { }
         node01: { }
         node02: { }
+        node20: { }
     raspberrypi:
       vars:
         ansible_ssh_user: pi
       children:
-        master: { }
-        worker: { }
+        rpi4: { }
+        rpi5: { }

--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: raspberrypi
+- hosts: k3s_cluster
   become: true
   gather_facts: false
   vars:

--- a/ansible/playbooks/k3s/001-cni.yaml
+++ b/ansible/playbooks/k3s/001-cni.yaml
@@ -111,8 +111,12 @@
     - name: Apply Envoy Gateway CRDs
       shell: |
         chart_archive="{{ envoy_gateway_chart_archive.files | map(attribute='path') | first }}"
-        tar -tzf "$chart_archive" | \
-          grep '^gateway-helm/crds/generated/gateway\.envoyproxy\.io_.*\.yaml$' | \
+        crd_paths="$(tar -tzf "$chart_archive" | grep -E '^gateway-helm/(crds|charts/crds/crds)/generated/gateway\.envoyproxy\.io_.*\.yaml$')"
+        if [ -z "$crd_paths" ]; then
+          echo "No Envoy Gateway CRDs found in $chart_archive" >&2
+          exit 1
+        fi
+        printf '%s\n' "$crd_paths" | \
           xargs tar -xOf "$chart_archive" | \
           kubectl apply --server-side --force-conflicts -f -
       register: envoy_gateway_crds_result

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: raspberrypi
+- hosts: k3s_cluster
   become: true
   gather_facts: false
   vars:

--- a/ansible/playbooks/nuke.yaml
+++ b/ansible/playbooks/nuke.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: raspberrypi
+- hosts: k3s_cluster
   become: true
 
   tasks:

--- a/ansible/playbooks/rpi/003-waveshare-poe-hat.yaml
+++ b/ansible/playbooks/rpi/003-waveshare-poe-hat.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: waveshare_poe_hat
+- hosts: rpi4
   become: true
   gather_facts: false
 

--- a/ansible/playbooks/rpi/005-cgroup.yaml
+++ b/ansible/playbooks/rpi/005-cgroup.yaml
@@ -105,6 +105,7 @@
     - name: Remove stale SSH host key for rebooted node from local known_hosts
       delegate_to: localhost
       become: false
+      throttle: 1
       known_hosts:
         path: "{{ lookup('ansible.builtin.env', 'HOME') }}/.ssh/known_hosts"
         name: "{{ ansible_host | default(inventory_hostname, true) }}"
@@ -114,6 +115,7 @@
     - name: Add current SSH host key for rebooted node to local known_hosts
       delegate_to: localhost
       become: false
+      throttle: 1
       known_hosts:
         path: "{{ lookup('ansible.builtin.env', 'HOME') }}/.ssh/known_hosts"
         name: "{{ ansible_host | default(inventory_hostname, true) }}"

--- a/ansible/playbooks/rpi/pre_tasks/wait-for-ssh.yaml
+++ b/ansible/playbooks/rpi/pre_tasks/wait-for-ssh.yaml
@@ -20,6 +20,7 @@
 - name: Remove stale SSH host key from local known_hosts
   delegate_to: localhost
   become: false
+  throttle: 1
   known_hosts:
     path: "{{ lookup('ansible.builtin.env', 'HOME') }}/.ssh/known_hosts"
     name: "{{ ansible_host | default(inventory_hostname, true) }}"
@@ -29,6 +30,7 @@
 - name: Add current SSH host key to local known_hosts
   delegate_to: localhost
   become: false
+  throttle: 1
   known_hosts:
     path: "{{ lookup('ansible.builtin.env', 'HOME') }}/.ssh/known_hosts"
     name: "{{ ansible_host | default(inventory_hostname, true) }}"

--- a/helm-charts/gateway-api/hack/download-crds.sh
+++ b/helm-charts/gateway-api/hack/download-crds.sh
@@ -25,3 +25,27 @@ popd >/dev/null
 pushd "${TEMPLATE_PATH}" >/dev/null
 echo "${yaml_content}" | yq e 'select(.kind != "CustomResourceDefinition")' | yq --split-exp '.kind + "-" + (.metadata.name | sub("\.", "-")) + ".yaml" | downcase'
 popd >/dev/null
+
+# The apiserver defaults these fields, and Argo CD already owns the live
+# defaults in this cluster. Keep the generated templates explicit so setup's
+# server-side apply can co-own the fields instead of conflicting with Argo.
+POLICY_FILE="${TEMPLATE_PATH}/validatingadmissionpolicy-safe-upgrades-gateway-networking-k8s-io.yaml"
+POLICY_BINDING_FILE="${TEMPLATE_PATH}/validatingadmissionpolicybinding-safe-upgrades-gateway-networking-k8s-io.yaml"
+
+if [[ -f "${POLICY_FILE}" ]]; then
+  yq -i '
+    .spec.matchConstraints.matchPolicy = "Equivalent" |
+    .spec.matchConstraints.namespaceSelector = {} |
+    .spec.matchConstraints.objectSelector = {} |
+    .spec.matchConstraints.resourceRules[].scope = "*"
+  ' "${POLICY_FILE}"
+fi
+
+if [[ -f "${POLICY_BINDING_FILE}" ]]; then
+  yq -i '
+    .spec.matchResources.matchPolicy = "Equivalent" |
+    .spec.matchResources.namespaceSelector = {} |
+    .spec.matchResources.objectSelector = {} |
+    .spec.matchResources.resourceRules[].scope = "*"
+  ' "${POLICY_BINDING_FILE}"
+fi

--- a/helm-charts/gateway-api/templates/validatingadmissionpolicy-safe-upgrades-gateway-networking-k8s-io.yaml
+++ b/helm-charts/gateway-api/templates/validatingadmissionpolicy-safe-upgrades-gateway-networking-k8s-io.yaml
@@ -16,6 +16,10 @@ spec:
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
         resources: ["*"]
+        scope: '*'
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
   validations:
     - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || ( has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || ( oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
       message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."

--- a/helm-charts/gateway-api/templates/validatingadmissionpolicybinding-safe-upgrades-gateway-networking-k8s-io.yaml
+++ b/helm-charts/gateway-api/templates/validatingadmissionpolicybinding-safe-upgrades-gateway-networking-k8s-io.yaml
@@ -15,3 +15,7 @@ spec:
         apiVersions: ["v1"]
         resources: ["customresourcedefinitions"]
         operations: ["CREATE", "UPDATE"]
+        scope: '*'
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}


### PR DESCRIPTION
## Summary
- add `nuc-00` as a LUKS-aware k3s worker and split Pi-only groups from the full `k3s_cluster`
- update k3s/nuke play targets to use `k3s_cluster` while keeping Pi hardware tasks scoped to Pi groups
- fix setup blockers for serialized `known_hosts` updates, Gateway API SSA defaults, and Envoy Gateway CRD extraction

## Validation
- `make test`
- `ansible-playbook -i ansible/inventory.yaml ansible/playbooks/setup.yaml --list-hosts`
- completed setup continuation with `failed=0`
- `kubectl get nodes -o wide` showed `nuc-00` Ready at `192.168.10.80`
- `kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded`
