### PR TITLE
fix(kyverno-policy): allow heartbeats item for argocd ExternalSecrets

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -7,6 +7,7 @@ clusterSecretStorePolicy:
   allowedNamespaces:
     argocd:
       - argocd-secret
+      - heartbeats
       - openclaw
       - Otaru - GitHub Private
     blocky:


### PR DESCRIPTION
Adds `heartbeats` to the argocd namespace 1Password key allowlist so `argocd-heartbeat` ExternalSecret can sync.