### PR TITLE
docs: require rationale comment on resource changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,12 @@ create missing values.yaml files, resolve template rendering issues.
 Set memory requests equal to memory limits unless the user explicitly asks otherwise.
 Do not set CPU limits unless the user explicitly asks for them.
 Set explicit ephemeral-storage requests and limits with suitable values for the workload.
+Whenever you change a resource request or limit, add an inline comment in the
+resource block stating the observed symptom and the reason for the new value.
+This covers CPU, memory, and ephemeral-storage bumps, whether triggered by an
+OOMKill, CPU throttling, disk-pressure eviction, or capacity headroom. Record
+the trigger, for example the exit code and the workload that caused it, and why
+the previous value was too low.
 
 **Markdown**: fix linting violations directly, never disable markdownlint rules.
 


### PR DESCRIPTION
## Summary

Extends the Helm Charts guidance in `AGENTS.md` so any resource request or limit
change carries an inline comment explaining why.

Previously the convention was implicit (see the existing example in
`helm-charts/changedetection/values.yaml`, where the 1Gi memory block notes that
256Mi caused OOMKilled exit 137). This makes it an explicit rule and broadens it
beyond OOMKills to cover CPU throttling, disk-pressure eviction, and capacity
headroom across CPU, memory, and ephemeral-storage.

## Change

- `AGENTS.md`: add a sentence under the Helm Charts error-handling case
  requiring an inline rationale comment on any resource change, recording the
  trigger and why the previous value was too low.

Docs only. No chart or manifest behaviour changes.