### PR TITLE
Document KRR usage in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ change.
   `helm-charts/monitoring/values.yaml` (see `route-internal.yaml` for the
   hostname pattern). Do not hardcode cluster hostnames here.
 - Run: `krr simple -p <prometheus-url>`
+- Before changing requests, read inline resource comments for past incidents
+  (OOM, probe failures, scheduling pressure) and do not downsize past those
+  guardrails.
 
 ## Node Reboot Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,11 +97,10 @@ change.
 
 ## KRR (Kubernetes Resource Recommender)
 
-- Install: `pip install robusta-krr`
+- Run: `krr simple -p <prometheus-url>`
 - Prometheus URL: HTTPS ingress for `httpRoutes.prometheus` in
   `helm-charts/monitoring/values.yaml` (see `route-internal.yaml` for the
   hostname pattern). Do not hardcode cluster hostnames here.
-- Run: `krr simple -p <prometheus-url>`
 - Before changing requests, read inline resource comments for past incidents
   (OOM, probe failures, scheduling pressure) and do not downsize past those
   guardrails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,30 @@ For mutating operations, keep GitOps as the source of truth: patch the repo and
 let Argo CD reconcile unless the user explicitly asks for an emergency live
 change.
 
+## KRR (Kubernetes Resource Recommender)
+
+Use Robusta KRR (`robusta-krr`, CLI `krr`) for live CPU and memory recommendations
+before right-sizing workload requests.
+
+- Install if missing: `pip install robusta-krr`
+- Run a cluster scan: `krr simple -p <prometheus-url>`
+- Resolve `<prometheus-url>` from the monitoring chart ingress config in
+  `helm-charts/monitoring/values.yaml` (`httpRoutes.prometheus`) and
+  `helm-charts/monitoring/templates/route-internal.yaml`. Use the HTTPS base URL
+  for that route. Do not hardcode cluster-specific hostnames in committed docs.
+- Prefer the ingress URL from the controller host. Do not use `kubectl
+  port-forward` for KRR when that ingress is reachable; reserve port-forward
+  only as a fallback when ingress is unavailable.
+- Do not point KRR at `*.svc.cluster.local` service URLs from a Mac or other
+  off-cluster host. Cluster DNS is not reachable there.
+- Bare `krr simple` without `-p` may fail when KRR auto-detection hits the
+  Kubernetes API proxy (for example HTTP 403). Pass `-p` explicitly.
+- Before downsizing, cross-check inline resource comments and recent incident
+  PRs. Do not cut workloads with documented OOM, probe-failure, or scheduling
+  history.
+- When applying KRR-driven request changes, add inline comments with the scan
+  date and observed peak usage, per the Helm Charts policy above.
+
 ## Node Reboot Policy
 
 Some Raspberry Pi nodes use LUKS encrypted root disks and do not return from a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,7 @@ change.
 
 - Run: `krr simple -p <prometheus-url>`
 - Prometheus URL: HTTPS ingress for `httpRoutes.prometheus` in
-  `helm-charts/monitoring/values.yaml` (see `route-internal.yaml` for the
-  hostname pattern). Do not hardcode cluster hostnames here.
+  `helm-charts/monitoring/values.yaml` (see `route-internal.yaml`).
 - Before changing requests, read inline resource comments for past incidents
   (OOM, probe failures, scheduling pressure) and do not downsize past those
   guardrails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ change.
 
 ## KRR (Kubernetes Resource Recommender)
 
-- Run: `krr simple -p <prometheus-url>`
-- Prometheus URL: HTTPS ingress for `httpRoutes.prometheus` in
+- Run: `krr simple -p <prometheus-url-via-ingress>`
+- `<prometheus-url-via-ingress>`: HTTPS ingress for `httpRoutes.prometheus` in
   `helm-charts/monitoring/values.yaml` (see `route-internal.yaml`).
 - When building the report and recommendations, read inline resource comments
   for past incidents (OOM, probe failures, scheduling pressure) and exclude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,9 @@ change.
 - Run: `krr simple -p <prometheus-url>`
 - Prometheus URL: HTTPS ingress for `httpRoutes.prometheus` in
   `helm-charts/monitoring/values.yaml` (see `route-internal.yaml`).
-- Before changing requests, read inline resource comments for past incidents
-  (OOM, probe failures, scheduling pressure) and do not downsize past those
-  guardrails.
+- When building the report and recommendations, read inline resource comments
+  for past incidents (OOM, probe failures, scheduling pressure) and exclude
+  downsizing past those guardrails.
 
 ## Node Reboot Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,27 +97,11 @@ change.
 
 ## KRR (Kubernetes Resource Recommender)
 
-Use Robusta KRR (`robusta-krr`, CLI `krr`) for live CPU and memory recommendations
-before right-sizing workload requests.
-
-- Install if missing: `pip install robusta-krr`
-- Run a cluster scan: `krr simple -p <prometheus-url>`
-- Resolve `<prometheus-url>` from the monitoring chart ingress config in
-  `helm-charts/monitoring/values.yaml` (`httpRoutes.prometheus`) and
-  `helm-charts/monitoring/templates/route-internal.yaml`. Use the HTTPS base URL
-  for that route. Do not hardcode cluster-specific hostnames in committed docs.
-- Prefer the ingress URL from the controller host. Do not use `kubectl
-  port-forward` for KRR when that ingress is reachable; reserve port-forward
-  only as a fallback when ingress is unavailable.
-- Do not point KRR at `*.svc.cluster.local` service URLs from a Mac or other
-  off-cluster host. Cluster DNS is not reachable there.
-- Bare `krr simple` without `-p` may fail when KRR auto-detection hits the
-  Kubernetes API proxy (for example HTTP 403). Pass `-p` explicitly.
-- Before downsizing, cross-check inline resource comments and recent incident
-  PRs. Do not cut workloads with documented OOM, probe-failure, or scheduling
-  history.
-- When applying KRR-driven request changes, add inline comments with the scan
-  date and observed peak usage, per the Helm Charts policy above.
+- Install: `pip install robusta-krr`
+- Prometheus URL: HTTPS ingress for `httpRoutes.prometheus` in
+  `helm-charts/monitoring/values.yaml` (see `route-internal.yaml` for the
+  hostname pattern). Do not hardcode cluster hostnames here.
+- Run: `krr simple -p <prometheus-url>`
 
 ## Node Reboot Policy
 


### PR DESCRIPTION
## Summary

Add a **KRR (Kubernetes Resource Recommender)** section to `AGENTS.md` covering:

- How to resolve the Prometheus URL from the monitoring chart ingress config
- Prefer ingress over `kubectl port-forward` from the controller host
- Avoid `*.svc.cluster.local` URLs off-cluster
- Pass `-p` explicitly when auto-detection fails
- Cross-check incident comments before downsizing

No cluster-specific hostnames are hardcoded in the doc.