### PR TITLE
Add ephemeral-storage metrics exporter to monitoring chart

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: "right-sizing"
+description: >-
+  Right-size otaru workloads via KRR (CPU/memory) and Prometheus ephemeral-storage
+  metrics. Read incident comments as guardrails, apply downsizes and upsizes in one
+  GitOps PR, verify rollout. Invoke as /right-sizing from self-heal loops or manually.
+metadata:
+  short-description: "KRR and ephemeral-storage right-sizing for otaru"
+---
+
+# Otaru workload right-sizing
+
+Right-size cluster workloads on the otaru home-lab. The cluster is memory-tight —
+apply **both** downsizes and upsizes in the same PR when safe.
+
+Invoke as `/right-sizing`. Called from the hourly self-heal loop when healthy and
+no pass ran in the last 24 hours (see `.claude/commands/otaru-self-heal-loop.md`).
+
+## When to run
+
+- Cluster healthy and journal has no right-sizing pass in the last 24 hours.
+- Sooner when workloads show OOMKills, probe failures, scheduling pressure, or
+  ephemeral-storage evictions / `DiskPressure`.
+- Skip guarded workloads (see below) even when metrics suggest downsizing.
+
+## Part 1 — CPU and memory (KRR)
+
+### Collect recommendations
+
+Resolve `<prometheus-url-via-ingress>` from `httpRoutes.prometheus` in
+`helm-charts/monitoring/values.yaml` (hostname pattern in
+`templates/route-internal.yaml`: `https://<route-key>.internal.siutsin.com`).
+Do not use `*.svc.cluster.local` from off-cluster; use the ingress URL.
+
+```bash
+krr simple -p <prometheus-url-via-ingress> -f json -q > /tmp/krr-otaru-$(date +%F).json
+```
+
+### Build the change set
+
+For each candidate workload in `helm-charts/**/values.yaml` (and chart templates
+when resources live there):
+
+1. Read inline resource comments for past incidents (OOM, probe failures, scheduling pressure). **Do not downsize past those guardrails.**
+2. **Downsize** when KRR peak is well below the request and no incident comment blocks it.
+3. **Upsize** when KRR peak exceeds the request/limit or live pods show OOM risk.
+4. Skip guarded workloads when comments document repeated OOM or sync spikes (for example changedetection app, blocky, grafanas, argocd, jellyfin).
+
+### Helm chart rules
+
+See `AGENTS.md`:
+
+- Set memory requests equal to memory limits.
+- Do not set CPU limits unless the user explicitly asks.
+- Set explicit ephemeral-storage requests and limits.
+- Add an inline `# KRR YYYY-MM-DD:` comment for CPU/memory changes stating the observed peak/symptom and why the previous value was wrong.
+
+KRR covers **CPU and memory only** — not ephemeral-storage.
+
+## Part 2 — GitOps PR
+
+1. Branch from `master`, edit only in-scope chart values/templates.
+2. Run `make test` and fix failures.
+3. Open one PR covering all safe changes for that pass (KRR + ephemeral-storage).
+4. Run `/pr-autofix` — `auto_merge=false` on unattended cron fires; merge when the user is present and the PR is green.
+
+## Part 3 — Verify rollout
+
+After merge:
+
+- Confirm Argo CD apps sync to the new revision for touched workloads.
+- Inspect pod `resources` and `lastState.terminated.reason` for OOMKill.
+- Watch upsized workloads for 24h (prometheus CPU/memory, browser, umami, etc.).
+
+### Hotfix regressions
+
+Open a follow-up PR immediately if rollout breaks a workload:
+
+- **OOM after downsize** — bump memory above the failing limit; comment exit code
+  and workload (for example happy OOMKill exit 137 at 640Mi → 896Mi).
+- **Init/exec format error on nuc-00** — arm64-only images on amd64; pin
+  `nodeSelector: kubernetes.io/arch: arm64` when charts use arm64-only digests.
+
+Journal each pass in `.scratchpad/SELF_HEALING.md` with KRR score, workloads
+changed, PR URL, and rollout result.
+
+## Part 4 — Ephemeral-storage (Prometheus)
+
+KRR does not recommend ephemeral-storage. Use metrics from
+`k8s-ephemeral-storage-metrics` (subchart of `helm-charts/monitoring`) scraped
+into Prometheus as job `k8s-ephemeral-storage-metrics`.
+
+Query via the same `<prometheus-url-via-ingress>` as KRR (HTTP API or Grafana).
+
+### Key metrics
+
+| Metric | Use |
+| ------ | --- |
+| `ephemeral_storage_pod_usage` | Peak bytes per pod |
+| `ephemeral_storage_container_volume_usage` | Per-container emptyDir / writable layers |
+| `ephemeral_storage_container_limit_percentage` | Usage vs configured limit |
+| `ephemeral_storage_node_percentage` | Node-level disk pressure context |
+
+Compare configured limits with kube-state-metrics:
+
+```promql
+kube_pod_container_resource_limits{resource="ephemeral_storage", namespace="happy"}
+```
+
+### Example queries
+
+Peak pod ephemeral usage over 14 days:
+
+```promql
+max_over_time(ephemeral_storage_pod_usage{pod_namespace="happy"}[14d])
+```
+
+Workloads approaching their limit (>80%):
+
+```promql
+ephemeral_storage_container_limit_percentage > 80
+```
+
+Top consumers cluster-wide:
+
+```promql
+topk(20, max_over_time(ephemeral_storage_pod_usage[14d]))
+```
+
+### Build ephemeral-storage changes
+
+1. Run the queries above (instant query API or `query_range` for history).
+2. For each workload above ~70% of limit or with eviction history, bump `ephemeral-storage` request and limit together in the Helm chart.
+3. Add an inline comment with the observed peak bytes or percentage and trigger (for example `DiskPressure`, eviction event) — not a `# KRR` comment.
+4. Prefer `emptyDir.sizeLimit` for `/tmp` or cache volumes when the workload writes locally and the chart supports it.
+5. Do **not** use these metrics for PVC/Longhorn volumes — exporter ignores CSI-backed storage.
+
+### Limits
+
+- Exporter does not monitor generic ephemeral volumes (CSI-backed).
+- No CLI recommender — interpret PromQL peaks manually with headroom (~20–30%).
+- Combine ephemeral changes with KRR CPU/memory in the same PR when both apply.

