### PR TITLE
Bump CNPG backup retention to 30 days

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -51,7 +51,7 @@ defaults:
     switchoverDelay: 3600
     backup:
       target: primary
-      retentionPolicy: 1d
+      retentionPolicy: 30d
     plugins:
       - enabled: true
         isWALArchiver: false
@@ -92,7 +92,7 @@ defaults:
     enabled: true
     schedule: "0 0 */3 * * *"
   objectStore:
-    retentionPolicy: 1d
+    retentionPolicy: 30d
     instanceSidecarResources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Bump CNPG backup retention from 1d to 30d in cloudnative-pg-clusters defaults.

Changes:
- `defaults.cluster.backup.retentionPolicy`: 1d → 30d
- `defaults.objectStore.retentionPolicy`: 1d → 30d