### PR TITLE
Select verify-pitr backups by cluster spec, not label

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -123,9 +123,8 @@ spec:
                   VERIFY_BACKUP_META=$(
                     kubectl get backups.postgresql.cnpg.io \
                       -n "${VERIFY_NAMESPACE}" \
-                      -l cnpg.io/cluster="${VERIFY_SOURCE_CLUSTER}" \
-                      -o jsonpath='{range .items[*]}{.status.stoppedAt}{"|"}{.status.backupId}{"|"}{.status.phase}{"|"}{.status.pluginMetadata.timeline}{"\n"}{end}' |
-                      awk -F'|' '$3=="completed"{print}' |
+                      -o jsonpath='{range .items[*]}{.spec.cluster.name}{"|"}{.status.stoppedAt}{"|"}{.status.backupId}{"|"}{.status.phase}{"|"}{.status.pluginMetadata.timeline}{"\n"}{end}' |
+                      awk -F'|' -v cluster="${VERIFY_SOURCE_CLUSTER}" '$1 == cluster && $4 == "completed" { print $2 "|" $3 "|" $5 }' |
                       sort |
                       tail -n1
                   )


### PR DESCRIPTION
## Summary

Manual Backup CRs do not get the `cnpg.io/cluster` label, so verify-pitr kept selecting the pre-promotion timeline-10 backup and aborting with a timeline history archiver error.

Select the latest completed backup by `spec.cluster.name` instead.

## Test plan

- [x] `helm template` for teslamate chart
- [ ] Merge, Argo sync, re-run verify-pitr e2e