### PR TITLE
Fix happy OOM and openclaw arch scheduling after KRR rollout

### DIFF
--- a/helm-charts/happy/values.yaml
+++ b/helm-charts/happy/values.yaml
@@ -40,13 +40,13 @@ persistence:
 deployment:
   replicas: 1
   resources:
-    # KRR 2026-07-05: live peak ~561Mi working set; 2Gi reserved ~3.5x headroom with no OOM history.
+    # OOMKill exit 137 at 640Mi on 2026-07-05 rollout; PGLite startup spike exceeds KRR steady-state peak.
     requests:
       cpu: 50m
-      memory: 640Mi
+      memory: 896Mi
       ephemeral-storage: 512Mi
     limits:
-      memory: 640Mi
+      memory: 896Mi
       ephemeral-storage: 512Mi
 
 route:

--- a/helm-charts/openclaw/templates/deployment.yaml
+++ b/helm-charts/openclaw/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -25,6 +25,10 @@ gateway:
       lockoutMs: 300000
       exemptLoopback: true
 
+# Pin to arm64: busybox and openclaw images are arm64-only; rollout to nuc-00 (amd64) failed init with exec format error.
+nodeSelector:
+  kubernetes.io/arch: arm64
+
 persistence:
   claimName: openclaw-pvc
   mountPath: /var/lib/openclaw


### PR DESCRIPTION
## Summary

Post-rollout fixes from KRR right-sizing (#2687):

- **happy**: OOMKilled (exit 137) at 640Mi during PGLite startup — bump to 896Mi
- **openclaw**: init `exec format error` when scheduled on nuc-00 (amd64) with arm64-only busybox — pin to `kubernetes.io/arch: arm64`

## Test plan

- [x] `make test`
- [ ] happy pod becomes Ready without OOM
- [ ] openclaw pod schedules on arm64 and passes init