### PR TITLE
Tune Argo CD repo-server autoscaling

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -122,8 +122,13 @@ argo-cd:
       enabled: true
       minReplicas: 1
       maxReplicas: 3
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
+      metrics:
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80
       behavior:
         scaleDown:
           stabilizationWindowSeconds: 60


### PR DESCRIPTION
## Summary
- make repo-server HPA scale on memory only
- keep min 1 and max 3 so it normally returns to one replica while retaining headroom for memory pressure

## Test
- make test