### PR TITLE
Fix changedetection browser profile cleanup

### DIFF
--- a/helm-charts/changedetection-volume/values.yaml
+++ b/helm-charts/changedetection-volume/values.yaml
@@ -6,6 +6,6 @@ longhorn-volume-lib:
       sizeBytes: "10737418240"
       fromBackup: ""
     changedetection-browser-profile:
-      size: "2Gi"
-      sizeBytes: "2147483648"
+      size: "10Gi"
+      sizeBytes: "10737418240"
       fromBackup: ""

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -25,6 +25,32 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: cleanup-browser-metrics
+          image: {{ .Values.browser.cleanup.image.repository }}:{{ .Values.browser.cleanup.image.tag }}
+          imagePullPolicy: {{ .Values.browser.cleanup.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              metrics_dir={{ printf "%s/chromium/DeferredBrowserMetrics" .Values.browser.profile.mountPath | quote }}
+              if [ -d "$metrics_dir" ]; then
+                find "$metrics_dir" -type f -name '*.pma' -delete
+              fi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: {{ .Values.browser.profile.fsGroup }}
+            runAsGroup: {{ .Values.browser.profile.fsGroup }}
+            runAsNonRoot: true
+          resources: {{ toYaml .Values.browser.cleanup.resources | nindent 12 }}
+          volumeMounts:
+            - name: profile
+              mountPath: {{ .Values.browser.profile.mountPath }}
       containers:
         - name: {{ .Values.browser.name }}
           image: {{ .Values.browser.image.repository }}@{{ .Values.browser.image.digest }}
@@ -73,6 +99,34 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: profile
+              mountPath: {{ .Values.browser.profile.mountPath }}
+        - name: cleanup-browser-metrics-loop
+          image: {{ .Values.browser.cleanup.image.repository }}:{{ .Values.browser.cleanup.image.tag }}
+          imagePullPolicy: {{ .Values.browser.cleanup.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              metrics_dir={{ printf "%s/chromium/DeferredBrowserMetrics" .Values.browser.profile.mountPath | quote }}
+              while true; do
+                if [ -d "$metrics_dir" ]; then
+                  find "$metrics_dir" -type f -name '*.pma' -mmin +{{ .Values.browser.cleanup.minAgeMinutes }} -delete
+                fi
+                sleep {{ .Values.browser.cleanup.intervalSeconds }}
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: {{ .Values.browser.profile.fsGroup }}
+            runAsGroup: {{ .Values.browser.profile.fsGroup }}
+            runAsNonRoot: true
+          resources: {{ toYaml .Values.browser.cleanup.resources | nindent 12 }}
+          volumeMounts:
             - name: profile
               mountPath: {{ .Values.browser.profile.mountPath }}
       volumes:

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -45,6 +45,21 @@ browser:
     mountPath: /profile
     claimName: changedetection-browser-profile-pvc
     fsGroup: 1000
+  cleanup:
+    intervalSeconds: 3600
+    minAgeMinutes: 60
+    image:
+      repository: busybox
+      tag: 1.38.0@sha256:8f2ffdcb46f1b83e46665954ec130e497b979db766854f79ca9eee43242b7e4c
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+        ephemeral-storage: 16Mi
+      limits:
+        memory: 32Mi
+        ephemeral-storage: 16Mi
   env:
     SCREEN_WIDTH: "1920"
     SCREEN_HEIGHT: "1024"


### PR DESCRIPTION
## Summary

- expand the changedetection browser profile Longhorn volume from 2Gi to 10Gi
- add a startup cleanup init container for Chromium `DeferredBrowserMetrics/*.pma`
- add an hourly cleanup sidecar that removes `.pma` metrics files older than 60 minutes while the browser pod stays running

## Diagnosis

`changedetection-browser-profile-pvc` was full. The profile volume was 2Gi, and `/profile/chromium/DeferredBrowserMetrics` had grown to about 1.9Gi from Chromium metrics files. changedetection was still Kubernetes-healthy, but fetch workers failed to connect to the browser CDP endpoint with `TargetClosedError`.

## Validation

- `helm template changedetection helm-charts/changedetection --namespace changedetection`
- `make test`
