### PR TITLE
fix(argocd): restore non-ambient repo-server and redis with cert-manager TLS

### DIFF
--- a/helm-charts/argocd/templates/certificate-repo-server.yaml
+++ b/helm-charts/argocd/templates/certificate-repo-server.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.integrations.certManager }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-repo-server-tls
+  namespace: {{ .Values.namespace }}
+spec:
+  secretName: argocd-repo-server-tls
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: argocd-repo-server
+  dnsNames:
+    - argocd-repo-server
+    - argocd-repo-server.{{ .Values.namespace }}
+    - argocd-repo-server.{{ .Values.namespace }}.svc
+    - argocd-repo-server.{{ .Values.namespace }}.svc.cluster.local
+  usages:
+    - server auth
+{{- end }}

--- a/helm-charts/argocd/templates/issuer-repo-server.yaml
+++ b/helm-charts/argocd/templates/issuer-repo-server.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.integrations.certManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: argocd-repo-server
+  namespace: {{ .Values.namespace }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -1,5 +1,6 @@
 namespace: argocd
 integrations:
+  certManager: true
   externalSecrets: true
 
 argo-cd:
@@ -59,12 +60,10 @@ argo-cd:
       reposerver.parallelism.limit: 2
       # Allow cold-cache manifest generation queues to drain before controllers mark comparison as Unknown.
       controller.repo.server.timeout.seconds: 180
-      # Ambient HBONE encrypts east-west traffic; app-layer TLS on repo-server:8081 conflicts
-      # with waypoint interception and caused handshake EOF when argocd-repo-server-tls existed.
-      reposerver.disable.tls: true
-      controller.repo.server.plaintext: true
-      server.repo.server.plaintext: true
-      applicationsetcontroller.repo.server.plaintext: true
+      # cert-manager maintains argocd-repo-server-tls; enable strict verification now that
+      # the Secret exists (Helm only presets this when certificateSecret.enabled is true).
+      controller.repo.server.strict.tls: true
+      server.repo.server.strict.tls: true
       server.repo.server.timeout.seconds: 180
       applicationsetcontroller.repo.server.timeout.seconds: 180
       server.insecure: true
@@ -100,6 +99,8 @@ argo-cd:
     enabled: false
   controller:
     replicas: 1
+    statefulsetAnnotations:
+      secret.reloader.stakater.com/reload: argocd-repo-server-tls
     metrics:
       enabled: true
     resources: *controllerResources
@@ -127,11 +128,27 @@ argo-cd:
       enabled: true
     pdb: *singletonPdb
   redis:
+    # Repo-server runs outside ambient; redis must match so manifest/git caches are reachable
+    # without waypoint identity checks blocking non-ambient callers.
+    podLabels:
+      istio.io/dataplane-mode: none
+    service:
+      annotations:
+        mesh.otaru.io/non-ambient-endpoints: "true"
     resources: *redisResources
     pdb: *singletonPdb
     secretInit:
       enabled: false
   repoServer:
+    deploymentAnnotations:
+      secret.reloader.stakater.com/reload: argocd-repo-server-tls
+    # Ambient waypoint intercepts repo-server:8081 gRPC and breaks manifest generation.
+    # Keep manifest-generation traffic on direct pod networking like onepassword-connect.
+    podLabels:
+      istio.io/dataplane-mode: none
+    service:
+      annotations:
+        mesh.otaru.io/non-ambient-endpoints: "true"
     metrics:
       enabled: true
     replicas: 1

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -33,6 +33,7 @@ clusterSecretStorePolicy:
     monitoring:
       - grafana
       - heartbeats
+      - monitoring
     openclaw:
       - openclaw
     teslamate:


### PR DESCRIPTION
## Summary

- Reverts the ambient plaintext gRPC approach from #2698, which left repo-server unreachable through the shared waypoint and put 56/58 Argo CD Applications in `Unknown`.
- Restores the proven non-ambient endpoint opt-out for `argocd-repo-server`, matching the `onepassword-connect` bootstrap pattern.
- Adds the same non-ambient opt-out for `argocd-redis` so repo-server git/manifest caches work once repo-server is outside ambient.
- Re-enables cert-manager `argocd-repo-server-tls` with strict client verification for app-layer TLS on the non-ambient control-plane path.

## Test plan

- [x] `make test`
- [ ] Merge and confirm Argo CD `argocd` Application syncs without drift
- [ ] Confirm all Applications return to `Synced`/`Healthy`
- [ ] Confirm `monitoring` stack finishes deploying