### PR TITLE
Pin argocd repo-server to arm64 for jsonnet CMP sidecar

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -119,6 +119,13 @@ argo-cd:
       enabled: false
   repoServer:
     replicas: 1
+    # The jsonnet-with-secret CMP sidecar (ghcr.io/siutsin/images/go-jsonnet)
+    # ships an arm64-only binary. On the amd64 nuc-00 node the jsonnet binary
+    # fails with "exec format error", which breaks manifest generation for the
+    # bootstrap and private apps. Pin the repo-server to arm64 nodes so the
+    # sidecar architecture always matches.
+    nodeSelector:
+      kubernetes.io/arch: arm64
     autoscaling:
       enabled: false
       minReplicas: 1


### PR DESCRIPTION
## Problem

The Argo CD \`bootstrap\` (app-of-apps) and \`private\` applications went sync status **Unknown** with:

\`\`\`
ComparisonError: ... error generating manifests: fork/exec /usr/local/bin/jsonnet: exec format error
\`\`\`

## Root cause

The \`jsonnet-with-secret\` CMP sidecar image (\`ghcr.io/siutsin/images/go-jsonnet\`, pinned by digest) ships an **arm64-only** binary. The repo-server was rescheduled onto the amd64 \`nuc-00\` node, where the arm64 jsonnet binary cannot exec, breaking manifest generation for the two jsonnet-based apps. The apps stayed Healthy (last-synced state) but could not reconcile.

## Fix

Pin \`argocd.repoServer\` to arm64 nodes via \`nodeSelector\` so the sidecar architecture always matches. This restores the prior working placement (the repo-server previously ran on the arm64 Raspberry Pi nodes).

## Validation

- \`helm template\` confirms the nodeSelector lands on the repo-server Deployment only.
- \`make test\` passes.

## Follow-up (not in this PR)

A more flexible long-term fix is to publish \`go-jsonnet\` as a multi-arch image so the repo-server can run on any node. That lives in the image-build repo, not here.