### PR TITLE
Remove max-turns cap from Claude PR review

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -75,7 +75,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: false
           claude_args: |
-            --model claude-opus-4-8 --max-turns 10 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
+            --model claude-opus-4-8 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
           prompt: |
             Review only. Do not push commits, edit PR metadata, change labels, write repository content, or run code from the PR.
 


### PR DESCRIPTION
## Summary

Remove `--max-turns 10` from the Claude PR review workflow. Larger PRs (e.g. #2590) were hitting `error_max_turns` before the review could finish.

The existing `timeout-minutes: 15` job limit still bounds runtime.

## Note

This PR modifies `.github/workflows/claude.yaml`, so the Claude review job skips itself per the workflow guard.

## Test plan

- [x] YAML syntax check passes
- [x] zizmor audit passes