### PR TITLE
feat(monitoring): alerting, blackbox probes, and expanded heartbeats

### DIFF
--- a/helm-charts/argocd/templates/authorization-policy.yaml
+++ b/helm-charts/argocd/templates/authorization-policy.yaml
@@ -1,0 +1,32 @@
+{{- $prometheusPrincipal := "cluster.local/ns/monitoring/sa/monitoring-prometheus-server" -}}
+{{- $waypointPrincipal := "cluster.local/ns/istio-waypoints/sa/waypoint" -}}
+{{- $components := list
+  (dict "name" "argocd-application-controller" "port" "8082")
+  (dict "name" "argocd-server" "port" "8083")
+  (dict "name" "argocd-repo-server" "port" "8084")
+  (dict "name" "argocd-applicationset-controller" "port" "8080")
+  (dict "name" "argocd-redis" "port" "9121")
+-}}
+{{- range $components }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .name }}-metrics
+  namespace: {{ $.Values.namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .name }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - {{ .port | quote }}
+{{- end }}

--- a/helm-charts/argocd/templates/heartbeat.yaml
+++ b/helm-charts/argocd/templates/heartbeat.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $endpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $endpointTypes }}
+    - secretKey: argocd-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: heartbeats
+        metadataPolicy: None
+        property: argocd-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: argocd-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: argocd-heartbeat
+    targetEndpointKey: argocd-target-endpoint
+    healthyEndpointKey: argocd-healthy-endpoint
+    unhealthyEndpointKey: argocd-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -3,6 +3,8 @@ integrations:
   externalSecrets: true
 
 argo-cd:
+  global:
+    addPrometheusAnnotations: true
   _shared:
     controllerResources: &controllerResources
       # Keep memory at 2Gi: sync spikes can queue many repo comparisons at once,
@@ -92,10 +94,14 @@ argo-cd:
     enabled: false
   controller:
     replicas: 1
+    metrics:
+      enabled: true
     resources: *controllerResources
     readinessProbe: *readinessProbe
     pdb: *singletonPdb
   server:
+    metrics:
+      enabled: true
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -104,6 +110,8 @@ argo-cd:
     livenessProbe: *livenessProbe
     pdb: *haPdb
   applicationSet:
+    metrics:
+      enabled: true
     resources: *componentResources
     readinessProbe:
       <<: *readinessProbe
@@ -118,6 +126,8 @@ argo-cd:
     secretInit:
       enabled: false
   repoServer:
+    metrics:
+      enabled: true
     replicas: 1
     # The jsonnet-with-secret CMP sidecar (ghcr.io/siutsin/images/go-jsonnet)
     # ships an arm64-only binary. On the amd64 nuc-00 node the jsonnet binary

--- a/helm-charts/blocky/templates/heartbeat.yaml
+++ b/helm-charts/blocky/templates/heartbeat.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $endpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $endpointTypes }}
+    - secretKey: {{ $.Values.name }}-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: heartbeats
+        metadataPolicy: None
+        property: {{ $.Values.name }}-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: {{ .Values.name }}-heartbeat
+    targetEndpointKey: {{ .Values.name }}-target-endpoint
+    healthyEndpointKey: {{ .Values.name }}-healthy-endpoint
+    unhealthyEndpointKey: {{ .Values.name }}-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m

