### PR TITLE
Fix local-path storage class drift

### DIFF
--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -22,6 +22,7 @@
         curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ K3S_CHANNEL }} INSTALL_K3S_SKIP_DOWNLOAD=false sh -s - \
           --cluster-init \
           --disable coredns \
+          --disable local-storage \
           --disable metrics-server \
           --disable servicelb \
           --disable traefik \

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -36,8 +36,12 @@
       # https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md
       shell: |
         curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ K3S_CHANNEL }} INSTALL_K3S_SKIP_DOWNLOAD=false sh -s - \
+          {% if inventory_hostname == groups['master'][0] %}
+          --cluster-init \
+          {% else %}
           --token {{ hostvars['localhost']['k3s_master_token'] }} \
           --server https://{{ hostvars[groups['master'][0]]['ansible_host'] }}:6443 \
+          {% endif %}
           --disable coredns \
           --disable local-storage \
           --disable metrics-server \
@@ -61,9 +65,7 @@
       delay: 10
       register: k3s_master_install
       changed_when: k3s_master_install.stdout is not search('No change detected so skipping service start')
-      when:
-        - "'master' in group_names"
-        - inventory_hostname != groups['master'][0]
+      when: "'master' in group_names"
 
     - name: Check if serving cert contains required TLS SANs
       shell: |

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -112,6 +112,30 @@
       changed_when: k3s_worker_install.stdout is not search('No change detected so skipping service start')
       when: "'worker' in group_names"
 
+    - name: Keep packaged local-storage manifest from becoming default StorageClass
+      replace:
+        path: /var/lib/rancher/k3s/server/manifests/local-storage.yaml
+        regexp: 'storageclass\.kubernetes\.io/is-default-class: "true"'
+        replace: 'storageclass.kubernetes.io/is-default-class: "false"'
+      when: "'master' in group_names"
+
+    - name: Reconcile live local-path default storage class annotation
+      shell: |
+        set -euo pipefail
+        current="$(k3s kubectl get storageclass local-path -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')"
+        if [ "$current" != "false" ]; then
+          k3s kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class=false --overwrite
+          echo "updated"
+        fi
+      args:
+        executable: /bin/bash
+      register: local_path_default_annotation
+      changed_when: "'updated' in local_path_default_annotation.stdout"
+      retries: 5
+      delay: 10
+      until: local_path_default_annotation.rc == 0
+      when: inventory_hostname == groups['master'][0]
+
     - name: Ensure k3s CNI plugin path resolves istio-cni binary
       file:
         src: /opt/cni/bin/istio-cni

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -39,6 +39,7 @@
           --token {{ hostvars['localhost']['k3s_master_token'] }} \
           --server https://{{ hostvars[groups['master'][0]]['ansible_host'] }}:6443 \
           --disable coredns \
+          --disable local-storage \
           --disable metrics-server \
           --disable servicelb \
           --disable traefik \
@@ -111,30 +112,6 @@
       register: k3s_worker_install
       changed_when: k3s_worker_install.stdout is not search('No change detected so skipping service start')
       when: "'worker' in group_names"
-
-    - name: Keep packaged local-storage manifest from becoming default StorageClass
-      replace:
-        path: /var/lib/rancher/k3s/server/manifests/local-storage.yaml
-        regexp: 'storageclass\.kubernetes\.io/is-default-class: "true"'
-        replace: 'storageclass.kubernetes.io/is-default-class: "false"'
-      when: "'master' in group_names"
-
-    - name: Reconcile live local-path default storage class annotation
-      shell: |
-        set -euo pipefail
-        current="$(k3s kubectl get storageclass local-path -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')"
-        if [ "$current" != "false" ]; then
-          k3s kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class=false --overwrite
-          echo "updated"
-        fi
-      args:
-        executable: /bin/bash
-      register: local_path_default_annotation
-      changed_when: "'updated' in local_path_default_annotation.stdout"
-      retries: 5
-      delay: 10
-      until: local_path_default_annotation.rc == 0
-      when: inventory_hostname == groups['master'][0]
 
     - name: Ensure k3s CNI plugin path resolves istio-cni binary
       file:

--- a/ansible/playbooks/k3s/003-bootstrap.yaml
+++ b/ansible/playbooks/k3s/003-bootstrap.yaml
@@ -34,24 +34,6 @@
     delay: 10
     until: coredns_ready_result.rc == 0
 
-  # Set local-path not to be the default storage class
-
-  - name: Reconcile local-path storage class default annotation
-    shell: |
-      cat <<'EOF' | kubectl apply -f -
-      apiVersion: storage.k8s.io/v1
-      kind: StorageClass
-      metadata:
-        name: local-path
-        annotations:
-          storageclass.kubernetes.io/is-default-class: "false"
-      EOF
-    register: local_path_result
-    retries: 5
-    delay: 10
-    until: local_path_result.rc == 0
-    changed_when: "'unchanged' not in local_path_result.stdout"
-
   # 1Password Connect
 
   - name: Verify local 1Password Connect secret files exist

--- a/helm-charts/longhorn-config/templates/local-path-storageclass.yaml
+++ b/helm-charts/longhorn-config/templates/local-path-storageclass.yaml
@@ -1,9 +1,0 @@
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: local-path
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
-provisioner: rancher.io/local-path
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Summary
- disable the packaged K3s `local-storage` component during cluster init and node joins/upgrades
- make the upgrade playbook apply the same server flags to the first master as well as secondary masters
- remove the repo-managed `local-path` StorageClass manifest so Argo no longer fights K3s over a packaged component
- keep `longhorn-crypto-global` as the only default StorageClass

## Validation
- `make test`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook -i ansible/inventory.yaml ansible/playbooks/k3s/000-init-cluster.yaml --syntax-check`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook -i ansible/inventory.yaml ansible/playbooks/k3s/002-nodes.yaml --syntax-check`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook -i ansible/inventory.yaml ansible/playbooks/k3s/003-bootstrap.yaml --syntax-check`

## Live verification
- `local-path=false`
- `longhorn-crypto-global=true`
- Argo CD apps healthy/synced after refresh
