### PR TITLE
Enable node03 NVMe for Longhorn and remove sd-card scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Current cluster layout:
 | `raspberrypi-00`  | [Raspberry Pi 5 8GB][rpi5]                                     | Control plane  | [Lexar NM620 256GB][lexar-nm620]       |
 | `raspberrypi-01`  | Raspberry Pi 5 8GB                                             | Control plane  | [Crucial P3 Plus 4TB][crucial-p3-plus] |
 | `raspberrypi-02`  | Raspberry Pi 5 8GB                                             | Control plane  | Crucial P3 Plus 4TB                    |
-| `raspberrypi-03`  | Raspberry Pi 5 8GB                                             | Worker         | SanDisk Max Endurance 32 GB            |
+| `raspberrypi-03`  | Raspberry Pi 5 8GB                                             | Worker         | [Crucial P2 500GB][crucial-p2]         |
 | `nuc-00`[^nuc-00] | [Intel NUC Mini PC Core i3-3217U DC3217IYE 8GB][intel-nuc-8gb] | Worker         | 64 GB SSD                              |
 | `ucg-ultra`       | [UniFi Cloud Gateway Ultra][ucg-ultra]                         | Router/Gateway | -                                      |
 | `usw-ultra`       | [UniFi Switch Ultra][usw-ultra]                                | PoE switch     | -                                      |
@@ -60,6 +60,7 @@ Three nodes form the control plane. Two nodes remain workers, including temporar
 
 [lexar-nm620]: https://www.lexar.com/global/products/Lexar-NM620-M-2-2280-NVMe-SSD/
 [crucial-p3-plus]: https://www.crucial.com/ssd/p3-plus/ct4000p3pssd8
+[crucial-p2]: https://www.crucial.com/ssd/p2/ct500p2ssd8
 [intel-nuc-8gb]: https://www.intel.com/content/www/us/en/products/sku/71275/intel-nuc-kit-dc3217iye/specifications.html
 [rackmate-t1]: https://www.amazon.co.uk/dp/B0CS6MHCY8
 [rack-mount]: https://www.amazon.co.uk/dp/B0DRGF68Z9

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -70,6 +70,7 @@ all:
         node00: { }
         node01: { }
         node02: { }
+        node03: { }
         node20: { }
     raspberrypi:
       vars:

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -27,6 +27,22 @@
       run_once: true
       no_log: true
 
+    - name: Get k3s release version from master
+      shell: set -o pipefail && k3s --version | awk '/k3s version/ { print $3 }'
+      args:
+        executable: /bin/bash
+      register: k3s_release_version
+      run_once: true
+      delegate_to: "{{ groups['master'][0] }}"
+      changed_when: false
+
+    - name: Share k3s release version with subsequent tasks
+      set_fact:
+        k3s_release_version: "{{ k3s_release_version.stdout }}"
+      delegate_to: localhost
+      delegate_facts: true
+      run_once: true
+
     - name: Install k3s on master nodes with LB_API_SERVER_IP
       # Enable anonymous authentication
       # https://stackoverflow.com/questions/74603633/k3s-allow-unauthenticated-access-to-oidc-endpoints
@@ -104,6 +120,7 @@
     - name: Install k3s on workers
       shell: |
         curl -sfL https://get.k3s.io | \
+          INSTALL_K3S_VERSION={{ hostvars['localhost']['k3s_release_version'] }} \
           INSTALL_K3S_CHANNEL={{ K3S_CHANNEL }} \
           INSTALL_K3S_SKIP_DOWNLOAD=false \
           K3S_TOKEN={{ hostvars['localhost']['k3s_master_token'] }} \

--- a/ansible/playbooks/luks.yaml
+++ b/ansible/playbooks/luks.yaml
@@ -4,6 +4,7 @@
   gather_facts: false
 
   vars:
+    otaru_repo_root: "{{ playbook_dir }}/../.."
     target_node: "{{ target_node | default('', true) }}"
     expected_disk_model_substring: "{{ expected_disk_model_substring | default('', true) }}"
     luks_rescue_host: "{{ luks_rescue_host | default('192.168.10.40', true) }}"

