### PR TITLE
Raise CNPG barman sidecar resources

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -98,11 +98,11 @@ defaults:
     instanceSidecarResources:
       requests:
         cpu: 50m
-        memory: 128Mi
-        ephemeral-storage: 256Mi
+        memory: 512Mi
+        ephemeral-storage: 512Mi
       limits:
-        memory: 128Mi
-        ephemeral-storage: 256Mi
+        memory: 512Mi
+        ephemeral-storage: 512Mi
 
 clusters:
   # https://cloudnative-pg.io/documentation/current/recovery/#restoring-into-a-cluster-with-a-backup-section


### PR DESCRIPTION
## Summary
- raise CNPG barman ObjectStore instance sidecar memory from 128Mi to 512Mi
- raise sidecar ephemeral storage from 256Mi to 512Mi to match the larger backup workload

## Testing
- make test
- git diff --check

## Live finding
- Teslamate on-demand plugin backup started, then failed with EOF because the primary plugin-barman-cloud sidecar was OOMKilled at 128Mi during barman-cloud-backup.