### PR TITLE
Use Claude Sonnet 5 with high effort for PR reviews

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -75,7 +75,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: false
           claude_args: |
-            --model claude-opus-4-8 --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
+            --model claude-sonnet-5 --effort high --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
           prompt: |
             Review only. Do not push commits, edit PR metadata, change labels, write repository content, or run code from the PR.
 


### PR DESCRIPTION
## Summary

- Switch `.github/workflows/claude.yaml` from `claude-opus-4-8` to `claude-sonnet-5`
- Add `--effort high` so reviews stay thorough

## Notes

The workflow skips Claude review when this file is in the PR diff, so this change will not self-trigger a review run.