--- a/helm-charts/cloudnative-pg-clusters/templates/authorization-policy.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/authorization-policy.yaml
@@ -1,0 +1,24 @@
+{{- $prometheusPrincipal := "cluster.local/ns/monitoring/sa/monitoring-prometheus-server" -}}
+{{- range $k, $clusterConfig := .Values.clusters }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $clusterConfig.clusterName }}-postgres-metrics
+  namespace: {{ $clusterConfig.namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      cnpg.io/cluster: {{ $clusterConfig.clusterName }}
+      cnpg.io/podRole: instance
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9187"
+{{- end }}

--- a/helm-charts/cloudnative-pg-clusters/templates/clusters.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/clusters.yaml
@@ -108,6 +108,12 @@ spec:
   monitoring: {{ toYaml $.Values.defaults.cluster.monitoring | nindent 4 }}
   {{- end }}
 
+  {{- if $clusterConfig.podTemplate }}
+  podTemplate: {{ toYaml $clusterConfig.podTemplate | nindent 4 }}
+  {{- else if $.Values.defaults.cluster.podTemplate }}
+  podTemplate: {{ toYaml $.Values.defaults.cluster.podTemplate | nindent 4 }}
+  {{- end }}
+
   # Bootstrap configuration for initial database setup (optional)
   {{- if $clusterConfig.bootstrap }}
   bootstrap: {{ toYaml $clusterConfig.bootstrap | nindent 4 }}

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -22,6 +22,11 @@ defaults:
           key: queries
       disableDefaultQueries: false
       enablePodMonitor: false
+    podTemplate:
+      metadata:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9187"
     postgresGID: 26
     postgresUID: 26
     primaryUpdateMethod: switchover

--- a/helm-charts/longhorn/templates/authorization-policy.yaml
+++ b/helm-charts/longhorn/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $prometheusPrincipal := "cluster.local/ns/monitoring/sa/monitoring-prometheus-server" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -56,6 +57,7 @@ spec:
             principals:
               - cluster.local/ns/{{ .Values.namespace }}/sa/longhorn-service-account
               - cluster.local/ns/{{ .Values.namespace }}/sa/longhorn-ui-service-account
+              - {{ $prometheusPrincipal }}
       to:
         - operation:
             ports:

--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -2,6 +2,10 @@ name: longhorn
 namespace: longhorn-system
 
 longhorn:
+  longhornManager:
+    serviceAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9500"
   preUpgradeChecker:
     jobEnabled: false
   persistence:

--- a/helm-charts/monitoring/Chart.lock
+++ b/helm-charts/monitoring/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 10.5.15
+- name: prometheus-blackbox-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 11.12.0
 digest: sha256:37597984d49e77bba2bf892e85c2cec8e12bc2cae85eb9860941b9ac020af2b5
-generated: "2026-06-26T05:54:09.892278531Z"
+generated: "2026-07-05T21:00:00.000000000Z"

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -2,11 +2,14 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.1.3
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: prometheus
   version: 29.13.0
+  repository: https://prometheus-community.github.io/helm-charts
+- name: prometheus-blackbox-exporter
+  version: 11.12.0
   repository: https://prometheus-community.github.io/helm-charts
 - name: loki
   version: 7.0.0

--- a/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
+++ b/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
@@ -1,0 +1,53 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-telegram-config
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        alertmanager.yml: |
+          global:
+            resolve_timeout: 5m
+          route:
+            receiver: telegram
+            group_by:
+              - alertname
+              - namespace
+              - severity
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 4h
+          receivers:
+            - name: telegram
+              telegram_configs:
+                - bot_token: '{{ .telegram_bot_token }}'
+                  chat_id: {{ .telegram_chat_id }}
+                  send_resolved: true
+                  parse_mode: HTML
+  data:
+    - secretKey: telegram_bot_token
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: ALERTMANAGER_TELEGRAM_BOT_TOKEN
+    - secretKey: telegram_chat_id
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: ALERTMANAGER_TELEGRAM_CHAT_ID

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -166,6 +166,27 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  name: blackbox
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: blackbox
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9115"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
   name: monitoring-prometheus-pushgateway
   namespace: {{ .Values.namespace }}
 spec:

--- a/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
+++ b/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
@@ -1,0 +1,80 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: blackbox-scrape-config
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+      data:
+        blackbox-scrape-config.yml: |
+          - job_name: blackbox-https
+            metrics_path: /probe
+            params:
+              module:
+                - http_2xx
+            static_configs:
+              - targets:
+                - {{ .gateway_url | quote }}
+                - {{ .grafana_url | quote }}
+                - {{ .prometheus_url | quote }}
+                - {{ .argocd_url | quote }}
+                - {{ .umami_url | quote }}
+            relabel_configs:
+              - source_labels:
+                  - __address__
+                target_label: __param_target
+              - source_labels:
+                  - __param_target
+                target_label: instance
+              - target_label: __address__
+                replacement: blackbox:9115
+  data:
+    - secretKey: gateway_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: BLACKBOX_PROBE_GATEWAY_URL
+    - secretKey: grafana_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: BLACKBOX_PROBE_GRAFANA_URL
+    - secretKey: prometheus_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: BLACKBOX_PROBE_PROMETHEUS_URL
+    - secretKey: argocd_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: BLACKBOX_PROBE_ARGOCD_URL
+    - secretKey: umami_url
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: monitoring
+        metadataPolicy: None
+        property: BLACKBOX_PROBE_UMAMI_URL

--- a/helm-charts/monitoring/templates/heartbeat.yaml
+++ b/helm-charts/monitoring/templates/heartbeat.yaml
@@ -77,3 +77,43 @@ spec:
     - min: 200
       max: 299
   interval: 5m
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $grafanaEndpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $grafanaEndpointTypes }}
+    - secretKey: grafana-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: heartbeats
+        metadataPolicy: None
+        property: grafana-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: grafana-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: grafana-heartbeat
+    targetEndpointKey: grafana-target-endpoint
+    healthyEndpointKey: grafana-healthy-endpoint
+    unhealthyEndpointKey: grafana-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -60,8 +60,28 @@ prometheus:
     # Live 2026-07-05: ~8.3GiB on disk at 7d retention (~1.2GiB/day). 30d ≈ 36GiB TSDB; 100GB cap matches PVC budget.
     retentionSize: 100GB
     retention: 30d
