### PR TITLE
Disable Longhorn anonymous usage metrics collection

### DIFF
--- a/helm-charts/longhorn-config/templates/setting.yaml
+++ b/helm-charts/longhorn-config/templates/setting.yaml
@@ -1,0 +1,9 @@
+{{- range $name, $value := .Values.settings }}
+---
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Values.namespace }}
+value: {{ $value | quote }}
+{{- end }}

--- a/helm-charts/longhorn-config/values.yaml
+++ b/helm-charts/longhorn-config/values.yaml
@@ -1,6 +1,9 @@
 name: longhorn
 namespace: longhorn-system
 
+settings:
+  allow-collecting-longhorn-usage-metrics: "false"
+
 # Per-node Longhorn disk settings. Use a stable disk name (`default`) so rebuilds
 # get the same Node CR shape from Git instead of FSID-derived default-disk-<hex>.
 #

--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -9,6 +9,7 @@ longhorn:
     defaultClassReplicaCount: 2
     defaultDataLocality: disabled # change to best-effort once added more drives
   defaultSettings:
+    allowCollectingLonghornUsageMetrics: false
     defaultReplicaCount: 2
     replicaSoftAntiAffinity: false
     replicaAutoBalance: best-effort


### PR DESCRIPTION
## Summary

- Set `allowCollectingLonghornUsageMetrics: false` in the Longhorn Helm chart defaults
- Add a `longhorn-config` Setting CR so the live cluster value is enforced via GitOps (Helm defaults alone do not flip an existing setting)

## Test plan

- [x] `helm template` renders `allow-collecting-longhorn-usage-metrics: false`
- [x] Live cluster setting patched to `false`
- [ ] CI passes