### PR TITLE
Right-size KRR round 2: trim and bump tight workloads

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -57,12 +57,13 @@ browser:
       tag: 1.38.0@sha256:8f2ffdcb46f1b83e46665954ec130e497b979db766854f79ca9eee43242b7e4c
       pullPolicy: IfNotPresent
     resources:
+      # KRR 2026-07-05: profile cleanup sidecar peaked at ~100Mi during hourly prune runs.
       requests:
         cpu: 10m
-        memory: 32Mi
+        memory: 128Mi
         ephemeral-storage: 16Mi
       limits:
-        memory: 32Mi
+        memory: 128Mi
         ephemeral-storage: 16Mi
   env:
     SCREEN_WIDTH: "1920"
@@ -70,12 +71,13 @@ browser:
     SCREEN_DEPTH: "16"
     MAX_CONCURRENT_CHROME_PROCESSES: "1"
   resources:
+    # KRR 2026-07-05: Playwright browser peaked at ~1.08Gi during Amazon watch fetches; 1Gi left ~6Mi headroom.
     requests:
-      cpu: 250m
-      memory: 1Gi
+      cpu: 50m
+      memory: 1152Mi
       ephemeral-storage: 1Gi
     limits:
-      memory: 1Gi
+      memory: 1152Mi
       ephemeral-storage: 1Gi
 
 service:

--- a/helm-charts/istiod/values.yaml
+++ b/helm-charts/istiod/values.yaml
@@ -6,10 +6,11 @@ istiod:
     env:
       ENABLE_INGRESS_WAYPOINT_ROUTING: "true"
     resources:
+      # KRR 2026-07-05: live peak ~182Mi working set; 256Mi request was ~1.4x actual usage.
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 192Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 256Mi
+        memory: 192Mi
         ephemeral-storage: 128Mi

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -44,13 +44,13 @@ prometheus:
       resources: *smallResources
   server:
     resources:
-      # Keep memory at 3Gi: Grafana dashboard queries pushed Prometheus close to the previous 2Gi limit.
+      # KRR 2026-07-05: live peak ~3.16Gi working set; prior 3Gi bump (#2309) was still ~40Mi short.
       requests:
-        cpu: 100m
-        memory: 3Gi
+        cpu: 800m
+        memory: 3264Mi
         ephemeral-storage: 256Mi
       limits:
-        memory: 3Gi
+        memory: 3264Mi
         ephemeral-storage: 256Mi
     persistentVolume:
       size: 100Gi
@@ -150,13 +150,13 @@ loki:
       # Loki is written to directly by non-ambient fluent-bit; keep ingestion off the ambient dataplane.
       istio.io/dataplane-mode: none
     resources:
-      # Keep the single-binary pod (plus 128Mi sidecar) schedulable on memory-tight Pi nodes.
+      # KRR 2026-07-05: live peak ~583Mi working set; 512Mi request (#2567) left ~70Mi headroom.
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 608Mi
         ephemeral-storage: 128Mi
       limits:
-        memory: 512Mi
+        memory: 608Mi
         ephemeral-storage: 128Mi
   minio:
     enabled: false
@@ -165,12 +165,13 @@ loki:
   resultsCache:
     allocatedMemory: 128
     resources:
+      # KRR 2026-07-05: live peak ~100Mi working set; 154Mi request was never approached.
       requests:
         cpu: 100m
-        memory: 154Mi
+        memory: 128Mi
         ephemeral-storage: 64Mi
       limits:
-        memory: 154Mi
+        memory: 128Mi
         ephemeral-storage: 64Mi
   memcachedExporter:
     resources: *smallResources

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -124,12 +124,13 @@ probes:
     failureThreshold: 3
 
 resources:
+  # KRR 2026-07-05: live peak ~763Mi working set; 1Gi request reserved ~1.3x actual usage.
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 320m
+    memory: 768Mi
     ephemeralStorage: 1Gi
   limits:
-    memory: 1Gi
+    memory: 768Mi
     ephemeralStorage: 1Gi
 
 initContainer:

--- a/helm-charts/umami/values.yaml
+++ b/helm-charts/umami/values.yaml
@@ -27,13 +27,14 @@ service:
 deployment:
   replicas: 1
   resources:
+    # KRR 2026-07-05: live peak ~340Mi working set; 256Mi request left ~84Mi headroom.
     requests:
       cpu: 50m
-      memory: 256Mi
+      memory: 384Mi
       ephemeral-storage: 256Mi
     limits:
-      memory: 512Mi
-      ephemeral-storage: 512Mi
+      memory: 384Mi
+      ephemeral-storage: 256Mi
 
 routes:
   collect:


### PR DESCRIPTION
## Summary

Second KRR pass (`krr simple` via Prometheus ingress, 2026-07-05). Recommendations cross-checked against inline incident comments; guarded workloads left unchanged.

### Downsizes (free capacity)

| Workload | Before | After |
|----------|--------|-------|
| openclaw | 1Gi / 500m | 768Mi / 320m |
| istiod | 256Mi / 100m | 192Mi / 100m |
| loki resultsCache | 154Mi | 128Mi |

### Upsizes (OOM / headroom risk)

| Workload | Before | After |
|----------|--------|-------|
| prometheus server | 3Gi / 100m | 3264Mi / 800m |
| loki singleBinary | 512Mi / 100m | 608Mi / 100m |
| umami app | 256Mi (limit 512Mi) | 384Mi req=limit |
| changedetection browser | 1Gi / 250m | 1152Mi / 50m |
| browser cleanup sidecar | 32Mi | 128Mi |

### Explicitly unchanged (guarded)

changedetection app (OOM history), blocky, grafanas, argocd controller/repo-server, jellyfin.

## Test plan

- [x] `make test`
- [ ] Argo CD sync: monitoring, istiod, openclaw, umami, changedetection
- [ ] Watch prometheus CPU scheduling on tight Pi nodes
- [ ] Confirm no OOM on browser/umami/loki after rollout