### PR TITLE
fix(argocd): restore repo-server TLS under ambient mesh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,18 @@ Do not remove a worktree, local branch, or remote branch that another agent may
 still be using. Always report which of your own worktrees were removed and which
 remain open.
 
+## GitHub CLI
+
+When waiting on pull requests or CI, use `gh` watch commands instead of `sleep`
+loops or manual polling.
+
+- PR checks: `gh pr checks <number> --watch --fail-fast`
+- Workflow run: `gh run watch <run-id> --exit-status`
+- One-shot status: `gh pr checks <number>` or `gh pr view <number> --json statusCheckRollup`
+
+For cluster or workload readiness, prefer `kubectl wait`, `kubectl rollout
+status`, or `kubectl get <resource> -w` rather than `sleep`.
+
 ## Testing Protocol
 
 Always run `make test` after making changes and fix any failures immediately.

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -60,6 +60,10 @@ argo-cd:
       reposerver.parallelism.limit: 2
       # Allow cold-cache manifest generation queues to drain before controllers mark comparison as Unknown.
       controller.repo.server.timeout.seconds: 180
+      # cert-manager maintains argocd-repo-server-tls; enable strict verification now that
+      # the Secret exists (Helm only presets this when certificateSecret.enabled is true).
+      controller.repo.server.strict.tls: true
+      server.repo.server.strict.tls: true
       server.repo.server.timeout.seconds: 180
       applicationsetcontroller.repo.server.timeout.seconds: 180
       server.insecure: true
@@ -95,7 +99,7 @@ argo-cd:
     enabled: false
   controller:
     replicas: 1
-    deploymentAnnotations:
+    statefulsetAnnotations:
       secret.reloader.stakater.com/reload: argocd-repo-server-tls
     metrics:
       enabled: true
@@ -131,6 +135,13 @@ argo-cd:
   repoServer:
     deploymentAnnotations:
       secret.reloader.stakater.com/reload: argocd-repo-server-tls
+    # Ambient mesh HBONE intercepts port 8081 and breaks repo-server gRPC TLS; keep
+    # manifest-generation traffic on direct pod networking like onepassword-connect.
+    podLabels:
+      istio.io/dataplane-mode: none
+    service:
+      annotations:
+        mesh.otaru.io/non-ambient-endpoints: "true"
     metrics:
       enabled: true
     replicas: 1


### PR DESCRIPTION
## Problem

After #2695 added cert-manager TLS for `argocd-repo-server-tls`, comparisons still failed with `transport: authentication handshake failed: EOF`. OpenSSL from the application-controller showed no peer certificate — ambient mesh HBONE was intercepting port 8081 before traffic reached the repo-server pod.

## Solution

- Annotate `argocd-repo-server` Service with `mesh.otaru.io/non-ambient-endpoints: "true"`
- Label repo-server pods `istio.io/dataplane-mode: none` (required by Kyverno)
- Enable `controller.repo.server.strict.tls` and `server.repo.server.strict.tls` now that the stable cert is reachable
- Fix Reloader annotation to use `statefulsetAnnotations` for the controller
- Document `gh pr checks --watch` in AGENTS.md

## Verification

- [x] `make test`
- [x] Live cluster: TLS handshake succeeds, `monitoring` and `argocd` apps reach `OutOfSync` (comparisons working)