### PR TITLE
fix(longhorn): deepen weekly backup retention 1 to 4

### DIFF
--- a/helm-charts/longhorn-config/templates/recurring-job.yaml
+++ b/helm-charts/longhorn-config/templates/recurring-job.yaml
@@ -8,7 +8,11 @@ spec:
   task: backup
   groups:
     - backup
-  retain: 1
+  # Keep four weekly backups (~1 month of restore points). With retain: 1 a
+  # single bad state, such as a filesystem reformat on attach, is captured by
+  # the next weekly run and immediately overwrites the last good copy, leaving
+  # no way back. Backups are incremental to S3, so the extra copies are cheap.
+  retain: 4
   concurrency: 1
 ---
 apiVersion: longhorn.io/v1beta2


### PR DESCRIPTION
## Why

Follow-up to the changedetection data-loss investigation (#2673).

The changedetection volume lost its data when its filesystem was reformatted on
attach around 2026-06-20 (an encrypted, single-replica Longhorn volume; a fresh
`mkfs` at the CSI/crypto layer wipes the contents). Recovery was impossible
because the shared `backup` recurring job kept only **one** copy (`retain: 1`)
on a **weekly** schedule. The next weekly run captured the reset state and
overwrote the last good backup, so no pre-loss restore point survived.

Note: more replicas would not have prevented this. Replicas mirror the same
LUKS device, so a reformat at the attach layer propagates to all of them.
Independent point-in-time backups are the real protection, hence deepening
retention rather than adding replicas.

## Change

- `backup` recurring job `retain: 1` -> `retain: 4` (about one month of weekly
  restore points). Applies to all volumes in the `backup` group. Longhorn
  backups are incremental to S3, so the extra copies are cheap.

## Testing

`make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)