### PR TITLE
Fix Longhorn volume Argo sync and replica scheduling

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -51,6 +51,12 @@ local cleanerExcludeDeleted = [{
   jqPathExpressions: ['.spec.resourcePolicySet.resourceSelectors[].excludeDeleted'],
 }];
 
+// Bound PV CSI volumeAttributes are immutable; replica count lives on the Volume CR.
+local longhornVolumePvAttributes = [{
+  kind: 'PersistentVolume',
+  jsonPointers: ['/spec/csi/volumeAttributes/numberOfReplicas'],
+}];
+
 local cnpgClusterOperatorDefaults = [{
   group: 'postgresql.cnpg.io',
   kind: 'Cluster',
@@ -130,14 +136,33 @@ local homeAssistantVolumeHelm = { parameters: [{ name: 'longhorn-volume-lib.volu
 local openClawHelm = { parameters: [{ name: 'route.hostname', value: std.extVar('OPENCLAW_CONTROL_UI_HOSTNAME') }] };
 local application = [
   { wave: '10', name: 'blocky', namespace: 'blocky' },
-  { wave: '10', name: 'changedetection-volume', namespace: 'changedetection' },
+  {
+    wave: '10',
+    name: 'changedetection-volume',
+    namespace: 'changedetection',
+    syncOptions: ['RespectIgnoreDifferences=true'],
+    ignoreDifferences: longhornVolumePvAttributes,
+  },
   { wave: '10', name: 'cyberchef', namespace: 'cyberchef' },
   { wave: '10', name: 'excalidraw', namespace: 'excalidraw' },
   { wave: '11', name: 'happy', namespace: 'happy' },
-  { wave: '10', name: 'home-assistant-volume', namespace: 'home-assistant', helm: homeAssistantVolumeHelm },
+  {
+    wave: '10',
+    name: 'home-assistant-volume',
+    namespace: 'home-assistant',
+    helm: homeAssistantVolumeHelm,
+    syncOptions: ['RespectIgnoreDifferences=true'],
+    ignoreDifferences: longhornVolumePvAttributes,
+  },
   { wave: '10', name: 'jsoncrack', namespace: 'jsoncrack' },
   { wave: '10', name: 'kubernetes-mcp-server', namespace: 'kubernetes-mcp-server' },
-  { wave: '10', name: 'openclaw-volume', namespace: 'openclaw' },
+  {
+    wave: '10',
+    name: 'openclaw-volume',
+    namespace: 'openclaw',
+    syncOptions: ['RespectIgnoreDifferences=true'],
+    ignoreDifferences: longhornVolumePvAttributes,
+  },
   { wave: '11', name: 'openclaw', namespace: 'openclaw', helm: openClawHelm },
   { wave: '10', name: 'teslamate', namespace: 'teslamate' },
   { wave: '10', name: 'umami', namespace: 'umami' },

--- a/helm-charts/changedetection-volume/Chart.lock
+++ b/helm-charts/changedetection-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.0
-digest: sha256:f36adeb3d0242d1345651c81a065f52d0a6c34fdc46cd2093070cbbee60a9bc6
-generated: "2026-07-05T18:03:26.332446+01:00"
+  version: 0.3.1
+digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
+generated: "2026-07-05T18:11:18.526674+01:00"

--- a/helm-charts/changedetection-volume/Chart.yaml
+++ b/helm-charts/changedetection-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.3.0
+  version: 0.3.1
   repository: file://../longhorn-volume-lib

--- a/helm-charts/home-assistant-volume/Chart.lock
+++ b/helm-charts/home-assistant-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.0
-digest: sha256:f36adeb3d0242d1345651c81a065f52d0a6c34fdc46cd2093070cbbee60a9bc6
-generated: "2026-07-05T18:03:29.146119+01:00"
+  version: 0.3.1
+digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
+generated: "2026-07-05T18:11:21.317414+01:00"

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.3.0
+  version: 0.3.1
   repository: file://../longhorn-volume-lib

--- a/helm-charts/longhorn-volume-lib/Chart.yaml
+++ b/helm-charts/longhorn-volume-lib/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: longhorn-volume-lib
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/longhorn-volume-lib/templates/volume.yaml
+++ b/helm-charts/longhorn-volume-lib/templates/volume.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $value := .Values.volumes }}
 {{- $replicas := default 1 $value.numberOfReplicas }}
+{{- $nodeSelector := default (list) $value.nodeSelector }}
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -28,7 +29,8 @@ spec:
     driver: driver.longhorn.io
     fsType: ext4
     volumeAttributes:
-      numberOfReplicas: {{ $replicas | quote }}
+      # Immutable on bound PVs; replica count is driven by the Longhorn Volume CR.
+      numberOfReplicas: "1"
       dataLocality: disabled
       replicaAutoBalance: best-effort
       encrypted: "true"
@@ -85,5 +87,7 @@ spec:
   frontend: blockdev
   size: {{ $value.sizeBytes | quote }}
   numberOfReplicas: {{ $replicas }}
+  nodeSelector:
+{{ toYaml $nodeSelector | indent 4 }}
   fromBackup: {{ $value.fromBackup | quote }}
 {{- end }}

--- a/helm-charts/longhorn-volume-lib/values.yaml
+++ b/helm-charts/longhorn-volume-lib/values.yaml
@@ -10,6 +10,7 @@ volumes: {}
   #   size: "2Gi"
   #   sizeBytes: "2147483648"
   #   fromBackup: "s3://bucket@region/?backup=backup-id&volume=vol-name"
-  #   numberOfReplicas: 1  # optional, defaults to 1
+  #   numberOfReplicas: 1  # optional, defaults to 1 (Volume CR only; PV stays 1)
+  #   nodeSelector: []     # optional, defaults to [] (no replica placement restriction)
   #   enableBackup: true  # optional, defaults to true
   #   enableTrim: true    # optional, defaults to true

--- a/helm-charts/openclaw-volume/Chart.lock
+++ b/helm-charts/openclaw-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.0
-digest: sha256:f36adeb3d0242d1345651c81a065f52d0a6c34fdc46cd2093070cbbee60a9bc6
-generated: "2026-07-05T18:03:31.961233+01:00"
+  version: 0.3.1
+digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
+generated: "2026-07-05T18:11:24.088336+01:00"

--- a/helm-charts/openclaw-volume/Chart.yaml
+++ b/helm-charts/openclaw-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
   - name: longhorn-volume-lib
-    version: 0.3.0
+    version: 0.3.1
     repository: file://../longhorn-volume-lib


### PR DESCRIPTION
## Summary

- Keep `numberOfReplicas` on the Longhorn Volume CR only; PV CSI `volumeAttributes` stay at `"1"` because they are immutable on bound volumes.
- Add `ignoreDifferences` on the three volume Argo CD apps as belt-and-braces.
- Emit `nodeSelector: []` by default on Volume CRs to clear live drift (`raspberrypi-00`) blocking second replica scheduling on changedetection volumes.

## Why

PR #2675 left volume apps OutOfSync (PV patch rejected) and changedetection volumes degraded (`disks are unavailable`) because replicas were pinned to `raspberrypi-00`.

## Test plan

- [x] `/usr/bin/make test`
- [ ] After merge, volume apps Synced and changedetection volumes reach 2 healthy replicas