### PR TITLE
feat(scheduling): pin movable workloads to raspberrypi-03 sd-card node

### DIFF
--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -18,10 +18,9 @@ resources:
 
 affinity:
   nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        preference:
-          matchExpressions:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
             - key: node.siutsin.com/storage-tier
               operator: In
               values:

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -19,6 +19,16 @@ defaults:
                   operator: NotIn
                   values:
                     - sd-card
+    affinitySdCard: &sdCardClusterAffinity
+      podAntiAffinityType: preferred
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node.siutsin.com/storage-tier
+                  operator: In
+                  values:
+                    - sd-card
     instances: 1
     enablePDB: true
     failoverDelay: 0
@@ -173,7 +183,7 @@ clusters:
       size: 2Gi
       storageClass: longhorn-crypto-global
     affinity:
-      <<: *excludeSdCardClusterAffinity
+      <<: *sdCardClusterAffinity
     postgresql:
       <<: *postgresql
       pg_hba:

--- a/helm-charts/cyberchef/templates/deployment.yaml
+++ b/helm-charts/cyberchef/templates/deployment.yaml
@@ -50,10 +50,9 @@ spec:
               ephemeral-storage: 100Mi
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node.siutsin.com/storage-tier
                     operator: In
                     values:

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -53,10 +53,9 @@ spec:
               ephemeral-storage: 100Mi
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node.siutsin.com/storage-tier
                     operator: In
                     values:

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -19,10 +19,9 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node.siutsin.com/storage-tier
                     operator: In
                     values:

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -37,10 +37,9 @@ spec:
               port: http
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node.siutsin.com/storage-tier
                     operator: In
                     values:

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: node.siutsin.com/storage-tier
-                    operator: NotIn
+                    operator: In
                     values:
                       - sd-card
         podAntiAffinity:
@@ -37,6 +37,11 @@ spec:
                       values:
                         - {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule
       serviceAccountName: {{ .Values.name }}
       containers:
         - name: {{ .Values.name }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -17,10 +17,9 @@ kubernetes-mcp-server:
       ephemeral-storage: 64Mi
   affinity:
     nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          preference:
-            matchExpressions:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
               - key: node.siutsin.com/storage-tier
                 operator: In
                 values:

--- a/helm-charts/openclaw/templates/deployment.yaml
+++ b/helm-charts/openclaw/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: node.siutsin.com/storage-tier
-                    operator: NotIn
+                    operator: In
                     values:
                       - sd-card
         podAntiAffinity:
@@ -47,6 +47,11 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule
       initContainers:
         - name: init-state
           image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -59,10 +59,9 @@ spec:
             secretName: {{ .Values.database.caSecretName }}
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node.siutsin.com/storage-tier
                     operator: In
                     values:


### PR DESCRIPTION
`raspberrypi-03` is the only `sd-card` node and has ~6Gi of unused memory request headroom. Congested nodes (nuc-00, pi-00/01/02) are at 89–95% of allocatable memory requests, blocking Umami CNPG (1536Mi).

## Changes

Require `node.siutsin.com/storage-tier=sd-card` for:

- **Tools:** httpbin, cyberchef, excalidraw, jsoncrack, kubernetes-mcp-server
- **Infra:** cloudflare-tunnel (both replicas)
- **Apps:** jung2bot (prod + dev), openclaw, umami deployment
- **Data:** umami CNPG cluster (`umami-20260614-0001`)

Previously these either preferred sd-card (soft) or explicitly excluded it.

## Post-merge

Argo will roll affected deployments and patch the CNPG cluster affinity. Verify pods consolidate on `raspberrypi-03` and `umami-20260614-0001-1` becomes Ready.

Left on fast nodes: blocky, happy, home-assistant, TeslaMate CNPG, changedetection (PVC-bound or intentionally excluded).