+    extraSecretMounts:
+      - name: blackbox-scrape-config
+        mountPath: /etc/prometheus/secrets/blackbox
+        secretName: blackbox-scrape-config
+        readOnly: true
+    scrapeConfigFiles:
+      - /etc/prometheus/secrets/blackbox/blackbox-scrape-config.yml
   alertmanager:
-    enabled: false
+    enabled: true
+    resources: *smallResources
+    persistence:
+      enabled: true
+      size: 1Gi
+    config:
+      enabled: false
+    extraArgs:
+      config.file: /etc/secrets/alertmanager/alertmanager.yml
+    extraSecretMounts:
+      - name: alertmanager-config
+        mountPath: /etc/secrets/alertmanager
+        secretName: alertmanager-telegram-config
+        readOnly: true
   kube-state-metrics:
     resources: *smallResources
   prometheus-node-exporter:
@@ -94,6 +114,62 @@ prometheus:
                 sum by (namespace, pod) (
                   container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
                 )
+    alerting_rules.yml:
+      groups:
+        - name: cluster-health
+          rules:
+            - alert: DeploymentUnavailable
+              expr: kube_deployment_status_replicas_unavailable > 0
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has unavailable replicas
+                description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} reports {{ $value }} unavailable replica(s) for more than 10 minutes.
+            - alert: PodNotReady
+              expr: kube_pod_status_ready{condition="true"} == 0 and on(namespace, pod) kube_pod_status_phase{phase="Running"} == 1
+              for: 15m
+              labels:
+                severity: warning
+              annotations:
+                summary: Pod {{ $labels.namespace }}/{{ $labels.pod }} is not ready
+                description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been running but not ready for more than 15 minutes.
+            - alert: ScrapeTargetDown
+              expr: up == 0
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: Prometheus scrape target {{ $labels.job }} is down
+                description: Target {{ $labels.instance }} in job {{ $labels.job }} has been unreachable for more than 10 minutes.
+            - alert: NodeNotReady
+              expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+              for: 5m
+              labels:
+                severity: critical
+              annotations:
+                summary: Node {{ $labels.node }} is not ready
+                description: Node {{ $labels.node }} has been NotReady for more than 5 minutes.
+            - alert: CertificateExpiringSoon
+              expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < 7 * 24 * 3600
+              for: 1h
+              labels:
+                severity: warning
+              annotations:
+                summary: Certificate {{ $labels.name }} in {{ $labels.namespace }} expires soon
+                description: Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 7 days.
+            - alert: BlackboxProbeFailed
+              expr: probe_success{job="blackbox-https"} == 0
+              for: 5m
+              labels:
+                severity: warning
+              annotations:
+                summary: Blackbox probe failed for {{ $labels.instance }}
+                description: HTTPS probe to {{ $labels.instance }} has been failing for more than 5 minutes.
+
+prometheus-blackbox-exporter:
+  fullnameOverride: blackbox
+  resources: *smallResources
 
 grafana:
   resources:

