### PR TITLE
Work around e1000e NIC hang on nuc-00

### DIFF
--- a/ansible/playbooks/nuc/000-e1000e-offload.yaml
+++ b/ansible/playbooks/nuc/000-e1000e-offload.yaml
@@ -1,0 +1,37 @@
+---
+- hosts: node20
+  become: true
+  gather_facts: false
+
+  # Disable segmentation and receive offloads on the Intel 82579V NIC to work
+  # around the e1000e "Detected Hardware Unit Hang" TX-queue stall. The hang
+  # took nuc-00 NotReady on 2026-06-28: the NIC stopped transmitting while the
+  # OS kept running, so the kubelet could not reach the API server.
+  # See documentation/gotcha.md - e1000e Detected Hardware Unit Hang.
+  tasks:
+    - name: Configure e1000e offload link options
+      copy:
+        dest: /etc/systemd/network/10-eno1-offload.link
+        content: |
+          # Work around the e1000e "Detected Hardware Unit Hang" on Intel 82579V.
+          # See documentation/gotcha.md - e1000e Detected Hardware Unit Hang.
+          [Match]
+          OriginalName=eno1
+
+          [Link]
+          TCPSegmentationOffload=false
+          GenericSegmentationOffload=false
+          GenericReceiveOffload=false
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reapply udev link settings for eno1
+
+  handlers:
+    - name: Reapply udev link settings for eno1
+      # Toggling offload features does not bounce the carrier, so this is safe
+      # to apply live without dropping the node's only network path.
+      shell: |
+        udevadm control --reload
+        udevadm trigger --action=add /sys/class/net/eno1
+      changed_when: true

--- a/ansible/playbooks/setup.yaml
+++ b/ansible/playbooks/setup.yaml
@@ -9,6 +9,8 @@
 - import_playbook: rpi/004-cgroup.yaml
 - import_playbook: rpi/005-brcmfmac-options.yaml
 - import_playbook: rpi/006-firewall.yaml
+# nuc
+- import_playbook: nuc/000-e1000e-offload.yaml
 # k3s
 - import_playbook: k3s/000-init-cluster.yaml
 - import_playbook: k3s/001-cni.yaml

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -621,6 +621,76 @@ filesystem.
     when the node is otherwise healthy. Remove the old key for both the hostname and IP, or
     temporarily disable host key checking for that one rejoin run.
 
+---
+
+## e1000e Detected Hardware Unit Hang
+
+The `nuc-00` worker uses an onboard Intel 82579V Gigabit NIC (`eno1`, PCI
+`8086:1503`) driven by `e1000e`. This chipset can stall its transmit queue and
+log `Detected Hardware Unit Hang` repeatedly, after which the driver never
+recovers. The host stays up but loses all network, so the kubelet cannot reach
+the API server and the node goes NotReady while the box appears alive.
+
+### Symptoms: e1000e Hang
+
+- A node goes NotReady but its power light stays on and it keeps logging locally.
+- `ping` and the initramfs dropbear port are both unreachable.
+- The previous boot's kernel log shows repeated entries like:
+
+```text
+e1000e 0000:00:19.0 eno1: Detected Hardware Unit Hang:
+  TDH <f8>  TDT <e0>  next_to_use <e0>  next_to_clean <f6>
+```
+
+The TX descriptor head (`TDH`) and tail (`TDT`) never advance for the duration of
+the hang.
+
+### Cause: TX Offload Stall on 82579
+
+The hang is triggered by the NIC's TCP/generic segmentation offload path on this
+silicon. It is a long-standing `e1000e`/82579 hardware quirk, not a Kubernetes or
+k3s fault.
+
+### Resolution: Disable Segmentation and Receive Offloads
+
+Persist offload-disabling link settings with a systemd-networkd `.link` file. The
+`nuc/000-e1000e-offload.yaml` play (run by `make setup`) writes
+`/etc/systemd/network/10-eno1-offload.link`:
+
+```ini
+[Match]
+OriginalName=eno1
+
+[Link]
+TCPSegmentationOffload=false
+GenericSegmentationOffload=false
+GenericReceiveOffload=false
+```
+
+systemd-udevd applies these at device initialisation. To apply live without a
+reboot (toggling offloads does not bounce the carrier):
+
+```shell
+sudo udevadm control --reload
+sudo udevadm trigger --action=add /sys/class/net/eno1
+ethtool -k eno1 | grep -E 'segmentation-offload|generic-receive'
+```
+
+If the hang recurs after offloads are disabled, the cause is likely deeper:
+disable PCIe ASPM (`pcie_aspm=off` or BIOS C-states) or treat the NIC as failing
+hardware.
+
+### Recovery After a Hang
+
+`nuc-00` is a LUKS-root node. A hung NIC means a power cycle is required, then a
+LUKS unlock before it rejoins:
+
+```shell
+make unlock nuc-00
+```
+
+Once booted, Longhorn re-attaches its volumes automatically.
+
 [envoy-issue]: https://github.com/envoyproxy/envoy/issues/23339
 [metallb-troubleshooting]: https://metallb.universe.tf/troubleshooting/#using-wifi-and-cant-reach-the-service
 [cilium-issue]: https://github.com/cilium/cilium/issues/19038


### PR DESCRIPTION
## Problem

On 2026-06-28 \`nuc-00\` went NotReady while its power light stayed on and it kept logging locally. Root cause from the previous boot's kernel log: the onboard Intel 82579V NIC (\`eno1\`, driver \`e1000e\`, PCI \`8086:1503\`) stalled its TX queue and logged \`Detected Hardware Unit Hang\` 914 times until power-off. The host stayed alive but had no network, so the kubelet could not reach the API server.

This is the well-known \`e1000e\`/82579 TX-offload hang. First occurrence in the last four boots.

## Change

- New play \`ansible/playbooks/nuc/000-e1000e-offload.yaml\` (targets \`node20\`) writes a systemd-networkd \`.link\` file disabling TCP/generic segmentation offload and generic receive offload on \`eno1\`. systemd-udevd applies it at device init; a handler re-triggers udev to apply live without bouncing the carrier.
- Wired into \`setup.yaml\` so \`make setup\` applies it.
- \`documentation/gotcha.md\` section covering symptoms, cause, mitigation, and LUKS recovery.

## Apply

GitOps only here. To roll out: \`make setup\` (or run the targeted play). Verify with:

\`\`\`shell
ethtool -k eno1 | grep -E 'segmentation-offload|generic-receive'
\`\`\`

## Caveat

Treats the symptom. If the hang recurs after offloads are disabled, the deeper fix is disabling PCIe ASPM / BIOS C-states or replacing the NIC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)