### PR TITLE
ci: disable setup-go cache for heartbeats updater

### DIFF
--- a/.github/workflows/auto-update-heartbeats.yaml
+++ b/.github/workflows/auto-update-heartbeats.yaml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
+          cache: false
 
       - name: Install go-jsonnet
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest


### PR DESCRIPTION
## Summary
- Disable actions/setup-go caching in the auto-update heartbeats workflow.

## Tests
- make test