### PR TITLE
fix(monitoring): keep Loki single-binary off ambient mesh

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -139,6 +139,9 @@ loki:
     resources: *smallResources
   singleBinary:
     replicas: 1
+    podLabels:
+      # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
+      istio.io/dataplane-mode: none
     affinity: *excludeSdCardNodeAffinity
     resources:
       # Keep the single-binary pod (plus 128Mi sidecar) schedulable on memory-tight Pi nodes.


### PR DESCRIPTION
## Summary

Label the Loki single-binary pod with `istio.io/dataplane-mode=none` so non-ambient fluent-bit can reach ingestion. Avoids annotating the Service, which would require gateway and cache pods to opt out as well per Kyverno.

## Test plan

- [x] `make test`
- [x] `monitoring-loki-0` accepts pushes from non-ambient callers after rollout
- [x] fluent-bit flush chunks succeed