### PR TITLE
fix(changedetection): pin image to 0.55.7 instead of latest

### DIFF
--- a/GOTCHA.md
+++ b/GOTCHA.md
@@ -1,0 +1,29 @@
+# Gotchas
+
+Non-obvious behaviours and workarounds discovered while working in this repo.
+
+## changedetection `latest` image tag resets the watch list
+
+**Problem:** The changedetection deployment lost its entire watch list and
+came back with only the fresh-install defaults.
+
+**Why it happens:** The image was pinned as
+`ghcr.io/dgtlmoon/changedetection.io:latest@sha256:...`. The `latest` label is
+mutable, so a Renovate digest bump or a fresh pull can land a newer
+changedetection release on restart. Newer releases run datastore migrations
+(the datastore moved to a per-watch `{uuid}/watch.json` layout with settings
+in `changedetection.json`). A migration that does not carry the old watches
+over leaves the app looking freshly installed.
+
+**Recovery limits:** The Longhorn `backup` recurring job for
+`changedetection-vol` is weekly (`0 4 * * 0`) with `retain: 1`. Only the most
+recent weekly snapshot/backup is kept, so once a bad state is captured it
+overwrites the last good copy within a week. There is no restore point older
+than the loss. Treat changedetection watch data as low-durability until the
+retention window is deepened.
+
+**Fix:** Pin the image to a concrete version tag instead of `latest` in
+`helm-charts/changedetection/values.yaml`. Version `0.55.7` resolves to the
+same digest `latest` currently points to, so pinning is a no-op for the
+running pod while stopping uncontrolled migrations. Renovate then proposes
+controlled version bumps that can be reviewed before they apply.

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -19,7 +19,11 @@ deployment:
     USE_X_SETTINGS: "true"
   image:
     repository: ghcr.io/dgtlmoon/changedetection.io
-    tag: latest@sha256:736331d2787f94d3201b64aa641e090f67e28577ba505bd7ba5d7c1841e1e0ca
+    # Pin to a specific version, not the mutable `latest` tag. An uncontrolled
+    # `latest` bump can ship a datastore migration that resets watches on
+    # restart. 0.55.7 resolves to the same digest `latest` currently points to,
+    # so this pin is a no-op for the running pod. See GOTCHA.md.
+    tag: 0.55.7@sha256:736331d2787f94d3201b64aa641e090f67e28577ba505bd7ba5d7c1841e1e0ca
     pullPolicy: IfNotPresent
   # Keep at 1Gi: browser-backed watches stitch screenshots in this app process;
   # 256Mi caused OOMKilled exit 137 while processing an Amazon watch.


### PR DESCRIPTION
## Problem

The changedetection watch list reset to install defaults. Investigation found
the datastore held only the two fresh-install default watches, both created
2026-06-20 12:33 UTC, matching the volume filesystem creation time.

The image was pinned as `latest@sha256:...`. The `latest` label is mutable, so
a Renovate digest bump or fresh pull can land a newer changedetection release
on restart. Newer releases run datastore migrations, and a migration that does
not carry the old watches over leaves the app looking freshly installed.

## Change

- Pin the image to `0.55.7`. It resolves to the exact same digest `latest`
  currently points to (`sha256:7363...`), so this is a no-op for the running
  pod while stopping uncontrolled migrations. Renovate can then propose
  reviewable version bumps.
- Document the incident, root cause, and recovery limits in `GOTCHA.md`.

## Recovery note (not fixed here)

No pre-loss restore point survives. The Longhorn `backup` recurring job for
`changedetection-vol` is weekly (`0 4 * * 0`) with `retain: 1`, so the only
snapshot/backup already captures the post-loss default state. Deepening that
retention window is a separate follow-up.

## Testing

`make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)