### PR TITLE
Fix OpenClaw ExternalSecret field selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # otaru
 
-![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.34.6+k3s1-blue)
+![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.35.5+k3s1-blue)
 [![Cluster Health](https://img.shields.io/static/v1?label=Cluster%20Health&message=WebGazer&color=brightgreen)](https://www.webgazer.io/s?id=493)
 
 > Over-Engineering at Its Finest
@@ -122,6 +122,7 @@ Three nodes form the control plane. One node remains a worker.
 | Connectivity | Cloudflare    | [DNS](https://developers.cloudflare.com/dns/)                                            | Authoritative DNS service                    |
 | Connectivity | Cloudflare    | [Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) | Edge connectivity                            |
 | Connectivity | UniFi         | [Network](https://ui.com/)                                                               | Gateway, VLAN, WLAN, and firewall management |
+| Messaging    | Telegram      | [Bot API](https://core.telegram.org/bots/api)                                            | Bot messaging for OpenClaw and 冗PowerBot     |
 | Monitoring   | Heartbeats    | [Heartbeats Operator](helm-charts/heartbeats)                                            | Kubernetes operator for heartbeat monitoring |
 | Monitoring   | WebGazer      | [Uptime Monitoring](https://www.webgazer.io/)                                            | Health check                                 |
 | Security     | 1Password     | [Connect](https://developer.1password.com/docs/connect/)                                 | Secrets automation                           |
@@ -131,7 +132,6 @@ Three nodes form the control plane. One node remains a worker.
 | Storage      | AWS           | [DynamoDB](https://aws.amazon.com/dynamodb/)                                             | Database backend for 冗PowerBot               |
 | Storage      | AWS           | [SQS](https://aws.amazon.com/sqs/)                                                       | Queue backend for 冗PowerBot                  |
 | Storage      | AWS           | [S3](https://aws.amazon.com/s3/)                                                         | OpenTofu remote state                        |
-| Messaging    | Telegram      | [Bot API](https://core.telegram.org/bots/api)                                            | Bot messaging for OpenClaw and 冗PowerBot     |
 | Storage      | Backblaze     | [B2](https://www.backblaze.com/cloud-storage)                                            | Longhorn and CloudNativePG backups           |
 <!-- markdownlint-enable MD060 -->
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Three nodes form the control plane. One node remains a worker.
 | Application  | [Home Assistant](https://www.home-assistant.io/)                                                    | Home automation                                                                                                                                                         |
 | Application  | [JSON Crack](https://github.com/AykutSarac/jsoncrack.com)                                           | JSON, YAML, etc. visualizer and editor                                                                                                                                  |
 | Application  | [Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-server)                        | Model Context Protocol server for Kubernetes cluster operations                                                                                                         |
+| Application  | [OpenClaw](helm-charts/openclaw)                                                                    | Self-hosted AI agent runtime with local model integration                                                                                                               |
 | Application  | [TeslaMate](https://github.com/teslamate-org/teslamate/)                                            | Self-hosted data logger for Tesla                                                                                                                                       |
 | Application  | [冗PowerBot](https://github.com/siutsin/telegram-jung2-bot)                                          | Telegram bot tracks and counts individual message counts in groups                                                                                                      |
 | CI/CD        | [Argo CD](https://github.com/argoproj/argo-cd)                                                      | GitOps, drift detection, and reconciliation                                                                                                                             |
@@ -130,6 +131,7 @@ Three nodes form the control plane. One node remains a worker.
 | Storage      | AWS           | [DynamoDB](https://aws.amazon.com/dynamodb/)                                             | Database backend for 冗PowerBot               |
 | Storage      | AWS           | [SQS](https://aws.amazon.com/sqs/)                                                       | Queue backend for 冗PowerBot                  |
 | Storage      | AWS           | [S3](https://aws.amazon.com/s3/)                                                         | OpenTofu remote state                        |
+| Messaging    | Telegram      | [Bot API](https://core.telegram.org/bots/api)                                            | Bot messaging for OpenClaw and 冗PowerBot     |
 | Storage      | Backblaze     | [B2](https://www.backblaze.com/cloud-storage)                                            | Longhorn and CloudNativePG backups           |
 <!-- markdownlint-enable MD060 -->
 

--- a/helm-charts/argocd/templates/external-secret.yaml
+++ b/helm-charts/argocd/templates/external-secret.yaml
@@ -59,6 +59,6 @@ spec:
         nullBytePolicy: Ignore
         key: openclaw
         metadataPolicy: None
-        property: openclaw/OPENCLAW_CONTROL_UI_HOSTNAME
+        property: OPENCLAW_CONTROL_UI_HOSTNAME
       secretKey: OPENCLAW_CONTROL_UI_HOSTNAME
 {{- end }}

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -37,14 +37,14 @@ externalSecret:
   remoteRef:
     key: openclaw
     properties:
-      gatewayToken: openclaw/OPENCLAW_GATEWAY_TOKEN
-      controlUiHostname: openclaw/OPENCLAW_CONTROL_UI_HOSTNAME
-      localModelApiKey: openclaw/LOCAL_MODEL_API_KEY
-      localModelBaseUrl: openclaw/LOCAL_MODEL_BASE_URL
-      localModelId: openclaw/LOCAL_MODEL_ID
-      localModelName: openclaw/LOCAL_MODEL_NAME
-      localModelInputJson: openclaw/LOCAL_MODEL_INPUT_JSON
-      telegramBotToken: telegram/token
+      gatewayToken: OPENCLAW_GATEWAY_TOKEN
+      controlUiHostname: OPENCLAW_CONTROL_UI_HOSTNAME
+      localModelApiKey: LOCAL_MODEL_API_KEY
+      localModelBaseUrl: LOCAL_MODEL_BASE_URL
+      localModelId: LOCAL_MODEL_ID
+      localModelName: LOCAL_MODEL_NAME
+      localModelInputJson: LOCAL_MODEL_INPUT_JSON
+      telegramBotToken: TELEGRAM_BOT_TOKEN
 
 secret:
   name: openclaw-secrets


### PR DESCRIPTION
## Summary
- remove section-qualified 1Password property paths from OpenClaw ExternalSecrets
- use the renamed TELEGRAM_BOT_TOKEN field label for Telegram
- add OpenClaw and Telegram to the root README and update the k3s version badge

## Tests
- make test