### PR TITLE
chore(monitoring): bump helm dependencies to latest versions

### DIFF
--- a/helm-charts/monitoring/Chart.lock
+++ b/helm-charts/monitoring/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 29.13.0
+  version: 29.14.0
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 11.12.0
+  version: 11.15.1
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 7.0.0
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.57.7
+  version: 0.57.8
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 10.5.15
-digest: sha256:6ea5436992814bfdb8a5659e6b9d5975e813a3defc9afb7496519398955bc2f8
-generated: "2026-07-05T21:23:45.867627313Z"
+digest: sha256:fc8978f306721e4b2ab2a166194685c56e64c1217894df58e805052caaa01c24
+generated: "2026-07-05T22:32:34.2314+01:00"

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -2,20 +2,20 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: prometheus
-  version: 29.13.0
+  version: 29.14.0
   repository: https://prometheus-community.github.io/helm-charts
 - name: prometheus-blackbox-exporter
-  version: 11.12.0
+  version: 11.15.1
   repository: https://prometheus-community.github.io/helm-charts
 - name: loki
   version: 7.0.0
   repository: https://grafana.github.io/helm-charts
 - name: fluent-bit
-  version: 0.57.7
+  version: 0.57.8
   repository: https://fluent.github.io/helm-charts
 - name: grafana
   version: 10.5.15


### PR DESCRIPTION
Bump monitoring subchart dependencies to the latest versions available in their upstream indexes:

| Dependency | Previous | Latest |
|------------|----------|--------|
| prometheus | 29.11.0 | 29.14.0 |
| prometheus-blackbox-exporter | 11.12.0 | 11.15.1 |
| fluent-bit | 0.57.7 | 0.57.8 |
| loki | 7.0.0 | 7.0.0 (unchanged) |
| grafana | 10.5.15 | 10.5.15 (unchanged) |

Regenerated `Chart.lock` with `make update-helm-deps`. `make test` passed.