--- a/ansible/playbooks/rpi/luks/setup.yaml
+++ b/ansible/playbooks/rpi/luks/setup.yaml
@@ -18,10 +18,10 @@
   set_fact:
     luks_target_hostname: "{{ luks_target_inventory_host | regex_replace('\\.local$', '') }}"
     luks_target_ip: "{{ hostvars[luks_target_inventory_host].ansible_host }}"
-    luks_target_gateway: "{{ hostvars[luks_target_inventory_host].luks_initramfs_gateway }}"
-    luks_target_netmask: "{{ hostvars[luks_target_inventory_host].luks_initramfs_netmask }}"
-    luks_target_dns: "{{ hostvars[luks_target_inventory_host].luks_initramfs_dns }}"
-    luks_target_dropbear_port: "{{ hostvars[luks_target_inventory_host].luks_dropbear_port }}"
+    luks_target_gateway: "{{ hostvars[luks_target_inventory_host].luks_initramfs_gateway | default('192.168.10.1', true) }}"
+    luks_target_netmask: "{{ hostvars[luks_target_inventory_host].luks_initramfs_netmask | default('255.255.255.0', true) }}"
+    luks_target_dns: "{{ hostvars[luks_target_inventory_host].luks_initramfs_dns | default('192.168.10.1', true) }}"
+    luks_target_dropbear_port: "{{ hostvars[luks_target_inventory_host].luks_dropbear_port | default('1024', true) }}"
 
 - name: Assert a LUKS password source is configured
   assert:
@@ -62,273 +62,23 @@
     delay: 2
     timeout: 600
 
-- name: Read rescue host authorized keys
-  slurp:
-    src: "{{ luks_rescue_authorized_keys_src }}"
-  delegate_to: luks_rescue_runtime
-  no_log: true
-  register: rescue_authorized_keys
-
-- name: Stage LUKS password on rescue host
-  copy:
-    content: "{{ luks_password_value }}"
-    dest: /root/luks-pass
-    owner: root
-    group: root
-    mode: "0600"
-  delegate_to: luks_rescue_runtime
-  become: true
-  no_log: true
-
 - name: Rebuild target disk into clean encrypted-root state on rescue host
