### PR TITLE
fix(cnpg): keep barman-cloud plugin off ambient dataplane

### DIFF
--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: barman-cloud
+        # CNPG operator reaches the plugin over direct gRPC; keep it off the ambient dataplane.
+        istio.io/dataplane-mode: none
     spec:
       containers:
         - args:


### PR DESCRIPTION
Completes CNPG ambient fix chain from #2703: operator (non-ambient) must reach barman plugin without connection resets.