### PR TITLE
refactor(scheduling): use otaru.io node storage-tier label key

### DIFF
--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: NotIn
                     values:
                       - sd-card

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: NotIn
                     values:
                       - sd-card

--- a/helm-charts/changedetection/templates/deployment.yaml
+++ b/helm-charts/changedetection/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: NotIn
                     values:
                       - sd-card

--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -21,7 +21,7 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: node.siutsin.com/storage-tier
+            - key: node.otaru.io/storage-tier
               operator: In
               values:
                 - sd-card
@@ -35,7 +35,7 @@ affinity:
           topologyKey: kubernetes.io/hostname
 
 tolerations:
-  - key: node.siutsin.com/storage-tier
+  - key: node.otaru.io/storage-tier
     operator: Equal
     value: sd-card
     effect: PreferNoSchedule

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -15,7 +15,7 @@ defaults:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - matchExpressions:
-                - key: node.siutsin.com/storage-tier
+                - key: node.otaru.io/storage-tier
                   operator: NotIn
                   values:
                     - sd-card
@@ -25,7 +25,7 @@ defaults:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - matchExpressions:
-                - key: node.siutsin.com/storage-tier
+                - key: node.otaru.io/storage-tier
                   operator: In
                   values:
                     - sd-card

--- a/helm-charts/cyberchef/templates/deployment.yaml
+++ b/helm-charts/cyberchef/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -66,7 +66,7 @@ spec:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -69,7 +69,7 @@ spec:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/happy/templates/deployment.yaml
+++ b/helm-charts/happy/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: NotIn
                     values:
                       - sd-card

--- a/helm-charts/home-assistant/values.yaml
+++ b/helm-charts/home-assistant/values.yaml
@@ -9,7 +9,7 @@ deployment:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node.siutsin.com/storage-tier
+              - key: node.otaru.io/storage-tier
                 operator: NotIn
                 values:
                   - sd-card

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -38,7 +38,7 @@ spec:
                         - {{ .Values.name }}
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -53,7 +53,7 @@ spec:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -38,7 +38,7 @@ spec:
                         - {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -20,7 +20,7 @@ kubernetes-mcp-server:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node.siutsin.com/storage-tier
+              - key: node.otaru.io/storage-tier
                 operator: In
                 values:
                   - sd-card
@@ -30,7 +30,7 @@ kubernetes-mcp-server:
           podAffinityTerm:
             topologyKey: kubernetes.io/hostname
   tolerations:
-    - key: node.siutsin.com/storage-tier
+    - key: node.otaru.io/storage-tier
       operator: Equal
       value: sd-card
       effect: PreferNoSchedule

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -7,7 +7,7 @@ _shared:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node.siutsin.com/storage-tier
+              - key: node.otaru.io/storage-tier
                 operator: NotIn
                 values:
                   - sd-card

--- a/helm-charts/openclaw/templates/deployment.yaml
+++ b/helm-charts/openclaw/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -48,7 +48,7 @@ spec:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -15,7 +15,7 @@ reloader:
             - weight: 100
               preference:
                 matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -25,7 +25,7 @@ reloader:
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -257,7 +257,7 @@ spec:
                         requiredDuringSchedulingIgnoredDuringExecution:
                           nodeSelectorTerms:
                             - matchExpressions:
-                                - key: node.siutsin.com/storage-tier
+                                - key: node.otaru.io/storage-tier
                                   operator: NotIn
                                   values:
                                     - sd-card

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -12,7 +12,7 @@ deployment:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node.siutsin.com/storage-tier
+              - key: node.otaru.io/storage-tier
                 operator: NotIn
                 values:
                   - sd-card
@@ -80,7 +80,7 @@ grafana:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node.siutsin.com/storage-tier
+              - key: node.otaru.io/storage-tier
                 operator: NotIn
                 values:
                   - sd-card

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node.siutsin.com/storage-tier
+                  - key: node.otaru.io/storage-tier
                     operator: In
                     values:
                       - sd-card
@@ -75,7 +75,7 @@ spec:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
       tolerations:
-        - key: node.siutsin.com/storage-tier
+        - key: node.otaru.io/storage-tier
           operator: Equal
           value: sd-card
           effect: PreferNoSchedule


### PR DESCRIPTION
## Summary

- Rename the node storage-tier label and taint key from a personal-domain prefix to `node.otaru.io/storage-tier` across Helm scheduling config (affinity, tolerations, CNPG anchors).
- Migrated `raspberrypi-03` live label/taint to the new key.

## Test plan

- [x] `make test`
- [x] `kubectl get node raspberrypi-03` shows `node.otaru.io/storage-tier=sd-card` label and matching taint
- [ ] Argo sync; movable workloads still schedule on pi-03 as before