### PR TITLE
feat(cloudflare): expose analytics.siutsin.com via tunnel

### DIFF
--- a/infrastructure/modules/cloudflare-tunnel/dns.tf
+++ b/infrastructure/modules/cloudflare-tunnel/dns.tf
@@ -19,3 +19,12 @@ resource "cloudflare_dns_record" "oidc" {
   ttl     = 1
   type    = "CNAME"
 }
+
+resource "cloudflare_dns_record" "analytics" {
+  zone_id = var.zone_id
+  content = local.tunnel_hostname
+  name    = "analytics"
+  proxied = true
+  ttl     = 1
+  type    = "CNAME"
+}

--- a/infrastructure/modules/cloudflare-tunnel/tunnel.tf
+++ b/infrastructure/modules/cloudflare-tunnel/tunnel.tf
@@ -48,6 +48,10 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
         service  = var.gateway_service
       },
       {
+        hostname = "analytics.${var.zone}"
+        service  = var.gateway_service
+      },
+      {
         service = "http_status:404"
       }
     ]


### PR DESCRIPTION
Adds Cloudflare tunnel ingress and proxied DNS for the public Umami collect endpoint at `analytics.siutsin.com`.

## Changes

- Tunnel ingress: `analytics.siutsin.com` → Envoy Gateway
- Proxied CNAME `analytics` → tunnel hostname

No Cloudflare Access on this hostname — browsers must reach `/script.js` and `/api/send` anonymously.

## Post-merge

Apply Terraform: `infrastructure/cloud/cloudflare/tunnel`.