### PR TITLE
Pin Teslamate PITR restore image

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -181,6 +181,7 @@ spec:
                       app.kubernetes.io/managed-by: teslamate-verify-pitr
                   spec:
                     instances: 1
+                    imageName: {{ .Values.backup.database.imageName }}
                     resources:
                       requests:
                         cpu: 250m

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -138,5 +138,6 @@ backup:
   backoffLimit: 4
   concurrencyPolicy: Forbid
   database:
+    imageName: ghcr.io/cloudnative-pg/postgresql:17.4
     secretName: *databaseAppSecretName
     postgresVersion: "17"


### PR DESCRIPTION
## Summary
- pin the temporary PITR restore CNPG cluster to the Teslamate PostgreSQL 17.4 image
- keep the restore image configurable alongside the existing backup database settings

## Testing
- make test
- git diff --check