### PR TITLE
Fix OpenClaw Telegram streaming config

### DIFF
--- a/.github/workflows/auto-update-heartbeats.yaml
+++ b/.github/workflows/auto-update-heartbeats.yaml
@@ -59,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
+          gh release download v3.6.1 --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
           tar -xzf /tmp/ec.tar.gz -C /tmp
           BINARY=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
           chmod +x "$BINARY"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
+          gh release download v3.6.1 --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
           tar -xzf /tmp/ec.tar.gz -C /tmp
           BINARY=$(find /tmp -type f -name "ec-linux-amd64" | head -n 1)
           chmod +x "$BINARY"

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -90,7 +90,8 @@ channels:
     groups:
       "*":
         requireMention: true
-    streaming: progress
+    streaming:
+      mode: progress
     replyToMode: first
     linkPreview: false
 


### PR DESCRIPTION
## Summary
- render Telegram streaming as an object with `mode: progress` for the current OpenClaw config schema
- pin the editorconfig-checker workflow install to v3.6.1 because the latest release currently has no downloadable assets

## Tests
- make test