### PR TITLE
chore(teslamate): pull app and Grafana images from GHCR

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -25,10 +25,10 @@ deployment:
                 app.kubernetes.io/name: teslamate
             topologyKey: kubernetes.io/hostname
   image:
+    # Pull from GHCR (ghcr.io/teslamate-org/teslamate), not Docker Hub.
     # Temporary hotfix for Tesla Owner API 403 after v4.0.0 (teslamate-org/teslamate#5399).
-    # GHCR main@6a9a33b includes merged PR #5406 (TLS 1.3 + HTTP/2 for auth.tesla.com).
-    # The pr-5406 tag is purged post-merge; main is the equivalent build.
-    # Revert to a stable release tag once 4.0.1+ is published on Docker Hub.
+    # main@6a9a33b includes merged PR #5406 (TLS 1.3 + HTTP/2 for auth.tesla.com).
+    # Pin to a stable GHCR release tag once 4.0.1+ is published.
     repository: ghcr.io/teslamate-org/teslamate
     tag: main@sha256:2c518518b17ea68d5a4fbf149b92e968d3c1a659bcda1e1794bba5c5d02c6d01
   envFrom:
@@ -109,8 +109,9 @@ grafana:
     timeoutSeconds: 30
     failureThreshold: 10
   image:
-    repository: teslamate/grafana
-    tag: 4.0.0@sha256:5b974c82b7684fbe071778e5e5e5f542dc9caffc2cacafb750edf8bf92124beb
+    registry: ghcr.io
+    repository: teslamate-org/teslamate/grafana
+    tag: main@sha256:6170c64cc0a9adb8650150e9e5243e14e8446e106a38ee2cfa4637a9fefb378a
   database:
     secretName: *databaseAppSecretName
   envValueFrom:


### PR DESCRIPTION
## Summary

Switch both TeslaMate images from Docker Hub to the official GitHub Container Registry:

| Component | Image |
|-----------|-------|
| TeslaMate | `ghcr.io/teslamate-org/teslamate:main@sha256:2c5185…` |
| Grafana | `ghcr.io/teslamate-org/teslamate/grafana:main@sha256:6170c6…` |

Sets `grafana.image.registry: ghcr.io` so the upstream Grafana subchart does not prepend `docker.io/`.

## Test plan

- [x] `make test`
- [ ] Argo CD sync + Grafana pod rollout