--- a/helm-charts/monitoring/Chart.lock
+++ b/helm-charts/monitoring/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 10.5.15
-digest: sha256:fc8978f306721e4b2ab2a166194685c56e64c1217894df58e805052caaa01c24
-generated: "2026-07-05T22:32:34.2314+01:00"
+- name: k8s-ephemeral-storage-metrics
+  repository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+  version: 1.19.2
+digest: sha256:0f02f98037949dcba8e515e791dea03c6e8c703b8d3b982916d869c784a996b1
+generated: "2026-07-05T22:36:20.913853+01:00"

--- a/helm-charts/monitoring/Chart.yaml
+++ b/helm-charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: prometheus
@@ -20,3 +20,6 @@ dependencies:
 - name: grafana
   version: 10.5.15
   repository: https://grafana.github.io/helm-charts
+- name: k8s-ephemeral-storage-metrics
+  version: 1.19.2
+  repository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -166,6 +166,27 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  name: k8s-ephemeral-storage-metrics
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: k8s-ephemeral-storage-metrics
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9100"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
   name: blackbox
   namespace: {{ .Values.namespace }}
 spec:

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -67,6 +67,11 @@ prometheus:
         readOnly: true
     scrapeConfigFiles:
       - /etc/prometheus/secrets/blackbox/blackbox-scrape-config.yml
+    extraScrapeConfigs: |
+      - job_name: k8s-ephemeral-storage-metrics
+        static_configs:
+          - targets:
+              - k8s-ephemeral-storage-metrics.monitoring.svc.cluster.local:9100
   alertmanager:
     enabled: true
     resources: *smallResources
@@ -170,6 +175,29 @@ prometheus:
 prometheus-blackbox-exporter:
   fullnameOverride: blackbox
   resources: *smallResources
+
+k8s-ephemeral-storage-metrics:
+  deploy_type: Deployment
+  pod_labels:
+    istio.io/dataplane-mode: none
+  prometheus:
+    enable: true
+    rules:
+      enable: false
+  serviceMonitor:
+    enable: false
+  image:
+    repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
+    tag: 1.19.2
+    imagePullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+      ephemeral-storage: 64Mi
+    limits:
+      memory: 128Mi
+      ephemeral-storage: 64Mi
 
 grafana:
   resources:


### PR DESCRIPTION
## Summary

- Add `k8s-ephemeral-storage-metrics` v1.19.2 as a dependency of the monitoring Helm chart
- Configure Prometheus static scrape of the exporter on port 9100
- Add Istio AuthorizationPolicy allowing prometheus → exporter
- Document ephemeral-storage right-sizing workflow in `.claude/skills/right-sizing/SKILL.md` (Part 4)

## Test plan

- [x] `make test` passes locally
- [ ] Argo CD syncs monitoring app after merge
- [ ] Prometheus scrape target `k8s-ephemeral-storage-metrics` is up
- [ ] `ephemeral_storage_*` metrics queryable via ingress