### PR TITLE
Keep Argo CD repo-server at one replica

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -118,8 +118,9 @@ argo-cd:
     secretInit:
       enabled: false
   repoServer:
+    replicas: 1
     autoscaling:
-      enabled: true
+      enabled: false
       minReplicas: 1
       maxReplicas: 3
       metrics:


### PR DESCRIPTION
## Summary
- disable repo-server HPA after it held two replicas despite low memory
- set repo-server replicas explicitly to 1

## Test
- make test