### PR TITLE
Exclude sd-card nodes from heavy workload scheduling

### DIFF
--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -24,6 +24,14 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -19,6 +19,15 @@ spec:
         app.kubernetes.io/name: {{ .Values.browser.name }}
         app.kubernetes.io/part-of: {{ .Values.name }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
       automountServiceAccountToken: false
       securityContext:
         fsGroup: {{ .Values.browser.profile.fsGroup }}

--- a/helm-charts/changedetection/templates/deployment.yaml
+++ b/helm-charts/changedetection/templates/deployment.yaml
@@ -22,6 +22,14 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -9,8 +9,16 @@ backup:
 
 defaults:
   cluster:
-    affinity:
+    affinity: &excludeSdCardClusterAffinity
       podAntiAffinityType: preferred
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node.siutsin.com/storage-tier
+                  operator: NotIn
+                  values:
+                    - sd-card
     instances: 1
     enablePDB: true
     failoverDelay: 0
@@ -116,6 +124,7 @@ clusters:
       size: 15Gi
       storageClass: longhorn-crypto-global
     affinity:
+      <<: *excludeSdCardClusterAffinity
       podAntiAffinityType: required
     instances: 2
     minSyncReplicas: 1

--- a/helm-charts/happy/templates/deployment.yaml
+++ b/helm-charts/happy/templates/deployment.yaml
@@ -88,6 +88,14 @@ spec:
           emptyDir: {}
           {{- end }}
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/home-assistant/values.yaml
+++ b/helm-charts/home-assistant/values.yaml
@@ -5,6 +5,14 @@ ip: 192.168.10.51
 
 deployment:
   affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.siutsin.com/storage-tier
+                operator: NotIn
+                values:
+                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -18,6 +18,14 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -2,6 +2,15 @@ name: monitoring
 namespace: monitoring
 
 _shared:
+  excludeSdCardNodeAffinity: &excludeSdCardNodeAffinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.siutsin.com/storage-tier
+                operator: NotIn
+                values:
+                  - sd-card
   smallResources: &smallResources
     requests:
       cpu: 50m
@@ -30,6 +39,7 @@ prometheus:
     prometheus:
       resources: *smallResources
   server:
+    affinity: *excludeSdCardNodeAffinity
     resources:
       # Keep memory at 3Gi: Grafana dashboard queries pushed Prometheus close to the previous 2Gi limit.
       requests:
@@ -80,6 +90,7 @@ prometheus:
                 )
 
 grafana:
+  affinity: *excludeSdCardNodeAffinity
   resources:
     # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
     requests:
@@ -128,6 +139,7 @@ loki:
     resources: *smallResources
   singleBinary:
     replicas: 1
+    affinity: *excludeSdCardNodeAffinity
     resources:
       requests:
         cpu: 100m

--- a/helm-charts/openclaw/templates/deployment.yaml
+++ b/helm-charts/openclaw/templates/deployment.yaml
@@ -31,6 +31,14 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: NotIn
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -213,6 +213,15 @@ spec:
                     labels:
                       app.kubernetes.io/managed-by: teslamate-verify-pitr
                   spec:
+                    affinity:
+                      nodeAffinity:
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          nodeSelectorTerms:
+                            - matchExpressions:
+                                - key: node.siutsin.com/storage-tier
+                                  operator: NotIn
+                                  values:
+                                    - sd-card
                     instances: 1
                     imageName: {{ .Values.backup.database.imageName }}
                     resources:

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -8,6 +8,14 @@ database:
 
 deployment:
   affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.siutsin.com/storage-tier
+                operator: NotIn
+                values:
+                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
@@ -61,6 +69,14 @@ grafana:
       memory: 512Mi
       ephemeral-storage: 128Mi
   affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.siutsin.com/storage-tier
+                operator: NotIn
+                values:
+                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100


### PR DESCRIPTION
## Summary

Add `requiredDuringSchedulingIgnoredDuringExecution` node affinity so heavy workloads cannot schedule on nodes labeled `node.siutsin.com/storage-tier=sd-card` (currently `raspberrypi-03`).

Complements the live `PreferNoSchedule` taint with an explicit workload-side rule.

## Workloads updated

- **monitoring**: Prometheus (3Gi), Grafana, Loki
- **cloudnative-pg-clusters**: defaults + TeslaMate CNPG cluster
- **teslamate**: app, Grafana, PITR verify restore cluster
- **home-assistant**, **openclaw**, **happy**
- **changedetection** + browser (Chromium)
- **blocky**, **jung2bot**

## Live prerequisite

`raspberrypi-03` is labeled:

```text
node.siutsin.com/storage-tier=sd-card
```

## Test plan

- [x] `make test`
- [x] `helm template` confirms nodeAffinity renders for CNPG and monitoring