### PR TITLE
fix(kyverno): allow umami namespace to use 1Password ExternalSecrets

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -20,6 +20,8 @@ clusterSecretStorePolicy:
       - heartbeats
     happy:
       - happy
+    umami:
+      - umami
     home-assistant:
       - heartbeats
     jung2bot:


### PR DESCRIPTION
The umami Argo app could not sync its ExternalSecret because Kyverno policy
\`restrict-onepassword-cluster-secret-store\` did not list the \`umami\` namespace.

## Changes

- Add \`umami\` to \`clusterSecretStorePolicy.allowedNamespaces\` with key \`umami\`

## Post-merge

Argo sync \`kyverno-policy\`; verify \`externalsecret/umami\` becomes Ready in namespace \`umami\`.