### PR TITLE
feat(umami): add helm chart, gateway allowlist, and Argo app

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -125,6 +125,7 @@ local application = [
   { wave: '10', name: 'openclaw-volume', namespace: 'openclaw' },
   { wave: '11', name: 'openclaw', namespace: 'openclaw', helm: openClawHelm },
   { wave: '10', name: 'teslamate', namespace: 'teslamate' },
+  { wave: '10', name: 'umami', namespace: 'umami' },
   { wave: '11', name: 'changedetection', namespace: 'changedetection' },
   { wave: '11', name: 'home-assistant', namespace: 'home-assistant' },
   { wave: '30', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot', helm: jung2botHelm },

--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -47,6 +47,7 @@ spec:
                   - monitoring
                   - openclaw
                   - teslamate
+                  - umami
     - name: http
       protocol: HTTP
       port: 80
@@ -76,6 +77,7 @@ spec:
                   - monitoring
                   - openclaw
                   - teslamate
+                  - umami
     - name: jellyfin-sftp
       protocol: TCP
       port: 2022

--- a/helm-charts/umami/.helmignore
+++ b/helm-charts/umami/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/umami/Chart.yaml
+++ b/helm-charts/umami/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: umami
+description: A Helm chart for Umami analytics
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/umami/templates/authorization-policy.yaml
+++ b/helm-charts/umami/templates/authorization-policy.yaml
@@ -1,0 +1,23 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+      to:
+        - operation:
+            ports:
+              - {{ .Values.service.port | quote }}

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -1,0 +1,82 @@
+{{- $version := regexReplaceAll "@sha256:.*$" .Values.image.tag "" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/version: {{ $version | quote }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.name }}
+        app.kubernetes.io/version: {{ $version | quote }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Values.name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: TZ
+              value: {{ .Values.env.TZ | quote }}
+            - name: APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: APP_SECRET
+          envFrom:
+            - secretRef:
+                name: {{ .Values.database.secretName }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/heartbeat
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/heartbeat
+              port: http
+          resources: {{ toYaml .Values.deployment.resources | nindent 12 }}
+          volumeMounts:
+            - name: ca
+              mountPath: /etc/secrets/ca
+              readOnly: true
+      volumes:
+        - name: ca
+          secret:
+            secretName: {{ .Values.database.caSecretName }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node.siutsin.com/storage-tier
+                    operator: In
+                    values:
+                      - sd-card
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ .Values.name }}
+                topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule

--- a/helm-charts/umami/templates/external-secret.yaml
+++ b/helm-charts/umami/templates/external-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.appSecret.externalSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.appSecret.externalSecret.secretStoreRef.kind }}
+    name: {{ .Values.appSecret.externalSecret.secretStoreRef.name }}
+  target:
+    name: {{ .Values.name }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  data:
+    - secretKey: APP_SECRET
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.appSecret.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: {{ .Values.appSecret.externalSecret.remoteRef.property }}

--- a/helm-charts/umami/templates/pdb.yaml
+++ b/helm-charts/umami/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/umami/templates/route-collect.yaml
+++ b/helm-charts/umami/templates/route-collect.yaml
@@ -1,0 +1,27 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}-collect
+  namespace: {{ .Values.namespace }}
+spec:
+  hostnames:
+    - {{ .Values.routes.collect.hostname }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayName }}
+      namespace: {{ $gatewayNamespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.name }}
+          port: {{ .Values.service.port }}
+          weight: 1

--- a/helm-charts/umami/templates/route-internal.yaml
+++ b/helm-charts/umami/templates/route-internal.yaml
@@ -1,0 +1,27 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}-internal
+  namespace: {{ .Values.namespace }}
+spec:
+  hostnames:
+    - {{ printf "%s.internal.siutsin.com" .Values.name }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayName }}
+      namespace: {{ $gatewayNamespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.name }}
+          port: {{ .Values.service.port }}
+          weight: 1

--- a/helm-charts/umami/templates/service.yaml
+++ b/helm-charts/umami/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: main
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/umami/values.yaml
+++ b/helm-charts/umami/values.yaml
@@ -1,0 +1,47 @@
+name: umami
+namespace: umami
+
+image:
+  repository: ghcr.io/umami-software/umami
+  tag: postgresql-latest@sha256:e3f80c0625aad7179b49da27d475357cabb1068b8cacd9a792cfd6966888b123
+  pullPolicy: IfNotPresent
+
+database:
+  secretName: umami-20260614-0001
+  caSecretName: umami-20260614-0001-ca
+
+appSecret:
+  externalSecret:
+    refreshInterval: 24h
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: onepassword-secret-store
+    remoteRef:
+      key: umami
+      property: APP_SECRET
+
+service:
+  port: 3000
+  targetPort: 3000
+
+deployment:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 512Mi
+      ephemeral-storage: 512Mi
+
+routes:
+  collect:
+    hostname: analytics.siutsin.com
+
+gateway:
+  name: gateway
+  namespace: gateway
+
+env:
+  TZ: Europe/London


### PR DESCRIPTION
Deploys Umami on the cluster for analytics collection and dashboard access.

## Changes

- New `helm-charts/umami/` chart
- HTTPRoutes: `analytics.siutsin.com` (collect), `umami.internal.siutsin.com` (dashboard)
- Add `umami` to Envoy Gateway HTTPS/HTTP namespace allowlists
- Register Argo CD application `umami` (wave 10)

## Depends on

- #2556 (feat/umami-cnpg-namespace) for CNPG cluster and namespace

## Post-merge

1. Create 1Password item `umami` with field `APP_SECRET`
2. Add `umami.internal` to `CLOUDFLARE_DNS_SUBDOMAINS` and apply DNS Terraform
3. Argo sync; verify `curl https://analytics.siutsin.com/api/heartbeat`