### PR TITLE
Tolerate sd-card taint for light workloads

### DIFF
--- a/helm-charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/helm-charts/cloudflare-tunnel/templates/deployment.yaml
@@ -72,3 +72,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -19,7 +19,7 @@ resources:
 affinity:
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 80
+      - weight: 100
         preference:
           matchExpressions:
             - key: node.siutsin.com/storage-tier
@@ -34,3 +34,9 @@ affinity:
             matchLabels:
               pod: cloudflared
           topologyKey: kubernetes.io/hostname
+
+tolerations:
+  - key: node.siutsin.com/storage-tier
+    operator: Equal
+    value: sd-card
+    effect: PreferNoSchedule

--- a/helm-charts/cyberchef/templates/deployment.yaml
+++ b/helm-charts/cyberchef/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: node.siutsin.com/storage-tier
@@ -66,3 +66,8 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: node.siutsin.com/storage-tier
@@ -69,3 +69,8 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: node.siutsin.com/storage-tier
@@ -38,6 +38,11 @@ spec:
                       values:
                         - {{ .Values.name }}
                 topologyKey: "kubernetes.io/hostname"
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule
       automountServiceAccountToken: false
       containers:
         - name: {{ .Values.name }}

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: node.siutsin.com/storage-tier
@@ -53,3 +53,8 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -18,7 +18,7 @@ kubernetes-mcp-server:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 80
+        - weight: 100
           preference:
             matchExpressions:
               - key: node.siutsin.com/storage-tier
@@ -30,3 +30,8 @@ kubernetes-mcp-server:
         - weight: 100
           podAffinityTerm:
             topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: node.siutsin.com/storage-tier
+      operator: Equal
+      value: sd-card
+      effect: PreferNoSchedule

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -12,7 +12,7 @@ reloader:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 80
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: node.siutsin.com/storage-tier
@@ -24,3 +24,8 @@ reloader:
             - weight: 100
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
+        tolerations:
+          - key: node.siutsin.com/storage-tier
+            operator: Equal
+            value: sd-card
+            effect: PreferNoSchedule


### PR DESCRIPTION
Follow-up to #2550: allow light workloads to land on raspberrypi-03 despite PreferNoSchedule.