### PR TITLE
Update k3s apiserver load balancer manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,17 @@ Set explicit ephemeral-storage requests and limits with suitable values for the 
 
 **Markdown**: fix linting violations directly, never disable markdownlint rules.
 
+## Cluster Access
+
+Use the Kubernetes MCP tools for live cluster inspection whenever they are
+available. Prefer them for read-only diagnostics such as listing Pods, reading
+events, checking Argo CD Applications, inspecting resources, logs, and metrics
+before falling back to `kubectl`.
+
+For mutating operations, keep GitOps as the source of truth: patch the repo and
+let Argo CD reconcile unless the user explicitly asks for an emergency live
+change.
+
 ## Node Reboot Policy
 
 Some Raspberry Pi nodes use LUKS encrypted root disks and do not return from a

--- a/helm-charts/k3s-apiserver-loadbalancer/hack/create-manifest.sh
+++ b/helm-charts/k3s-apiserver-loadbalancer/hack/create-manifest.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 CRD_PATH="$SCRIPT_DIR/../templates"
 
 LATEST_TAG=$(curl -sL "https://api.github.com/repos/siutsin/k3s-apiserver-loadbalancer/releases/latest" | jq -r '.tag_name')
+export LATEST_TAG
 
 if [ -z "${LATEST_TAG}" ] || [ "${LATEST_TAG}" = "null" ]; then
   echo "Error: Failed to get latest release tag" >&2
@@ -23,5 +24,39 @@ yaml_content=$(curl -sL "${MANIFEST_URL}" | yq e 'select(.)')
 echo "${yaml_content}" | yq --split-exp '.kind + "-" + (.metadata.name | sub("\.", "-")) + ".yaml" | downcase'
 
 popd >/dev/null
+
+DEPLOYMENT_FILE="${CRD_PATH}/deployment-k3s-apiserver-loadbalancer-controller-manager.yaml"
+NAMESPACE_FILE="${CRD_PATH}/namespace-k3s-apiserver-loadbalancer-system.yaml"
+SERVICE_FILE="${CRD_PATH}/service-k3s-apiserver-loadbalancer-controller-manager-metrics-service.yaml"
+
+if [[ -f "${DEPLOYMENT_FILE}" ]]; then
+  yq -i '
+    .metadata.labels."app.kubernetes.io/version" = strenv(LATEST_TAG) |
+    .spec.template.metadata.labels."app.kubernetes.io/version" = strenv(LATEST_TAG) |
+    del(.spec.template.spec.containers[] | select(.name == "manager").resources.limits.cpu) |
+    (.spec.template.spec.containers[] | select(.name == "manager").resources.limits.memory) = "128Mi" |
+    (.spec.template.spec.containers[] | select(.name == "manager").resources.limits."ephemeral-storage") = "64Mi" |
+    (.spec.template.spec.containers[] | select(.name == "manager").resources.requests.cpu) = "10m" |
+    (.spec.template.spec.containers[] | select(.name == "manager").resources.requests.memory) = "128Mi" |
+    (.spec.template.spec.containers[] | select(.name == "manager").resources.requests."ephemeral-storage") = "64Mi"
+  ' "${DEPLOYMENT_FILE}"
+fi
+
+if [[ -f "${NAMESPACE_FILE}" ]]; then
+  yq -i '
+    .metadata.annotations."argocd.argoproj.io/sync-options" = "Delete=false,Prune=false" |
+    .metadata.labels."app.kubernetes.io/version" = strenv(LATEST_TAG) |
+    .metadata.labels."istio.io/dataplane-mode" = "ambient" |
+    .metadata.labels."istio.io/use-waypoint" = "waypoint" |
+    .metadata.labels."istio.io/use-waypoint-namespace" = "istio-waypoints" |
+    .metadata.labels."istio.io/ingress-use-waypoint" = "true"
+  ' "${NAMESPACE_FILE}"
+fi
+
+if [[ -f "${SERVICE_FILE}" ]]; then
+  yq -i '
+    .metadata.labels."app.kubernetes.io/version" = strenv(LATEST_TAG)
+  ' "${SERVICE_FILE}"
+fi
 
 echo "Created k3s-apiserver-loadbalancer manifest"

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/deployment-k3s-apiserver-loadbalancer-controller-manager.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/deployment-k3s-apiserver-loadbalancer-controller-manager.yaml
@@ -4,8 +4,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
-    app.kubernetes.io/version: "v1.238.0"
     control-plane: controller-manager
+    app.kubernetes.io/version: v1.254.0
   name: k3s-apiserver-loadbalancer-controller-manager
   namespace: k3s-apiserver-loadbalancer-system
 spec:
@@ -20,7 +20,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         app.kubernetes.io/name: k3s-apiserver-loadbalancer
-        app.kubernetes.io/version: "v1.238.0"
+        app.kubernetes.io/version: v1.254.0
         control-plane: controller-manager
     spec:
       containers:
@@ -30,7 +30,7 @@ spec:
             - --health-probe-bind-address=:8081
           command:
             - /manager
-          image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.238.0
+          image: ghcr.io/siutsin/k3s-apiserver-loadbalancer:v1.254.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/namespace-k3s-apiserver-loadbalancer-system.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/namespace-k3s-apiserver-loadbalancer-system.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
+    app.kubernetes.io/version: v1.254.0
     control-plane: controller-manager
     istio.io/dataplane-mode: ambient
     istio.io/use-waypoint: waypoint
     istio.io/use-waypoint-namespace: istio-waypoints
     istio.io/ingress-use-waypoint: "true"
   name: k3s-apiserver-loadbalancer-system
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/service-k3s-apiserver-loadbalancer-controller-manager-metrics-service.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/service-k3s-apiserver-loadbalancer-controller-manager-metrics-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: k3s-apiserver-loadbalancer
+    app.kubernetes.io/version: v1.254.0
     control-plane: controller-manager
   name: k3s-apiserver-loadbalancer-controller-manager-metrics-service
   namespace: k3s-apiserver-loadbalancer-system


### PR DESCRIPTION
## Summary
- update k3s-apiserver-loadbalancer generated manifests to `v1.254.0`
- preserve local namespace labels/annotations and resource policy defaults in the manifest generator
- add cluster access guidance to `AGENTS.md`

## Validation
- `make test`
