### PR TITLE
feat(cnpg): add Umami PostgreSQL cluster and namespace

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -164,3 +164,34 @@ clusters:
           parameters:
             barmanObjectName: b2-backup
             serverName: teslamate-20251024-0015
+
+  umami:
+    clusterName: umami-20260614-0001
+    namespace: umami
+    instances: 1
+    storage:
+      size: 2Gi
+      storageClass: longhorn-crypto-global
+    affinity:
+      <<: *excludeSdCardClusterAffinity
+    postgresql:
+      <<: *postgresql
+      pg_hba:
+        - hostssl all all 0.0.0.0/0 scram-sha-256
+        - hostssl all all ::0/0 scram-sha-256
+    enableSuperuserAccess: false
+    managed:
+      roles:
+        - name: app
+          ensure: present
+          login: true
+          connectionLimit: -1
+    bootstrap:
+      initdb:
+        database: umami
+        owner: app
+        secret:
+          name: umami-20260614-0001
+    test:
+      enabled: true
+      query: SELECT 1;

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -40,3 +40,4 @@ namespaces:
   - name: onepassword
   - name: reloader
   - name: teslamate
+  - name: umami


### PR DESCRIPTION
Adds the `umami` namespace and a CNPG cluster for self-hosted Umami analytics.

## Changes

- Register `umami` namespace in `helm-charts/namespaces/values.yaml`
- Add CNPG cluster `umami-20260614-0001` (1 instance, 2Gi, scram-sha-256, excludes sd-card nodes)

## Post-merge

Argo sync `cloudnative-pg-clusters`; verify Cluster reaches Ready in namespace `umami`.