### PR TITLE
Disable Grafana Helm test hooks in TeslaMate chart

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -63,6 +63,9 @@ service:
   port: 4000
 
 grafana:
+  testFramework:
+    # Helm test hooks are not run under Argo CD and leave orphaned resources that degrade app health.
+    enabled: false
   resources:
     # Keep memory at 512Mi: TeslaMate dashboard usage pushed Grafana against the 128Mi limit and caused OOMKills.
     requests:


### PR DESCRIPTION
## Summary

- Disable the Grafana subchart `testFramework` so Helm test hook manifests are not rendered
- Prevents orphaned `teslamate-grafana-test` ConfigMap/ServiceAccount resources under Argo CD

Helm test hooks are not executed in our GitOps flow and were leaving stale cluster objects that marked the `teslamate` Application as Degraded.

## Test plan

- [x] `make test`
- [x] Deleted existing orphaned `teslamate-grafana-test` resources from the cluster