### PR TITLE
fix(kyverno): allow umami CNPG backup ObjectStore and B2 credentials

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -22,6 +22,7 @@ clusterSecretStorePolicy:
       - happy
     umami:
       - umami
+      - b2-secret-cloudnative-pg
     home-assistant:
       - heartbeats
     jung2bot:
@@ -58,6 +59,11 @@ barmanObjectStorePolicy:
   enabled: true
   allowedNamespaces:
     teslamate:
+      objectStores:
+        - b2-backup
+      credentialSecrets:
+        - b2-backup-credentials
+    umami:
       objectStores:
         - b2-backup
       credentialSecrets:


### PR DESCRIPTION
Umami CNPG cluster reconciliation was stuck: the barman-cloud pre-reconcile hook kept requeueing because \`ObjectStore/b2-backup\` and \`ExternalSecret/b2-backup-credentials\` could not be created in namespace \`umami\`.

## Changes

- Add \`b2-secret-cloudnative-pg\` to umami 1Password key allowlist
- Add umami to \`barmanObjectStorePolicy.allowedNamespaces\`

## Post-merge

Argo sync \`kyverno-policy\` and \`cloudnative-pg-clusters\`; verify \`umami-20260614-0001\` pod becomes Ready.