### PR TITLE
Scale monitoring storage HA and Umami CNPG to 2 instances

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/objectstore-b2-backup.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/objectstore-b2-backup.yaml
@@ -19,7 +19,11 @@ spec:
         key: "AWS_SECRET_ACCESS_KEY"
       inheritFromIAMRole: false
   instanceSidecarConfiguration:
-    resources: {{ toYaml $.Values.defaults.objectStore.instanceSidecarResources | nindent 6 }}
+    {{- $sidecarResources := $.Values.defaults.objectStore.instanceSidecarResources }}
+    {{- if and $clusterConfig.objectStore $clusterConfig.objectStore.instanceSidecarResources }}
+    {{- $sidecarResources = $clusterConfig.objectStore.instanceSidecarResources }}
+    {{- end }}
+    resources: {{ toYaml $sidecarResources | nindent 6 }}
   retentionPolicy: {{ $.Values.defaults.objectStore.retentionPolicy | quote }}
 {{- end }}
 {{- end }}

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -157,7 +157,28 @@ clusters:
   umami:
     clusterName: umami-20260614-0001
     namespace: umami
-    instances: 1
+    affinity:
+      podAntiAffinityType: required
+    instances: 2
+    # Light analytics DB: live usage ~10m CPU / 74Mi; keep headroom for failover and vacuum.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+        ephemeral-storage: 512Mi
+      limits:
+        memory: 256Mi
+        ephemeral-storage: 512Mi
+    objectStore:
+      # Barman sidecar live usage ~44Mi; match plugin-barman-cloud controller sizing.
+      instanceSidecarResources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+          ephemeral-storage: 128Mi
+        limits:
+          memory: 128Mi
+          ephemeral-storage: 128Mi
     storage:
       size: 2Gi
       storageClass: longhorn-crypto-global

--- a/helm-charts/monitoring/templates/loki-longhorn-volume.yaml
+++ b/helm-charts/monitoring/templates/loki-longhorn-volume.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.lokiLonghornVolume.enabled }}
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: {{ .Values.lokiLonghornVolume.name }}
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: loki
+    recurring-job-group.longhorn.io/backup: enabled
+    recurring-job-group.longhorn.io/trim: enabled
+spec:
+  numberOfReplicas: {{ .Values.lokiLonghornVolume.numberOfReplicas }}
+{{- end }}

--- a/helm-charts/monitoring/templates/loki-pvc-labels.yaml
+++ b/helm-charts/monitoring/templates/loki-pvc-labels.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.lokiLonghornVolume.enabled }}
+# StatefulSet volumeClaimTemplates are immutable; label the bound PVC directly for Longhorn recurring jobs.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-monitoring-loki-0
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/component: single-binary
+    app.kubernetes.io/instance: monitoring
+    app.kubernetes.io/name: loki
+    recurring-job-group.longhorn.io/backup: enabled
+    recurring-job-group.longhorn.io/trim: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn-crypto-global
+  volumeName: {{ .Values.lokiLonghornVolume.name }}
+{{- end }}

--- a/helm-charts/monitoring/templates/prometheus-longhorn-volume.yaml
+++ b/helm-charts/monitoring/templates/prometheus-longhorn-volume.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.prometheusLonghornVolume.enabled }}
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: {{ .Values.prometheusLonghornVolume.name }}
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: prometheus
+    recurring-job-group.longhorn.io/backup: enabled
+    recurring-job-group.longhorn.io/trim: enabled
+spec:
+  numberOfReplicas: {{ .Values.prometheusLonghornVolume.numberOfReplicas }}
+{{- end }}

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -1,6 +1,19 @@
 name: monitoring
 namespace: monitoring
 
+# Longhorn Volume CR for the dynamically provisioned Prometheus PVC (name = bound PV).
+# Lookup: kubectl -n monitoring get pvc monitoring-prometheus-server -o jsonpath='{.spec.volumeName}'
+prometheusLonghornVolume:
+  enabled: true
+  name: pvc-429394f8-4469-42bd-913a-9952629d36d1
+  numberOfReplicas: 2
+
+# Lookup: kubectl -n monitoring get pvc storage-monitoring-loki-0 -o jsonpath='{.spec.volumeName}'
+lokiLonghornVolume:
+  enabled: true
+  name: pvc-40c3f449-86c7-4d7f-83ec-0912076a2d7b
+  numberOfReplicas: 2
+
 _shared:
   smallResources: &smallResources
     requests:
@@ -40,10 +53,13 @@ prometheus:
         memory: 3Gi
         ephemeral-storage: 256Mi
     persistentVolume:
-      size: 50Gi
-    # One day currently uses about 2.3G; cap at 40GB on the 50Gi PVC to leave WAL/headroom and growth space.
-    retentionSize: 40GB
-    retention: 7d
+      size: 100Gi
+      labels:
+        recurring-job-group.longhorn.io/backup: enabled
+        recurring-job-group.longhorn.io/trim: enabled
+    # Live 2026-07-05: ~8.3GiB on disk at 7d retention (~1.2GiB/day). 30d ≈ 36GiB TSDB; 100GB cap matches PVC budget.
+    retentionSize: 100GB
+    retention: 30d
   alertmanager:
     enabled: false
   kube-state-metrics:
@@ -130,6 +146,10 @@ loki:
     resources: *smallResources
   singleBinary:
     replicas: 1
+    persistence:
+      labels:
+        recurring-job-group.longhorn.io/backup: enabled
+        recurring-job-group.longhorn.io/trim: enabled
     podLabels:
       # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
       istio.io/dataplane-mode: none


### PR DESCRIPTION
## Summary

- **Prometheus**: bump retention to 30d with 100Gi PVC / 100GB `retentionSize`; add Longhorn 2-replica Volume CR and backup/trim labels on the PVC.
- **Loki**: keep 7d retention; add Longhorn 2-replica Volume CR, backup/trim labels on the bound StatefulSet PVC, and persistence labels for future PVC recreation.
- **Umami CNPG**: scale to 2 instances with required pod anti-affinity, right-size postgres and barman sidecar resources, and support per-cluster ObjectStore sidecar resource overrides.

## Test plan

- [x] `make test` passes locally
- [ ] Argo CD reconciles Longhorn replica rebuilds and backup enrollment for Prometheus + Loki PVCs
- [ ] Umami CNPG failover with 2 instances