### PR TITLE
fix(argocd): clear OutOfSync drift across four apps

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -51,6 +51,21 @@ local cleanerExcludeDeleted = [{
   jqPathExpressions: ['.spec.resourcePolicySet.resourceSelectors[].excludeDeleted'],
 }];
 
+local cnpgClusterOperatorDefaults = [{
+  group: 'postgresql.cnpg.io',
+  kind: 'Cluster',
+  jqPathExpressions: [
+    '.metadata.annotations["kubectl.kubernetes.io/restartedAt"]',
+    '.metadata.annotations["cnpg.io/reloadedAt"]',
+    '.spec.bootstrap.initdb.encoding',
+    '.spec.bootstrap.initdb.localeCType',
+    '.spec.bootstrap.initdb.localeCollate',
+    '.spec.managed.roles[].inherit',
+    '.spec.probes',
+    '.spec.storage.resizeInUseVolumes',
+  ],
+}];
+
 local _ignoreDifferences = {
   bootstrap: {
     metallb: crdConversionCABundle('bgppeers.metallb.io'),
@@ -179,6 +194,8 @@ local database = [
     name: 'cloudnative-pg-clusters',
     namespace: 'cnpg-system',
     helm: cnpgClustersHelm,
+    syncOptions: ['RespectIgnoreDifferences=true'],
+    ignoreDifferences: cnpgClusterOperatorDefaults,
   },
 ];
 

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -45,6 +45,11 @@ loadBalancerIPPool:
   cidr: 192.168.10.51/32
 
 envoy-gateway:
+  # gateway-api owns the safe-upgrade ValidatingAdmissionPolicy.
+  crds:
+    gatewayAPI:
+      safeUpgradePolicy:
+        enabled: false
   deployment:
     envoyGateway:
       resources: *envoyGatewayResources

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -139,6 +139,9 @@ loki:
     resources: *smallResources
   singleBinary:
     replicas: 1
+    podLabels:
+      # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
+      istio.io/dataplane-mode: none
     affinity: *excludeSdCardNodeAffinity
     resources:
       # Keep the single-binary pod (plus 128Mi sidecar) schedulable on memory-tight Pi nodes.

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -24,8 +24,8 @@ reloader:
             - weight: 100
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
-        tolerations:
-          - key: node.siutsin.com/storage-tier
-            operator: Equal
-            value: sd-card
-            effect: PreferNoSchedule
+      tolerations:
+        - key: node.siutsin.com/storage-tier
+          operator: Equal
+          value: sd-card
+          effect: PreferNoSchedule


### PR DESCRIPTION
## Summary

- Fix reloader Argo CD comparison error by moving tolerations to the deployment pod spec (they were nested under affinity).
- Stop envoy-gateway from rendering the gateway safe-upgrade ValidatingAdmissionPolicy; gateway-api already owns that resource.
- Ignore CNPG operator-populated Cluster fields so cloudnative-pg-clusters stays Synced after live reconciliation.

## Test plan

- [x] `make test`
- [ ] Argo CD apps `reloader`, `envoy-gateway`, `cloudnative-pg-clusters`, and `longhorn-config` report Synced