### PR TITLE
Fix Teslamate PITR heartbeat verification

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -167,7 +167,7 @@ local database = [
     source: {
       repoURL: 'https://cloudnative-pg.io/charts/',
       chart: s.name,
-      targetRevision: '0.23.2',
+      targetRevision: '0.28.2',
       helm: cnpgHelm,
     },
   },

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/clusterrole-plugin-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/clusterrole-plugin-barman-cloud.yaml
@@ -49,6 +49,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
@@ -33,7 +33,7 @@ spec:
                 secretKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-gt85cmh99d
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.5.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/secret-plugin-barman-cloud-gt85cmh99d.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/secret-plugin-barman-cloud-gt85cmh99d.yaml
@@ -2,8 +2,7 @@
 apiVersion: v1
 data:
   SIDECAR_IMAGE: |
-    Z2hjci5pby9jbG91ZG5hdGl2ZS1wZy9wbHVnaW4tYmFybWFuLWNsb3VkLXNpZGVjYXI6dj
-    AuNS4w
+    Z2hjci5pby9jbG91ZG5hdGl2ZS1wZy9wbHVnaW4tYmFybWFuLWNsb3VkLXNpZGVjYXI6djAuMTIuMA==
 kind: Secret
 metadata:
   name: plugin-barman-cloud-gt85cmh99d

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -32,8 +32,10 @@ rules:
       - ""
     resources:
       - pods
+      - persistentvolumeclaims
       - secrets
     verbs:
+      - delete
       - get
       - list
       - watch
@@ -70,6 +72,7 @@ spec:
     spec:
       ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
       backoffLimit: {{ .Values.backup.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.backup.verifyPitr.activeDeadlineSeconds }}
       template:
         spec:
           serviceAccountName: {{ .Values.name }}-verify-pitr
@@ -83,13 +86,38 @@ spec:
 
                   apk add --no-cache curl
 
-                  VERIFY_CLUSTER="{{ .Values.name }}-verify-pitr-$(date +%s)"
+                  VERIFY_CLUSTER="${VERIFY_JOB_NAME:-{{ .Values.name }}-verify-pitr-$(date +%s)}"
                   VERIFY_NAMESPACE="{{ .Values.namespace }}"
                   VERIFY_SOURCE_CLUSTER="{{ trimSuffix "-app" .Values.backup.database.secretName }}"
                   VERIFY_DATABASE="{{ .Values.database.name }}"
                   VERIFY_OWNER="{{ .Values.database.name }}"
-                  VERIFY_TIMEOUT_SECONDS=1800
+                  VERIFY_TIMEOUT_SECONDS={{ .Values.backup.verifyPitr.timeoutSeconds }}
                   VERIFY_QUERY='{{ .Values.backup.verifyPitr.verificationQuery }}'
+
+                  cleanup() {
+                    echo "Cleaning up ${VERIFY_CLUSTER}..."
+                    kubectl delete cluster "${VERIFY_CLUSTER}" -n "${VERIFY_NAMESPACE}" --ignore-not-found=true --wait=false || true
+
+                    for _ in $(seq 1 60); do
+                      if ! kubectl get cluster "${VERIFY_CLUSTER}" -n "${VERIFY_NAMESPACE}" >/dev/null 2>&1; then
+                        break
+                      fi
+                      sleep 5
+                    done
+
+                    kubectl delete pvc -n "${VERIFY_NAMESPACE}" -l cnpg.io/cluster="${VERIFY_CLUSTER}" --ignore-not-found=true || true
+                    kubectl delete secret -n "${VERIFY_NAMESPACE}" -l cnpg.io/cluster="${VERIFY_CLUSTER}" --ignore-not-found=true || true
+                    kubectl delete secret -n "${VERIFY_NAMESPACE}" \
+                      "${VERIFY_CLUSTER}-app" \
+                      "${VERIFY_CLUSTER}-ca" \
+                      "${VERIFY_CLUSTER}-replication" \
+                      "${VERIFY_CLUSTER}-server" \
+                      --ignore-not-found=true || true
+                  }
+
+                  trap cleanup EXIT INT TERM
+                  cleanup
+
                   VERIFY_SOURCE_PRIMARY=$(kubectl get cluster "${VERIFY_SOURCE_CLUSTER}" -n "${VERIFY_NAMESPACE}" -o jsonpath='{.status.currentPrimary}')
                   VERIFY_BACKUP_ID=$(
                     kubectl get backups.postgresql.cnpg.io \
@@ -143,19 +171,14 @@ spec:
                   echo "Scanned ${VERIFY_TARGET_SCAN_COUNT} timestamp-like columns in public"
                   echo "Using targetTime ${VERIFY_TARGET_TIME}"
 
-                  cleanup() {
-                    echo "Cleaning up ${VERIFY_CLUSTER}..."
-                    kubectl delete cluster "${VERIFY_CLUSTER}" -n "${VERIFY_NAMESPACE}" --ignore-not-found=true --wait=false || true
-                  }
-
-                  trap cleanup EXIT
-
                   cat <<EOF | kubectl apply -f -
                   apiVersion: postgresql.cnpg.io/v1
                   kind: Cluster
                   metadata:
                     name: ${VERIFY_CLUSTER}
                     namespace: ${VERIFY_NAMESPACE}
+                    labels:
+                      app.kubernetes.io/managed-by: teslamate-verify-pitr
                   spec:
                     instances: 1
                     resources:
@@ -242,6 +265,11 @@ spec:
               envFrom:
                 - secretRef:
                     name: {{ .Values.name }}-heartbeat
+              env:
+                - name: VERIFY_JOB_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['batch.kubernetes.io/job-name']
               resources:
                 requests:
                   cpu: 50m

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -127,6 +127,8 @@ backup:
     verificationQuery: "SELECT count(*) FROM positions;"
   verifyPitr:
     schedule: "0 14 * * *"
+    activeDeadlineSeconds: 28800 # 8 hours
+    timeoutSeconds: 21600 # 6 hours
     verificationQuery: "SELECT count(*) FROM positions;"
     restore:
       storage:


### PR DESCRIPTION
## Summary
- upgrade CloudNativePG and the Barman Cloud plugin/sidecar to address the WAL archive path failure seen on Teslamate
- harden the Teslamate PITR verifier so retries reuse the Kubernetes Job name, clean leaked restore resources, and wait long enough for WAL-heavy restores
- add Barman plugin RBAC needed by the upgraded plugin

## Validation
- helm template teslamate helm-charts/teslamate
- helm template cloudnative-pg-plugin-barman-cloud helm-charts/cloudnative-pg-plugin-barman-cloud
- git diff --check
- make test

## Notes
- Shell `gh api` could not publish because this sandbox currently cannot resolve `api.github.com`, so this PR was created through the GitHub connector against the same branch.
- No live cleanup was performed; existing stale `teslamate-verify-pitr-*` restore clusters/PVCs may still need manual cleanup after merge/reconcile.