### PR TITLE
Fix Argo CD sync failure on monitoring-loki StatefulSet

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -146,10 +146,6 @@ loki:
     resources: *smallResources
   singleBinary:
     replicas: 1
-    persistence:
-      labels:
-        recurring-job-group.longhorn.io/backup: enabled
-        recurring-job-group.longhorn.io/trim: enabled
     podLabels:
       # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
       istio.io/dataplane-mode: none


### PR DESCRIPTION
## Summary

- PR #2682 added `loki.singleBinary.persistence.labels` to
  `helm-charts/monitoring/values.yaml`, which the Loki subchart renders into
  the StatefulSet's `volumeClaimTemplates`. That field is immutable outside a
  small allow-list, so every Argo CD auto-sync since has failed with
  `Forbidden: updates to statefulset spec for fields other than 'replicas' ...
  are forbidden`.
- The same PR already added `loki-pvc-labels.yaml` to label the bound PVC
  directly for exactly this reason (see its inline comment). The subchart
  labels were redundant and actively broke sync.
- Removes the redundant `persistence.labels` block. Rendered manifest now
  matches the deployed StatefulSet's `volumeClaimTemplates`.

## Test plan

- [x] `helm template` confirms `volumeClaimTemplates` for `monitoring-loki`
  no longer includes the disputed labels
- [x] `make test` passes
- [ ] Argo CD `monitoring` app returns to `Synced` after merge (auto-sync)