### PR TITLE
fix(argocd): ignore alertmanager subPath null SSA drift on monitoring app

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -51,6 +51,15 @@ local cleanerExcludeDeleted = [{
   jqPathExpressions: ['.spec.resourcePolicySet.resourceSelectors[].excludeDeleted'],
 }];
 
+local alertmanagerSubPathNull = [{
+  group: 'apps',
+  kind: 'StatefulSet',
+  name: 'monitoring-alertmanager',
+  jqPathExpressions: [
+    '.spec.template.spec.containers[].volumeMounts[]?.subPath',
+  ],
+}];
+
 local cnpgClusterOperatorDefaults = [{
   group: 'postgresql.cnpg.io',
   kind: 'Cluster',
@@ -77,6 +86,10 @@ local _ignoreDifferences = {
   serviceMesh: {
     'istio-base': webhookCaBundleAndFailurePolicy('istiod-default-validator'),
     istiod: webhookCaBundleAndFailurePolicy('istio-validator-istio-system'),
+  },
+  monitoring: {
+    // prometheus-community alertmanager chart always renders subPath: null for extraSecretMounts.
+    alertmanager: alertmanagerSubPathNull,
   },
   security: {
     // Re-check this list against rendered Kyverno CRDs when bumping the kyverno chart.
@@ -206,7 +219,14 @@ local monitoring = [
   { wave: '05', name: 'heartbeats', namespace: 'heartbeats-operator-system' },
   { wave: '05', name: 'kiali', namespace: 'kiali' },
   { wave: '10', name: 'metrics-server', namespace: 'monitoring' },
-  { wave: '10', name: 'monitoring', namespace: 'monitoring', helm: { valueFiles: _grafanaDashboards } },
+  {
+    wave: '10',
+    name: 'monitoring',
+    namespace: 'monitoring',
+    helm: { valueFiles: _grafanaDashboards },
+    syncOptions: ['RespectIgnoreDifferences=true'],
+    ignoreDifferences: _ignoreDifferences.monitoring.alertmanager,
+  },
 ];
 
 local scheduling = [


### PR DESCRIPTION
## Summary

- Ignore `subPath: null` on `monitoring-alertmanager` StatefulSet volumeMounts
- Enable `RespectIgnoreDifferences=true` on the monitoring Application

## Problem

The prometheus-community alertmanager subchart always renders `subPath: null` for `extraSecretMounts`. With `ServerSideApply=true`, Kubernetes omits empty optional fields on apply. Argo CD then reported the monitoring app OutOfSync even though alertmanager, prometheus, and blackbox were healthy.

## Fix

Add a targeted `ignoreDifferences` jqPath for the alertmanager StatefulSet, matching the pattern used for other SSA default-field drift (reloader, kyverno, istio webhooks).

## Test plan

- [x] `make test`
- [ ] Merge and confirm `monitoring` and `bootstrap` Applications are Synced/Healthy