--- a/helm-charts/teslamate/templates/heartbeat.yaml
+++ b/helm-charts/teslamate/templates/heartbeat.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $endpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $endpointTypes }}
+    - secretKey: {{ $.Values.name }}-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: heartbeats
+        metadataPolicy: None
+        property: {{ $.Values.name }}-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: {{ .Values.name }}-heartbeat
+    targetEndpointKey: {{ .Values.name }}-target-endpoint
+    healthyEndpointKey: {{ .Values.name }}-healthy-endpoint
+    unhealthyEndpointKey: {{ .Values.name }}-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m

--- a/helm-charts/umami/templates/heartbeat.yaml
+++ b/helm-charts/umami/templates/heartbeat.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+{{- $endpointTypes := list "target" "healthy" "unhealthy" }}
+{{- range $endpointTypes }}
+    - secretKey: {{ $.Values.name }}-{{ . }}-endpoint
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: heartbeats
+        metadataPolicy: None
+        property: {{ $.Values.name }}-{{ . }}-endpoint
+{{- end }}
+---
+apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: {{ .Values.name }}-heartbeat
+  namespace: {{ .Values.namespace }}
+spec:
+  endpointsSecret:
+    name: {{ .Values.name }}-heartbeat
+    targetEndpointKey: {{ .Values.name }}-target-endpoint
+    healthyEndpointKey: {{ .Values.name }}-healthy-endpoint
+    unhealthyEndpointKey: {{ .Values.name }}-unhealthy-endpoint
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+  interval: 5m


### PR DESCRIPTION
## Summary

Closes the monitoring gaps identified in the Prometheus/WebGazer review:

1. **Prometheus alerting** — enables Alertmanager with Telegram receiver and six cluster-health alert rules (deployments, pods, scrape targets, nodes, cert expiry, blackbox probes).
2. **Grafana heartbeat** — internal health check pushed to WebGazer.
3. **Platform `/metrics` scraping** — ArgoCD (service annotations), CNPG PostgreSQL pods (9187), Longhorn manager (9500), with Istio AuthorizationPolicies for Prometheus pod-IP scrapes.
4. **Blackbox exporter** — HTTPS probes for five critical public/internal URLs (URLs sourced from 1Password).
5. **Expanded Heartbeat CRs** — umami, teslamate, argocd, blocky (plus existing gateway/prometheus/loki/home-assistant/jellyfin).

## 1Password secrets required before merge

### New item: `monitoring`

| Field | Purpose |
|-------|---------|
| `ALERTMANAGER_TELEGRAM_BOT_TOKEN` | Telegram bot token for alert notifications |
| `ALERTMANAGER_TELEGRAM_CHAT_ID` | Telegram chat ID (numeric) |
| `BLACKBOX_PROBE_GATEWAY_URL` | e.g. `https://otaru.siutsin.com/httpbin/status/200` |
| `BLACKBOX_PROBE_GRAFANA_URL` | e.g. `https://grafana.internal.siutsin.com/api/health` |
| `BLACKBOX_PROBE_PROMETHEUS_URL` | e.g. `https://prometheus.internal.siutsin.com/-/healthy` |
| `BLACKBOX_PROBE_ARGOCD_URL` | e.g. `https://argocd.internal.siutsin.com/argocd/healthz` |
| `BLACKBOX_PROBE_UMAMI_URL` | e.g. `https://analytics.siutsin.com/api/heartbeat` |

### Extend existing item: `heartbeats`

Add WebGazer endpoint triplets (`-target-endpoint`, `-healthy-endpoint`, `-unhealthy-endpoint`) for each new monitor:

| Service | Suggested internal target |
|---------|------------------------|
| `grafana` | `http://monitoring-grafana.monitoring:80/api/health` |
| `argocd` | `http://argocd-server.argocd:8080/healthz` |
| `umami` | `http://umami.umami:3000/api/heartbeat` |
| `teslamate` | `http://teslamate.teslamate:4000/` |
| `blocky` | `http://blocky.blocky:4000/metrics` |

Target/healthy/unhealthy URLs come from WebGazer monitor setup. Create external WebGazer monitors for Grafana, ArgoCD, and Umami to double-cover alongside blackbox.

## Test plan

- [x] `make test`
- [ ] After secrets sync: verify `ExternalSecret` resources become `SecretSynced`
- [ ] Confirm Alertmanager pod starts with mounted Telegram config
- [ ] Confirm blackbox targets appear in Prometheus (`job=blackbox-https`)
- [ ] Send test alert via `amtool` or trigger a synthetic `up == 0`