### PR TITLE
Ensure Teslamate PITR target WAL is archived

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -166,6 +166,9 @@ spec:
                     exit 1
                   fi
 
+                  kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
+                    psql -d postgres -Atq -c "SELECT pg_logical_emit_message(false, 'teslamate_verify_pitr', 'archive target WAL')" >/dev/null
+
                   VERIFY_TARGET_WAL=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
                     psql -d postgres -Atq -c "SELECT pg_walfile_name(pg_current_wal_lsn())")
                   if [ -z "${VERIFY_TARGET_WAL}" ]; then

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -166,6 +166,36 @@ spec:
                     exit 1
                   fi
 
+                  VERIFY_TARGET_WAL=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
+                    psql -d postgres -Atq -c "SELECT pg_walfile_name(pg_current_wal_lsn())")
+                  if [ -z "${VERIFY_TARGET_WAL}" ]; then
+                    echo "Error: failed to determine current WAL file."
+                    exit 1
+                  fi
+
+                  echo "Forcing WAL switch so targetTime is archived in ${VERIFY_TARGET_WAL}"
+                  kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
+                    psql -d postgres -Atq -c "SELECT pg_switch_wal()" >/dev/null
+
+                  VERIFY_WAL_ARCHIVE_DEADLINE=$(( $(date +%s) + 300 ))
+                  while true; do
+                    VERIFY_LAST_ARCHIVED_WAL=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
+                      psql -d postgres -Atq -c "SELECT COALESCE(last_archived_wal, '') FROM pg_stat_archiver")
+
+                    if [ "${VERIFY_LAST_ARCHIVED_WAL}" \> "${VERIFY_TARGET_WAL}" ] || [ "${VERIFY_LAST_ARCHIVED_WAL}" = "${VERIFY_TARGET_WAL}" ]; then
+                      echo "Archived WAL ${VERIFY_LAST_ARCHIVED_WAL}; target WAL ${VERIFY_TARGET_WAL} is available."
+                      break
+                    fi
+
+                    if [ "$(date +%s)" -ge "${VERIFY_WAL_ARCHIVE_DEADLINE}" ]; then
+                      echo "Error: timed out waiting for WAL ${VERIFY_TARGET_WAL} to be archived."
+                      echo "Last archived WAL: ${VERIFY_LAST_ARCHIVED_WAL:-<none>}"
+                      exit 1
+                    fi
+
+                    sleep 5
+                  done
+
                   echo "Using source primary ${VERIFY_SOURCE_PRIMARY}"
                   echo "Using backupID ${VERIFY_BACKUP_ID}"
                   echo "Scanned ${VERIFY_TARGET_SCAN_COUNT} timestamp-like columns in public"


### PR DESCRIPTION
## Summary
- force a WAL switch after deriving the PITR verification target time
- wait for the target WAL segment to appear in pg_stat_archiver before creating the restore cluster

## Validation
- make test
- triggered a patched one-off PITR verification job in teslamate; restore completed, verification query passed, heartbeat accepted