### PR TITLE
Fix changedetection browser stale profile locks

### DIFF
--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -34,7 +34,9 @@ spec:
             - -ec
           args:
             - |
+              profile_dir={{ printf "%s/chromium" .Values.browser.profile.mountPath | quote }}
               metrics_dir={{ printf "%s/chromium/DeferredBrowserMetrics" .Values.browser.profile.mountPath | quote }}
+              rm -f "$profile_dir"/SingletonCookie "$profile_dir"/SingletonLock "$profile_dir"/SingletonSocket
               if [ -d "$metrics_dir" ]; then
                 find "$metrics_dir" -type f -name '*.pma' -delete
               fi


### PR DESCRIPTION
## Summary
- remove stale Chromium Singleton lock files from the browser profile during browser init
- keep lock cleanup out of the hourly metrics cleanup loop so active Chrome profiles are not touched

## Verification
- make test