-  shell: |
-    set -euo pipefail
-
-    img="{{ luks_remote_image_path }}"
-    disk="{{ luks_target_disk }}"
-    boot="${disk}p1"
-    root="${disk}p2"
-    mapper="cryptroot"
-    expected_disk_model_substring="{{ expected_disk_model_substring }}"
-    minimum_disk_size_bytes="{{ luks_minimum_disk_size_bytes }}"
-    ip_line="{{ luks_target_ip }}::{{ luks_target_gateway }}:{{ luks_target_netmask }}:{{ luks_target_hostname }}:eth0:off:{{ luks_target_dns }}"
-    work_dir="$(mktemp -d /tmp/luks-node-init.XXXXXX)"
-    src_boot="$work_dir/src-boot"
-    src_root="$work_dir/src-root"
-    dst_root="$work_dir/dst-root"
-    loop_dev=""
-    pass_file="/root/luks-pass"
-
-    cleanup() {
-      set +e
-      umount "$dst_root/dev/pts" 2>/dev/null || true
-      umount "$dst_root/boot/firmware" 2>/dev/null || true
-      umount "$dst_root/dev" 2>/dev/null || true
-      umount "$dst_root/proc" 2>/dev/null || true
-      umount "$dst_root/sys" 2>/dev/null || true
-      umount "$dst_root/run" 2>/dev/null || true
-      umount "$src_boot" 2>/dev/null || true
-      umount "$src_root" 2>/dev/null || true
-      umount "$dst_root" 2>/dev/null || true
-      cryptsetup close "$mapper" 2>/dev/null || true
-      if [[ -n "$loop_dev" ]]; then
-        losetup -d "$loop_dev"
-      fi
-      rm -f "$pass_file"
-      rm -rf "$work_dir"
-    }
-    trap cleanup EXIT
-
-    mkdir -p "$src_boot" "$src_root" "$dst_root"
-
-    umount -R /mnt/dst-root/boot/firmware 2>/dev/null || true
-    umount -R /mnt/dst-root 2>/dev/null || true
-    cryptsetup close "$mapper" 2>/dev/null || true
-
-    for mounted_target in $(findmnt -rn -S "$boot" -o TARGET 2>/dev/null); do
-      umount -R "$mounted_target" 2>/dev/null || true
-    done
-    for mounted_target in $(findmnt -rn -S "/dev/mapper/$mapper" -o TARGET 2>/dev/null); do
-      umount -R "$mounted_target" 2>/dev/null || true
-    done
-    cryptsetup close "$mapper" 2>/dev/null || true
-
-    if [[ ! -b "$disk" ]]; then
-      echo "Refusing to wipe $disk because it is not a block device." >&2
-      exit 1
-    fi
-
-    disk_type="$(lsblk -dn -o TYPE "$disk" 2>/dev/null || true)"
-    if [[ "$disk_type" != "disk" ]]; then
-      echo "Refusing to wipe $disk because its device type is '$disk_type', not 'disk'." >&2
-      exit 1
-    fi
-
-    disk_removable="$(lsblk -dn -o RM "$disk" 2>/dev/null || true)"
-    if [[ "$disk_removable" == "1" ]]; then
-      echo "Refusing to wipe $disk because it is marked removable on the rescue host." >&2
-      exit 1
-    fi
-
-    disk_model="$(lsblk -dn -o MODEL "$disk" 2>/dev/null || true)"
-    if [[ "$disk_model" != *"$expected_disk_model_substring"* ]]; then
-      echo "Refusing to wipe $disk because model '$disk_model' does not contain '$expected_disk_model_substring'." >&2
-      exit 1
-    fi
-
-    disk_size_bytes="$(blockdev --getsize64 "$disk" 2>/dev/null || true)"
-    if [[ -z "$disk_size_bytes" || "$disk_size_bytes" -lt "$minimum_disk_size_bytes" ]]; then
-      echo "Refusing to wipe $disk because size '$disk_size_bytes' is below minimum '$minimum_disk_size_bytes' bytes." >&2
-      exit 1
-    fi
-
-    if findmnt -rn -S "$disk" >/dev/null 2>&1; then
-      echo "Refusing to wipe $disk because it is mounted on the rescue host." >&2
-      exit 1
-    fi
-
-    root_source="$(findmnt -rn -o SOURCE / || true)"
-    if [[ "$root_source" == "$disk" || "$root_source" == "$boot" || "$root_source" == "$root" ]]; then
-      echo "Refusing to wipe $disk because it backs the rescue host root filesystem." >&2
-      exit 1
-    fi
-
-    lsblk -o NAME,TYPE,RM,SIZE,MODEL,FSTYPE,MOUNTPOINTS "$disk"
-    blkdiscard -f "$disk"
-    sgdisk -og \
-      -n 1:2048:+512M -t 1:0700 -c 1:system-boot \
-      -n 2:0:0 -t 2:8300 -c 2:writable \
-      "$disk"
-    partprobe "$disk"
-    udevadm settle
-
-    mkfs.vfat -F 32 -n system-boot "$boot"
-    cryptsetup luksFormat --batch-mode --type luks2 --pbkdf argon2id --key-file "$pass_file" "$root"
-    cryptsetup open --key-file "$pass_file" "$root" "$mapper"
-    mkfs.ext4 -F -L writable "/dev/mapper/$mapper"
-
-    loop_dev="$(losetup --show -Pf "$img")"
-    mount -o ro "${loop_dev}p1" "$src_boot"
-    mount -o ro "${loop_dev}p2" "$src_root"
-    mount "/dev/mapper/$mapper" "$dst_root"
-    mkdir -p "$dst_root/boot/firmware"
-    mount "$boot" "$dst_root/boot/firmware"
-
-    rsync -aHAX --delete --exclude=/boot/firmware "$src_root/" "$dst_root/"
-    rsync -aHAX --delete "$src_boot/" "$dst_root/boot/firmware/"
-
-    cat > "$dst_root/boot/firmware/user-data" <<USERDATA
-    #cloud-config
-    hostname: {{ luks_target_hostname }}
-    manage_etc_hosts: true
-
-    users:
-      - name: pi
-        groups: sudo
-        shell: /bin/bash
-        sudo: ALL=(ALL) NOPASSWD:ALL
-        ssh_authorized_keys:
-    {{ rescue_authorized_keys.content | b64decode | regex_replace('(?m)^', '          - ') }}
-    USERDATA
-
-    cat > "$dst_root/boot/firmware/network-config" <<NETCFG
-    version: 2
-    ethernets:
-      eth0:
-        dhcp4: false
-        addresses:
-          - {{ luks_target_ip }}/24
-        routes:
-          - to: default
-            via: {{ luks_target_gateway }}
-        nameservers:
-          addresses:
-            - {{ luks_target_dns }}
-    NETCFG
-
-    if ! grep -q '^dtparam=pciex1$' "$dst_root/boot/firmware/config.txt"; then
-      printf '\n[all]\ndtparam=pciex1\ndtparam=pciex1_gen=3\n' >> "$dst_root/boot/firmware/config.txt"
-    fi
-
-    sed -i 's#root=LABEL=writable#root=/dev/mapper/cryptroot#' "$dst_root/boot/firmware/cmdline.txt"
-    if ! grep -q 'rootdelay=10' "$dst_root/boot/firmware/cmdline.txt"; then
-      sed -i 's# rootwait# rootwait rootdelay=10#' "$dst_root/boot/firmware/cmdline.txt"
-    fi
-
-    root_uuid="$(blkid -s UUID -o value "$root")"
-    boot_uuid="$(blkid -s UUID -o value "$boot")"
-
-    cat > "$dst_root/etc/crypttab" <<CRYPTTAB
-    cryptroot UUID=${root_uuid} none luks,discard
-    CRYPTTAB
-
-    cat > "$dst_root/etc/fstab" <<FSTAB
-    /dev/mapper/cryptroot / ext4 defaults 0 1
-    UUID=${boot_uuid} /boot/firmware vfat defaults 0 1
-    FSTAB
-
-    rm -f "$dst_root/etc/resolv.conf"
-    cp /etc/resolv.conf "$dst_root/etc/resolv.conf"
-
-    mkdir -p "$dst_root/etc/dropbear/initramfs"
-    cat > "$dst_root/etc/dropbear/initramfs/authorized_keys" <<AUTHKEYS
-    {{ rescue_authorized_keys.content | b64decode }}
-    AUTHKEYS
-    chmod 600 "$dst_root/etc/dropbear/initramfs/authorized_keys"
-
-    mount --bind /dev "$dst_root/dev"
-    mkdir -p "$dst_root/dev/pts"
-    mount -t devpts devpts "$dst_root/dev/pts"
-    mount --bind /proc "$dst_root/proc"
-    mount --bind /sys "$dst_root/sys"
-    mount --bind /run "$dst_root/run"
-
-    chroot "$dst_root" /usr/bin/env DEBIAN_FRONTEND=noninteractive apt-get update
-    chroot "$dst_root" /usr/bin/env DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade
-    chroot "$dst_root" /usr/bin/env DEBIAN_FRONTEND=noninteractive apt-get \
-      -o Dpkg::Options::=--force-confdef \
-      -o Dpkg::Options::=--force-confold \
-      install -y cryptsetup-initramfs dropbear-initramfs
-
-    cat > "$dst_root/etc/dropbear/initramfs/dropbear.conf" <<DROPBEARCONF
-    DROPBEAR_OPTIONS="-I 180 -p {{ luks_target_dropbear_port }} -j -k -s"
-    DROPBEARCONF
-
-    if grep -q '^DROPBEAR=' "$dst_root/etc/initramfs-tools/initramfs.conf"; then
-      sed -i 's/^DROPBEAR=.*/DROPBEAR=y/' "$dst_root/etc/initramfs-tools/initramfs.conf"
-    else
-      echo 'DROPBEAR=y' >> "$dst_root/etc/initramfs-tools/initramfs.conf"
-    fi
-
-    if grep -q '^IP=' "$dst_root/etc/initramfs-tools/initramfs.conf"; then
-      sed -i "s#^IP=.*#IP=${ip_line}#" "$dst_root/etc/initramfs-tools/initramfs.conf"
-    else
-      echo "IP=${ip_line}" >> "$dst_root/etc/initramfs-tools/initramfs.conf"
-    fi
-
-    cat > "$dst_root/etc/initramfs-tools/modules" <<MODULES
-    nvme
-    nvme-core
-    dm_mod
-    dm_crypt
-    MODULES
-
-    chroot "$dst_root" update-initramfs -u -k all
-
-    mkdir -p "$dst_root/boot/firmware"
-    mountpoint -q "$dst_root" || mount "/dev/mapper/$mapper" "$dst_root"
-    mountpoint -q "$dst_root/boot/firmware" || mount "$boot" "$dst_root/boot/firmware"
-
-    kver="$(chroot "$dst_root" /bin/sh -c 'ls -1 /lib/modules | sort -V | tail -n 1')"
-    dtb_dir="$dst_root/usr/lib/firmware/$kver/device-tree/broadcom"
-
-    if [[ ! -d "$dtb_dir" ]]; then
-      echo "Expected DTB directory not found: $dtb_dir" >&2
-      exit 1
-    fi
-
-    cp "$dst_root/boot/vmlinuz-$kver" "$dst_root/boot/firmware/vmlinuz"
-    cp "$dst_root/boot/initrd.img-$kver" "$dst_root/boot/firmware/initrd.img"
-    shopt -s nullglob
-    dtb_files=("$dtb_dir"/*.dtb)
-    shopt -u nullglob
-    if [[ ${#dtb_files[@]} -eq 0 ]]; then
-      echo "Expected at least one DTB under $dtb_dir" >&2
-      exit 1
-    fi
-    cp "${dtb_files[@]}" "$dst_root/boot/firmware/"
-    rsync -a "$dst_root/usr/lib/firmware/$kver/device-tree/overlays/" "$dst_root/boot/firmware/overlays/"
-  args:
-    executable: /bin/bash
-  delegate_to: luks_rescue_runtime
-  become: true
-
-- name: Remove staged LUKS password from rescue host
-  file:
-    path: /root/luks-pass
-    state: absent
-  delegate_to: luks_rescue_runtime
-  become: true
+  ansible.builtin.command: "{{ otaru_repo_root }}/hack/luks-node-init.sh"
+  environment:
+    RESCUE_HOST: "{{ luks_rescue_user }}@{{ luks_rescue_host }}"
+    REMOTE_IMAGE_PATH: "{{ luks_remote_image_path }}"
+    TARGET_DISK: "{{ luks_target_disk }}"
+    TARGET_HOSTNAME: "{{ luks_target_hostname }}"
+    TARGET_IP: "{{ luks_target_ip }}"
+    TARGET_GATEWAY: "{{ luks_target_gateway }}"
+    TARGET_NETMASK: "{{ luks_target_netmask }}"
+    TARGET_DNS: "{{ luks_target_dns }}"
+    DROPBEAR_PORT: "{{ luks_target_dropbear_port | string }}"
+    EXPECTED_DISK_MODEL_SUBSTRING: "{{ expected_disk_model_substring }}"
+    MINIMUM_DISK_SIZE_BYTES: "{{ luks_minimum_disk_size_bytes | string }}"
+    LUKS_NODE_INIT_CONFIRM: "yes"
+    LUKS_PASSWORD_FILE: "{{ luks_password_file }}"
+    OTARU_LUKS_PASSWORD: "{{ luks_password_value | default('', true) }}"
   no_log: true
 
 - name: Power off rescue host after rebuild

--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -24,14 +24,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: NotIn
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -19,15 +19,6 @@ spec:
         app.kubernetes.io/name: {{ .Values.browser.name }}
         app.kubernetes.io/part-of: {{ .Values.name }}
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: NotIn
-                    values:
-                      - sd-card
       automountServiceAccountToken: false
       securityContext:
         fsGroup: {{ .Values.browser.profile.fsGroup }}

--- a/helm-charts/changedetection/templates/deployment.yaml
+++ b/helm-charts/changedetection/templates/deployment.yaml
@@ -22,14 +22,6 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: NotIn
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -17,14 +17,6 @@ resources:
     ephemeral-storage: 64Mi
 
 affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: node.otaru.io/storage-tier
-              operator: In
-              values:
-                - sd-card
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100
@@ -34,8 +26,4 @@ affinity:
               pod: cloudflared
           topologyKey: kubernetes.io/hostname
 
-tolerations:
-  - key: node.otaru.io/storage-tier
-    operator: Equal
-    value: sd-card
-    effect: PreferNoSchedule
+

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -9,26 +9,6 @@ backup:
 
 defaults:
   cluster:
-    affinity: &excludeSdCardClusterAffinity
-      podAntiAffinityType: preferred
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node.otaru.io/storage-tier
-                  operator: NotIn
-                  values:
-                    - sd-card
-    affinitySdCard: &sdCardClusterAffinity
-      podAntiAffinityType: preferred
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node.otaru.io/storage-tier
-                  operator: In
-                  values:
-                    - sd-card
     instances: 1
     enablePDB: true
     failoverDelay: 0
@@ -134,7 +114,6 @@ clusters:
       size: 15Gi
       storageClass: longhorn-crypto-global
     affinity:
-      <<: *excludeSdCardClusterAffinity
       podAntiAffinityType: required
     instances: 2
     minSyncReplicas: 1
@@ -182,8 +161,6 @@ clusters:
     storage:
       size: 2Gi
       storageClass: longhorn-crypto-global
-    affinity:
-      <<: *sdCardClusterAffinity
     postgresql:
       <<: *postgresql
       pg_hba:

--- a/helm-charts/cyberchef/templates/deployment.yaml
+++ b/helm-charts/cyberchef/templates/deployment.yaml
@@ -49,14 +49,6 @@ spec:
               memory: 100Mi
               ephemeral-storage: 100Mi
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -65,8 +57,4 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule
+

--- a/helm-charts/excalidraw/templates/deployment.yaml
+++ b/helm-charts/excalidraw/templates/deployment.yaml
@@ -52,14 +52,6 @@ spec:
               memory: 128Mi
               ephemeral-storage: 100Mi
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -68,8 +60,3 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule

--- a/helm-charts/happy/templates/deployment.yaml
+++ b/helm-charts/happy/templates/deployment.yaml
@@ -88,14 +88,6 @@ spec:
           emptyDir: {}
           {{- end }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: NotIn
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/helm-charts/home-assistant/values.yaml
+++ b/helm-charts/home-assistant/values.yaml
@@ -5,14 +5,6 @@ ip: 192.168.10.51
 
 deployment:
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.otaru.io/storage-tier
-                operator: NotIn
-                values:
-                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -18,14 +18,6 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -37,11 +29,6 @@ spec:
                       values:
                         - {{ .Values.name }}
                 topologyKey: "kubernetes.io/hostname"
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule
       automountServiceAccountToken: false
       containers:
         - name: {{ .Values.name }}

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -36,14 +36,6 @@ spec:
               path: /
               port: http
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -52,8 +44,3 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -18,14 +18,6 @@ spec:
         app.kubernetes.io/version: {{ $version | quote }}
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -37,11 +29,6 @@ spec:
                       values:
                         - {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule
       serviceAccountName: {{ .Values.name }}
       containers:
         - name: {{ .Values.name }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -16,21 +16,9 @@ kubernetes-mcp-server:
       memory: 128Mi
       ephemeral-storage: 64Mi
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.otaru.io/storage-tier
-                operator: In
-                values:
-                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
           podAffinityTerm:
             topologyKey: kubernetes.io/hostname
-  tolerations:
-    - key: node.otaru.io/storage-tier
-      operator: Equal
-      value: sd-card
-      effect: PreferNoSchedule
+

--- a/helm-charts/longhorn-config/templates/node.yaml
+++ b/helm-charts/longhorn-config/templates/node.yaml
@@ -4,5 +4,5 @@ metadata:
   name: raspberrypi-03
   namespace: {{ .Values.namespace }}
 spec:
-  allowScheduling: false
+  allowScheduling: true
   name: raspberrypi-03

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -2,15 +2,6 @@ name: monitoring
 namespace: monitoring
 
 _shared:
-  excludeSdCardNodeAffinity: &excludeSdCardNodeAffinity
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.otaru.io/storage-tier
-                operator: NotIn
-                values:
-                  - sd-card
   smallResources: &smallResources
     requests:
       cpu: 50m
@@ -39,7 +30,6 @@ prometheus:
     prometheus:
       resources: *smallResources
   server:
-    affinity: *excludeSdCardNodeAffinity
     resources:
       # Keep memory at 3Gi: Grafana dashboard queries pushed Prometheus close to the previous 2Gi limit.
       requests:
@@ -90,7 +80,6 @@ prometheus:
                 )
 
 grafana:
-  affinity: *excludeSdCardNodeAffinity
   resources:
     # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
     requests:
@@ -142,7 +131,6 @@ loki:
     podLabels:
       # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
       istio.io/dataplane-mode: none
-    affinity: *excludeSdCardNodeAffinity
     resources:
       # Keep the single-binary pod (plus 128Mi sidecar) schedulable on memory-tight Pi nodes.
       requests:

--- a/helm-charts/openclaw/templates/deployment.yaml
+++ b/helm-charts/openclaw/templates/deployment.yaml
@@ -31,14 +31,6 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -47,11 +39,6 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule
       initContainers:
         - name: init-state
           image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -10,22 +10,9 @@ reloader:
           memory: 64Mi
           ephemeral-storage: 64Mi
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule
+

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -252,15 +252,6 @@ spec:
                     labels:
                       app.kubernetes.io/managed-by: teslamate-verify-pitr
                   spec:
-                    affinity:
-                      nodeAffinity:
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          nodeSelectorTerms:
-                            - matchExpressions:
-                                - key: node.otaru.io/storage-tier
-                                  operator: NotIn
-                                  values:
-                                    - sd-card
                     instances: 1
                     imageName: {{ .Values.backup.database.imageName }}
                     resources:

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -8,14 +8,6 @@ database:
 
 deployment:
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.otaru.io/storage-tier
-                operator: NotIn
-                values:
-                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
@@ -76,14 +68,6 @@ grafana:
       memory: 512Mi
       ephemeral-storage: 128Mi
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node.otaru.io/storage-tier
-                operator: NotIn
-                values:
-                  - sd-card
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -58,14 +58,6 @@ spec:
           secret:
             secretName: {{ .Values.database.caSecretName }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node.otaru.io/storage-tier
-                    operator: In
-                    values:
-                      - sd-card
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -74,8 +66,3 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
-      tolerations:
-        - key: node.otaru.io/storage-tier
-          operator: Equal
-          value: sd-card
-          effect: PreferNoSchedule


### PR DESCRIPTION
## Summary
- Add raspberrypi-03 to `luks_root_nodes` and fix LUKS Ansible playbook delegation
- Pin k3s worker install version to match cluster master
- Enable Longhorn scheduling on raspberrypi-03 (was disabled during SD card era)
- Remove sd-card node affinity, tolerations, and anchor labels across helm charts
- Update README with node03 Crucial P2 500GB storage details

## Test plan
- [x] `make test` (monitoring helm dep drift is pre-existing)
- [ ] Argo sync `longhorn-config` after merge
- [ ] Register Longhorn default disk on node03
- [ ] Verify openclaw and umami volumes reattach