### PR TITLE
Clear changedetection browser rolling update field

### DIFF
--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.browser.name }}


### PR DESCRIPTION
## Summary
- explicitly render rollingUpdate: null for the Recreate browser Deployment strategy
- allow Argo server-side apply to clear the old RollingUpdate field

## Tests
- helm lint helm-charts/changedetection
- helm template changedetection helm-charts/changedetection --namespace changedetection
- kubectl apply --dry-run=server -f /tmp/changedetection-browser-recreate-null-render.yaml
- make test