### PR TITLE
upgrade(teslamate): bump TeslaMate and Grafana to v4.0.0

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -18,7 +18,7 @@ deployment:
             topologyKey: kubernetes.io/hostname
   image:
     repository: teslamate/teslamate
-    tag: 3.1.0@sha256:b7b8b21869d789d043f62b404dd689f55c601ef7d02222e92c0f5d596d0b1044
+    tag: 4.0.0@sha256:1c4f03e1c8a8e43269ac24c78a2f4a4a021637bbedf600d4b951ec1223889a4e
   envFrom:
     - secretRef:
         name: teslamate
@@ -90,7 +90,7 @@ grafana:
     failureThreshold: 10
   image:
     repository: teslamate/grafana
-    tag: 3.1.0@sha256:8d7287f44b1eefb39e649175aa14615df648c04a3162da9461d07c8a9ea1c7e9
+    tag: 4.0.0@sha256:5b974c82b7684fbe071778e5e5e5f542dc9caffc2cacafb750edf8bf92124beb
   database:
     secretName: *databaseAppSecretName
   envValueFrom:


### PR DESCRIPTION
## Summary

Upgrades `teslamate/teslamate` and `teslamate/grafana` from **3.1.0 → 4.0.0** to fix Tesla Owner API `403 Forbidden` errors.

## Why

TeslaMate v4.0.0 ([release notes](https://github.com/teslamate-org/teslamate/releases/tag/v4.0.0)) resolves [#5384](https://github.com/teslamate-org/teslamate/issues/5384): Tesla now requires TLS 1.3 for auth token exchange, which needs Erlang/OTP 28. Our cluster logs show token refresh succeeding but Owner API calls failing with:

```
"forbidden, see https://developer.tesla.com/docs/fleet-api"
```

Last vehicle data was recorded on **2026-06-12**.

## Compatibility

- Cluster nodes are **arm64** (Raspberry Pi) and **amd64** (nuc-00) — unaffected by the ARMv7 drop in v4.0.0
- `make test` passes

## Post-deploy steps

1. Argo CD syncs the new images
2. In TeslaMate **Settings → Sign out**, then sign back in with Tesla to mint fresh TLS 1.3 tokens
3. Confirm logs no longer show Owner API 403s and new positions appear