### PR TITLE
fix(teslamate): temporary GHCR main image for Owner API 403 hotfix

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -25,8 +25,12 @@ deployment:
                 app.kubernetes.io/name: teslamate
             topologyKey: kubernetes.io/hostname
   image:
-    repository: teslamate/teslamate
-    tag: 4.0.0@sha256:1c4f03e1c8a8e43269ac24c78a2f4a4a021637bbedf600d4b951ec1223889a4e
+    # Temporary hotfix for Tesla Owner API 403 after v4.0.0 (teslamate-org/teslamate#5399).
+    # GHCR main@6a9a33b includes merged PR #5406 (TLS 1.3 + HTTP/2 for auth.tesla.com).
+    # The pr-5406 tag is purged post-merge; main is the equivalent build.
+    # Revert to a stable release tag once 4.0.1+ is published on Docker Hub.
+    repository: ghcr.io/teslamate-org/teslamate
+    tag: main@sha256:2c518518b17ea68d5a4fbf149b92e968d3c1a659bcda1e1794bba5c5d02c6d01
   envFrom:
     - secretRef:
         name: teslamate


### PR DESCRIPTION
## Summary

Temporarily deploy TeslaMate from the official GHCR `main` build that includes merged [teslamate-org/teslamate#5406](https://github.com/teslamate-org/teslamate/pull/5406) (TLS 1.3 + HTTP/2 for `auth.tesla.com` token refresh).

This addresses Owner API `403` errors on v4.0.0 ([#5399](https://github.com/teslamate-org/teslamate/issues/5399)) without routing tokens through a third-party proxy.

## Image inspection

| Check | Result |
|-------|--------|
| Registry | `ghcr.io/teslamate-org/teslamate` (official org) |
| Git revision | `6a9a33b` — merge commit of PR #5406 |
| Code delta vs v4.0.0 | 8 lines in `lib/teslamate/http.ex` only |
| `pr-5406` tag | Purged by upstream CI post-merge; `main` is equivalent |
| User | `nonroot` (unchanged) |
| Size delta | +1.3 KB vs 4.0.0 arm64 image |

Pinned multi-arch digest: `sha256:2c518518b17ea68d5a4fbf149b92e968d3c1a659bcda1e1794bba5c5d02c6d01`

## Revert plan

Switch back to `teslamate/teslamate:<stable>` on Docker Hub once 4.0.1+ is published.

## Test plan

- [x] `make test`
- [ ] Argo CD sync + pod rollout
- [ ] TeslaMate logs show successful Owner API calls (no 403)