### PR TITLE
Enable Longhorn backup group on happy PVC

### DIFF
--- a/helm-charts/happy/templates/pvc.yaml
+++ b/helm-charts/happy/templates/pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.persistence.claimName }}
   namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    recurring-job-group.longhorn.io/backup: enabled
+    recurring-job-group.longhorn.io/trim: enabled
 spec:
   accessModes:
     {{- toYaml .Values.persistence.accessModes | nindent 4 }}


### PR DESCRIPTION
## Summary
- Add `recurring-job-group.longhorn.io/backup` and `recurring-job-group.longhorn.io/trim` labels to `happy-pvc`
- Aligns Happy PGLite volume with other critical Longhorn volumes that receive weekly S3 backups

## Test plan
- [x] `helm lint helm-charts/happy --quiet`
- [x] `helm template test helm-charts/happy | grep -A5 happy-pvc` confirms labels render