### PR TITLE
fix(teslamate): raise Grafana memory limit to stop OOMKills

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -52,12 +52,13 @@ service:
 
 grafana:
   resources:
+    # Keep memory at 512Mi: TeslaMate dashboard usage pushed Grafana against the 128Mi limit and caused OOMKills.
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 512Mi
       ephemeral-storage: 128Mi
     limits:
-      memory: 128Mi
+      memory: 512Mi
       ephemeral-storage: 128Mi
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
## Problem

Accessing `teslamate-grafana.internal.siutsin.com` returns:

```
upstream connect error or disconnect/reset before headers. reset reason: connection termination
```

The TeslaMate Grafana pod (`teslamate-grafana-645fc55545-cz8nl`) was repeatedly **OOMKilled** at the 128Mi memory limit. Live usage was ~124Mi before spikes during dashboard provisioning pushed it over the limit.

## Fix

Raise Grafana memory requests/limits from 128Mi to 512Mi, matching the monitoring Grafana chart which already documents the same failure mode.

## Verification

- `make test` passes locally
- Pod `lastState.terminated.reason` was `OOMKilled` (exit 137)