### PR TITLE
Remove unused longhorn-crypto-global-ha storage class

### DIFF
--- a/helm-charts/longhorn/templates/storage-class.yaml
+++ b/helm-charts/longhorn/templates/storage-class.yaml
@@ -17,21 +17,3 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: {{ .Values.encryption.secretName }}
   csi.storage.k8s.io/node-stage-secret-namespace: {{ .Values.namespace }}
 allowVolumeExpansion: true
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: longhorn-crypto-global-ha
-provisioner: driver.longhorn.io
-parameters:
-  numberOfReplicas: {{ .Values.longhorn.persistence.defaultClassReplicaCount | quote }}
-  dataLocality: {{ .Values.longhorn.persistence.defaultDataLocality }}
-  replicaAutoBalance: {{ .Values.longhorn.defaultSettings.replicaAutoBalance }}
-  encrypted: "true"
-  csi.storage.k8s.io/provisioner-secret-name: {{ .Values.encryption.secretName }}
-  csi.storage.k8s.io/provisioner-secret-namespace: {{ .Values.namespace }}
-  csi.storage.k8s.io/node-publish-secret-name: {{ .Values.encryption.secretName }}
-  csi.storage.k8s.io/node-publish-secret-namespace: {{ .Values.namespace }}
-  csi.storage.k8s.io/node-stage-secret-name: {{ .Values.encryption.secretName }}
-  csi.storage.k8s.io/node-stage-secret-namespace: {{ .Values.namespace }}
-allowVolumeExpansion: true

--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -6,8 +6,6 @@ longhorn:
     jobEnabled: false
   persistence:
     defaultClass: false
-    defaultClassReplicaCount: 2
-    defaultDataLocality: disabled # change to best-effort once added more drives
   defaultSettings:
     allowCollectingLonghornUsageMetrics: false
     defaultReplicaCount: 2


### PR DESCRIPTION
## Summary

- Remove the unused `longhorn-crypto-global-ha` StorageClass
- Drop `defaultClassReplicaCount` and `defaultDataLocality` values that only fed that class

## Context

No PVC in the cluster uses this storage class. HA replica counts for critical volumes are set explicitly via `longhorn-volume-lib` `numberOfReplicas` instead.

## Test plan

- [x] `helm lint helm-charts/longhorn`
- [x] `helm template` renders a single `longhorn-crypto-global` StorageClass