### PR TITLE
Prefer light workloads on sd-card nodes

### DIFF
--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -17,6 +17,15 @@ resources:
     ephemeral-storage: 64Mi
 
 affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 80
+        preference:
+          matchExpressions:
+            - key: node.siutsin.com/storage-tier
+              operator: In
+              values:
+                - sd-card
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100

--- a/helm-charts/cyberchef/templates/deployment.yaml
+++ b/helm-charts/cyberchef/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
               memory: 100Mi
               ephemeral-storage: 100Mi
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -52,6 +52,15 @@ spec:
               memory: 128Mi
               ephemeral-storage: 100Mi
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -18,6 +18,15 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -36,6 +36,15 @@ spec:
               path: /
               port: http
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -16,6 +16,15 @@ kubernetes-mcp-server:
       memory: 128Mi
       ephemeral-storage: 64Mi
   affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 80
+          preference:
+            matchExpressions:
+              - key: node.siutsin.com/storage-tier
+                operator: In
+                values:
+                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -10,6 +10,15 @@ reloader:
           memory: 64Mi
           ephemeral-storage: 64Mi
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100


### PR DESCRIPTION
Soft nodeAffinity toward raspberrypi-03 for httpbin, jsoncrack, excalidraw, cyberchef, cloudflare-tunnel, reloader, and kubernetes-mcp-server.