### PR TITLE
Set e1000e offloads with ethtool in handler

### DIFF
--- a/ansible/playbooks/nuc/000-e1000e-offload.yaml
+++ b/ansible/playbooks/nuc/000-e1000e-offload.yaml
@@ -29,9 +29,14 @@
 
   handlers:
     - name: Reapply udev link settings for eno1
-      # Toggling offload features does not bounce the carrier, so this is safe
-      # to apply live without dropping the node's only network path.
+      # Reload the .link file for the durable path (applied at device init on
+      # boot), then set the offloads explicitly with ethtool. A hot udev
+      # re-trigger on an already-initialised device does not reliably apply
+      # TCPSegmentationOffload, so a live run (e.g. make setup without a reboot)
+      # would otherwise leave tso on. Toggling these features does not bounce
+      # the carrier, so this is safe on the node's only network path.
       shell: |
         udevadm control --reload
         udevadm trigger --action=add /sys/class/net/eno1
+        ethtool -K eno1 tso off gso off gro off
       changed_when: true


### PR DESCRIPTION
## Follow-up to #2637

When the e1000e offload play (#2637) was applied live to nuc-00, the udev re-trigger set generic-segmentation-offload and generic-receive-offload off, but left tcp-segmentation-offload (TSO) **on**. A hot udev re-trigger on an already-initialised interface does not reliably apply \`TCPSegmentationOffload\` from the \`.link\` file. The \`.link\` file still applies all three correctly at device init on a real reboot, but a live \`make setup\` (no reboot) would leave TSO on — and TSO is the primary offload the hang stalls on.

## Change

Add an explicit \`ethtool -K eno1 tso off gso off gro off\` to the handler, after the udev reload/trigger. This makes the running state deterministic on a live apply as well as at boot. Toggling these features does not bounce the carrier.

Verified live on nuc-00: all three offloads now report \`off\`, node stayed reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)