### PR TITLE
Fix changedetection browser profile args

### DIFF
--- a/helm-charts/changedetection/config.example.yaml
+++ b/helm-charts/changedetection/config.example.yaml
@@ -1,5 +1,5 @@
 BASE_URL: https://changedetection.example.com
 USE_X_SETTINGS: true
 ALLOW_IANA_RESTRICTED_ADDRESSES: true
-PLAYWRIGHT_DRIVER_URL: ws://changedetection-browser.changedetection.svc.cluster.local:3000?user-data-dir=/profile/chromium
+PLAYWRIGHT_DRIVER_URL: ws://changedetection-browser.changedetection.svc.cluster.local:3000?--user-data-dir=/profile/chromium
 FETCH_WORKERS: 1

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -18,6 +18,8 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        fsGroup: {{ .Values.browser.profile.fsGroup }}
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -31,6 +31,7 @@ browser:
   profile:
     mountPath: /profile
     claimName: changedetection-browser-profile-pvc
+    fsGroup: 1000
   env:
     SCREEN_WIDTH: "1920"
     SCREEN_HEIGHT: "1024"


### PR DESCRIPTION
## Summary
- pass the persisted Chrome profile as a sockpuppetbrowser Chrome arg using ?--user-data-dir
- set browser pod fsGroup so the chrome user can write the Longhorn profile mount

## Tests
- helm lint helm-charts/changedetection
- helm template changedetection helm-charts/changedetection --namespace changedetection
- kubectl apply --dry-run=server -f /tmp/changedetection-profile-args-render.yaml
- make test