### PR TITLE
Fix kubeconfig VIP replacement and monitoring prometheus chart version

### DIFF
--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -77,11 +77,11 @@
       run_once: true
       changed_when: false
 
-    - name: Replace '127.0.0.1' with first master IP in local kube config
+    - name: Replace '127.0.0.1:6443' with LB VIP in local kube config
       replace:
         path: "{{ LOCAL_KUBECONFIG_PATH }}"
-        regexp: '127.0.0.1'
-        replace: "{{ hostvars[groups['master'][0]]['ansible_host'] }}"
+        regexp: '127\.0\.0\.1:6443'
+        replace: "{{ LB_API_SERVER_IP }}"
       delegate_to: localhost
       become: yes
       become_user: simon

--- a/helm-charts/monitoring/Chart.lock
+++ b/helm-charts/monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 29.12.0
+  version: 29.11.0
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 7.0.0
@@ -11,5 +11,5 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 10.5.15
-digest: sha256:ee40a0acbdfdd5f29531c1aa95a81b4187a5669fceff3c233ffd9d35486792e3
-generated: "2026-06-22T03:04:01.172329622Z"
+digest: sha256:da30844fd2522194708abebefc2b06d8ceeb7f39457ff6d47cadea41a38b22a1
+generated: "2026-06-22T16:16:22.568546+01:00"

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.2
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: prometheus
-  version: 29.12.0
+  version: 29.11.0
   repository: https://prometheus-community.github.io/helm-charts
 - name: loki
   version: 7.0.0


### PR DESCRIPTION
## Summary

- Ansible `000-init-cluster.yaml`: replace `127.0.0.1:6443` directly with `LB_API_SERVER_IP` so the generated kubeconfig points at the API server VIP (`192.168.10.50`) rather than stopping at the first control-plane node IP (`192.168.10.60:6443`)
- `helm-charts/monitoring/Chart.yaml`: roll prometheus back from `29.12.0` to `29.11.0` — `29.12.0` does not exist in the prometheus-community helm repository, causing `make test` to fail

## Test plan

- [x] `make test` passes
- [ ] Confirm `kubectl cluster-info` points to `192.168.10.50` after re-running the init playbook on a fresh cluster