### PR TITLE
fix: resolve remaining cluster drift after monitoring stack rollout

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/clusters.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/clusters.yaml
@@ -108,10 +108,10 @@ spec:
   monitoring: {{ toYaml $.Values.defaults.cluster.monitoring | nindent 4 }}
   {{- end }}
 
-  {{- if $clusterConfig.podTemplate }}
-  podTemplate: {{ toYaml $clusterConfig.podTemplate | nindent 4 }}
-  {{- else if $.Values.defaults.cluster.podTemplate }}
-  podTemplate: {{ toYaml $.Values.defaults.cluster.podTemplate | nindent 4 }}
+  {{- if $clusterConfig.inheritedMetadata }}
+  inheritedMetadata: {{ toYaml $clusterConfig.inheritedMetadata | nindent 4 }}
+  {{- else if $.Values.defaults.cluster.inheritedMetadata }}
+  inheritedMetadata: {{ toYaml $.Values.defaults.cluster.inheritedMetadata | nindent 4 }}
   {{- end }}
 
   # Bootstrap configuration for initial database setup (optional)

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -22,11 +22,10 @@ defaults:
           key: queries
       disableDefaultQueries: false
       enablePodMonitor: false
-    podTemplate:
-      metadata:
-        annotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "9187"
+    inheritedMetadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9187"
     postgresGID: 26
     postgresUID: 26
     primaryUpdateMethod: switchover

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -12,6 +12,7 @@ clusterSecretStorePolicy:
       - Otaru - GitHub Private
     blocky:
       - blocky
+      - heartbeats
     changedetection:
       - changedetection
     cloudflare-tunnel:
@@ -24,6 +25,7 @@ clusterSecretStorePolicy:
     umami:
       - Umami
       - b2-secret-cloudnative-pg
+      - heartbeats
     home-assistant:
       - heartbeats
     jung2bot:

--- a/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
+++ b/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
@@ -30,8 +30,8 @@ spec:
           receivers:
             - name: telegram
               telegram_configs:
-                - bot_token: '{{ .telegram_bot_token }}'
-                  chat_id: {{ .telegram_chat_id }}
+                - bot_token: '{{`{{ .telegram_bot_token }}`}}'
+                  chat_id: {{`{{ .telegram_chat_id }}`}}
                   send_resolved: true
                   parse_mode: HTML
   data:

--- a/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
+++ b/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
@@ -23,11 +23,11 @@ spec:
                 - http_2xx
             static_configs:
               - targets:
-                - {{ .gateway_url | quote }}
-                - {{ .grafana_url | quote }}
-                - {{ .prometheus_url | quote }}
-                - {{ .argocd_url | quote }}
-                - {{ .umami_url | quote }}
+                - {{`{{ .gateway_url | quote }}`}}
+                - {{`{{ .grafana_url | quote }}`}}
+                - {{`{{ .prometheus_url | quote }}`}}
+                - {{`{{ .argocd_url | quote }}`}}
+                - {{`{{ .umami_url | quote }}`}}
             relabel_configs:
               - source_labels:
                   - __address__


### PR DESCRIPTION
## Summary

- Add `heartbeats` to blocky and umami Kyverno 1Password allowlists so heartbeat ExternalSecrets sync
- Replace deprecated CNPG `podTemplate` with `inheritedMetadata` for prometheus scrape annotations (CNPG 0.28+)
- Escape ExternalSecret template variables in monitoring Helm charts so Helm does not consume ESO `{{ .field }}` placeholders at render time

## Root cause

Helm rendered `{{ .telegram_bot_token }}` and `{{ .gateway_url }}` as empty strings when templating the monitoring ExternalSecrets. ESO then baked those empty literals into the live ExternalSecret specs, so alertmanager crashed (`missing chat_id`) and blackbox probe targets were blank even though 1Password values were present.

## Test plan

- [x] `make test`
- [ ] All Argo CD apps Synced/Healthy after merge
- [ ] `monitoring-alertmanager-0` Running/Ready
- [ ] `blocky` and `umami` apps sync heartbeat ExternalSecrets
- [ ] `cloudnative-pg-clusters` comparison error cleared