### PR TITLE
Add changedetection browser worker

### DIFF
--- a/helm-charts/changedetection/config.example.yaml
+++ b/helm-charts/changedetection/config.example.yaml
@@ -1,2 +1,5 @@
 BASE_URL: https://changedetection.example.com
 USE_X_SETTINGS: true
+ALLOW_IANA_RESTRICTED_ADDRESSES: true
+PLAYWRIGHT_DRIVER_URL: ws://changedetection-browser.changedetection.svc.cluster.local:3000
+FETCH_WORKERS: 2

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.browser.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.browser.name }}
+    app.kubernetes.io/part-of: {{ .Values.name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.browser.name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.browser.name }}
+        app.kubernetes.io/part-of: {{ .Values.name }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ .Values.browser.name }}
+          image: {{ .Values.browser.image.repository }}@{{ .Values.browser.image.digest }}
+          imagePullPolicy: {{ .Values.browser.image.pullPolicy }}
+          env:
+            {{- range $name, $value := .Values.browser.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: cdp
+              containerPort: {{ .Values.browser.port }}
+              protocol: TCP
+            - name: stats
+              containerPort: {{ .Values.browser.statsPort }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - python3
+                - /usr/src/app/docker-health-check.py
+                - --host
+                - http://localhost
+          readinessProbe:
+            exec:
+              command:
+                - python3
+                - /usr/src/app/docker-health-check.py
+                - --host
+                - http://localhost
+          startupProbe:
+            exec:
+              command:
+                - python3
+                - /usr/src/app/docker-health-check.py
+                - --host
+                - http://localhost
+            failureThreshold: 30
+            periodSeconds: 10
+          resources: {{ toYaml .Values.browser.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.browser.tmpSizeLimit }}

--- a/helm-charts/changedetection/templates/browser-network-policy.yaml
+++ b/helm-charts/changedetection/templates/browser-network-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.browser.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.browser.name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Values.name }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.browser.port }}

--- a/helm-charts/changedetection/templates/browser-service.yaml
+++ b/helm-charts/changedetection/templates/browser-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.browser.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: cdp
+      port: {{ .Values.browser.port }}
+      protocol: TCP
+      targetPort: cdp
+  selector:
+    app.kubernetes.io/name: {{ .Values.browser.name }}

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -19,6 +19,29 @@ deployment:
       memory: 256Mi
       ephemeral-storage: 100Mi
 
+browser:
+  name: changedetection-browser
+  image:
+    repository: dgtlmoon/sockpuppetbrowser
+    digest: sha256:7116c61ef9cfce3d48a7efd9355d2fbe19f593ea3cfb52a5ded40ecbcb0a3f9d
+    pullPolicy: IfNotPresent
+  port: 3000
+  statsPort: 8080
+  tmpSizeLimit: 1Gi
+  env:
+    SCREEN_WIDTH: "1920"
+    SCREEN_HEIGHT: "1024"
+    SCREEN_DEPTH: "16"
+    MAX_CONCURRENT_CHROME_PROCESSES: "2"
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+      ephemeral-storage: 1Gi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
+
 service:
   port: 5000
   targetPort: 5000


### PR DESCRIPTION
## Summary
- add a private sockpuppetbrowser worker for changedetection Playwright fetches
- restrict browser ingress to the changedetection pod with NetworkPolicy
- document PLAYWRIGHT_DRIVER_URL, FETCH_WORKERS=2, and restricted-address LLM support in the config example

## Validation
- helm lint helm-charts/changedetection
- helm template changedetection helm-charts/changedetection -n changedetection | kubectl apply --dry-run=server -f -
- make test