### PR TITLE
Expand TeslaMate Postgres storage to 15Gi

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -111,6 +111,10 @@ clusters:
 
   teslamate:
     clusterName: teslamate-20260412-0619
+    storage:
+      resizeInUseVolumes: true
+      size: 15Gi
+      storageClass: longhorn-crypto-global
     affinity:
       podAntiAffinityType: required
     instances: 2


### PR DESCRIPTION
## Summary

- Increase the `teslamate` CNPG cluster PVC size from 5Gi to 15Gi
- Keep `resizeInUseVolumes: true` so existing volumes expand in place

## Context

TeslaMate Postgres hit disk full on the 5Gi Longhorn encrypted volumes (`no free disk space for WALs`), causing CNPG and the TeslaMate app to crashloop. Live cluster was already patched and recovered; this makes the fix durable in GitOps.

## Test plan

- [x] `make test`
- [x] Live cluster verified: CNPG `Cluster in healthy state`, 2/2 instances running, TeslaMate app `1/1 Running`