### PR TITLE
Use recreate rollout for changedetection browser

### DIFF
--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/name: {{ .Values.browser.name }}
     app.kubernetes.io/part-of: {{ .Values.name }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.browser.name }}


### PR DESCRIPTION
## Summary
- switch changedetection-browser Deployment to Recreate strategy
- avoid RWO profile PVC multi-attach during browser pod template changes

## Tests
- helm lint helm-charts/changedetection
- helm template changedetection helm-charts/changedetection --namespace changedetection
- kubectl apply --dry-run=server -f /tmp/changedetection-browser-recreate-render.yaml
- make test