### PR TITLE
Fix TeslaMate verify-pitr for Alpine /bin/sh

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -121,8 +121,9 @@ spec:
                   VERIFY_SOURCE_PRIMARY=$(kubectl get cluster "${VERIFY_SOURCE_CLUSTER}" -n "${VERIFY_NAMESPACE}" -o jsonpath='{.status.currentPrimary}')
                   VERIFY_CLUSTER_TIMELINE=$(kubectl get cluster "${VERIFY_SOURCE_CLUSTER}" -n "${VERIFY_NAMESPACE}" -o jsonpath='{.status.timelineID}')
                   VERIFY_BACKUP_JSONPATH='{range .items[*]}{.spec.cluster.name}{"|"}'
-                  VERIFY_BACKUP_JSONPATH+='{.status.stoppedAt}{"|"}{.status.backupId}{"|"}{.status.phase}{"|"}'
-                  VERIFY_BACKUP_JSONPATH+='{.status.pluginMetadata.timeline}{"\n"}{end}'
+                  VERIFY_BACKUP_JSONPATH="${VERIFY_BACKUP_JSONPATH}{.status.stoppedAt}{\"|\"}"
+                  VERIFY_BACKUP_JSONPATH="${VERIFY_BACKUP_JSONPATH}{.status.backupId}{\"|\"}{.status.phase}{\"|\"}"
+                  VERIFY_BACKUP_JSONPATH="${VERIFY_BACKUP_JSONPATH}{.status.pluginMetadata.timeline}{\"\\n\"}{end}"
                   VERIFY_BACKUP_META=$(
                     kubectl get backups.postgresql.cnpg.io \
                       -n "${VERIFY_NAMESPACE}" \


### PR DESCRIPTION
## Problem

The `teslamate-verify-pitr` CronJob runs under Alpine `/bin/sh`, but the backup jsonpath builder used bash-only `+=` syntax. The job failed immediately at 14:00 UTC today with:

```
/bin/sh: VERIFY_BACKUP_JSONPATH+=...: not found
```

That prevented the Healthchecks heartbeat from firing, which triggered the alert.

## Fix

Build `VERIFY_BACKUP_JSONPATH` with POSIX parameter expansion instead of bash `+=`.

## Verification

- `sh -n` passes on the rendered script
- Manual job `teslamate-verify-pitr-manual-1782139077` progressed past backup selection and started the PITR restore cluster