### PR TITLE
fix(cnpg): keep operator and postgres pods off ambient dataplane

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -108,6 +108,9 @@ local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extV
 local cnpgHelm = {
   releaseName: 'cloudnative-pg',
   valuesObject: {
+    podLabels: {
+      'istio.io/dataplane-mode': 'none',
+    },
     resources: {
       requests: {
         cpu: '100m',

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -26,6 +26,9 @@ defaults:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9187"
+      labels:
+        # CNPG operator scrapes instance status over direct pod HTTPS; keep DB pods off the ambient dataplane.
+        istio.io/dataplane-mode: none
     postgresGID: 26
     postgresUID: 26
     primaryUpdateMethod: switchover


### PR DESCRIPTION
## Summary

- Set `istio.io/dataplane-mode: none` on the CloudNativePG operator via `argocd/manifest.jsonnet`
- Add the same label to postgres pods through `inheritedMetadata.labels` in `cloudnative-pg-clusters`

## Problem

After #2702 fixed the `podTemplate` comparison error, Argo CD began evaluating CNPG Cluster health and reported `Unknown`. Operator logs show status extraction failing with `connection reset by peer` on `https://<pod-ip>:8000/pg/status` across ambient namespaces.

## Test plan

- [x] `make test`
- [ ] `cloudnative-pg-clusters` app becomes Synced/Healthy
- [ ] CNPG Cluster phase returns to healthy (not HTTP communication error)