### PR TITLE
Right-size KRR-verified safe workloads

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -1,12 +1,13 @@
 descheduler:
   kind: Deployment
   resources:
+    # KRR 2026-07-05: live peak ~100Mi working set; 256Mi request was never approached.
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 50m
+      memory: 128Mi
       ephemeral-storage: 64Mi
     limits:
-      memory: 256Mi
+      memory: 128Mi
       ephemeral-storage: 64Mi
   deschedulerPolicy:
     profiles:

--- a/helm-charts/happy/values.yaml
+++ b/helm-charts/happy/values.yaml
@@ -40,12 +40,13 @@ persistence:
 deployment:
   replicas: 1
   resources:
+    # KRR 2026-07-05: live peak ~561Mi working set; 2Gi reserved ~3.5x headroom with no OOM history.
     requests:
-      cpu: 100m
-      memory: 2Gi
+      cpu: 50m
+      memory: 640Mi
       ephemeral-storage: 512Mi
     limits:
-      memory: 2Gi
+      memory: 640Mi
       ephemeral-storage: 512Mi
 
 route:

--- a/helm-charts/home-assistant/templates/deployment.yaml
+++ b/helm-charts/home-assistant/templates/deployment.yaml
@@ -59,12 +59,13 @@ spec:
               name: configuration
               subPath: configuration.yaml
           resources:
+            # KRR 2026-07-05: live peak ~275Mi working set; 500Mi request was ~1.8x actual usage.
             requests:
-              cpu: "0.1"
-              memory: "500Mi"
+              cpu: "50m"
+              memory: "320Mi"
               ephemeral-storage: "100Mi"
             limits:
-              memory: "500Mi"
+              memory: "320Mi"
               ephemeral-storage: "100Mi"
       volumes:
         - name: config

--- a/helm-charts/kiali/values.yaml
+++ b/helm-charts/kiali/values.yaml
@@ -12,12 +12,13 @@ kiali-server:
       - "**"
     view_only_mode: true
     resources:
+      # KRR 2026-07-05: live peak ~124Mi working set; 256Mi request was ~2x actual usage.
       requests:
         cpu: 50m
-        memory: 256Mi
+        memory: 160Mi
         ephemeral-storage: 64Mi
       limits:
-        memory: 256Mi
+        memory: 160Mi
         ephemeral-storage: 64Mi
   external_services:
     grafana:

--- a/helm-charts/teslamate/templates/deployment.yaml
+++ b/helm-charts/teslamate/templates/deployment.yaml
@@ -47,10 +47,11 @@ spec:
             initialDelaySeconds: 15
             failureThreshold: 30
           resources:
+            # KRR 2026-07-05: live peak ~267Mi working set; 384Mi request was ~1.4x actual usage.
             requests:
-              cpu: 100m
-              memory: 384Mi
+              cpu: 50m
+              memory: 320Mi
               ephemeral-storage: 100Mi
             limits:
-              memory: 384Mi
+              memory: 320Mi
               ephemeral-storage: 100Mi


### PR DESCRIPTION
## Summary

Reduce CPU and memory requests for workloads where KRR (2026-07-05) showed large over-provisioning and git/PR review found no documented OOM incident history.

| Workload | Before | After | KRR peak |
|----------|--------|-------|----------|
| happy | 2Gi / 100m | 640Mi / 50m | ~561Mi |
| home-assistant | 500Mi / 100m | 320Mi / 50m | ~275Mi |
| descheduler | 256Mi / 100m | 128Mi / 50m | ~100Mi |
| kiali | 256Mi / 50m | 160Mi / 50m | ~124Mi |
| teslamate (app) | 384Mi / 100m | 320Mi / 50m | ~267Mi |

Each change includes an inline comment citing the KRR observation. Memory requests equal limits per repo policy.

**Not touched** (verified incident comments or KRR wants more): changedetection, blocky, monitoring/grafana, teslamate/grafana, prometheus, loki.

## Testing

- `make test`