### PR TITLE
fix(argocd): broaden alertmanager StatefulSet SSA ignoreDifferences

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -51,12 +51,35 @@ local cleanerExcludeDeleted = [{
   jqPathExpressions: ['.spec.resourcePolicySet.resourceSelectors[].excludeDeleted'],
 }];
 
-local alertmanagerSubPathNull = [{
+local alertmanagerSsaDefaults = [{
   group: 'apps',
   kind: 'StatefulSet',
   name: 'monitoring-alertmanager',
+  namespace: 'monitoring',
   jqPathExpressions: [
+    '.spec.minReadySeconds',
+    '.spec.persistentVolumeClaimRetentionPolicy',
+    '.spec.podManagementPolicy',
+    '.spec.updateStrategy',
+    '.spec.volumeClaimTemplates[]?.status',
     '.spec.template.spec.containers[].volumeMounts[]?.subPath',
+    '.spec.template.spec.containers[].livenessProbe.failureThreshold',
+    '.spec.template.spec.containers[].livenessProbe.periodSeconds',
+    '.spec.template.spec.containers[].livenessProbe.successThreshold',
+    '.spec.template.spec.containers[].livenessProbe.timeoutSeconds',
+    '.spec.template.spec.containers[].livenessProbe.httpGet.scheme',
+    '.spec.template.spec.containers[].readinessProbe.failureThreshold',
+    '.spec.template.spec.containers[].readinessProbe.periodSeconds',
+    '.spec.template.spec.containers[].readinessProbe.successThreshold',
+    '.spec.template.spec.containers[].readinessProbe.timeoutSeconds',
+    '.spec.template.spec.containers[].readinessProbe.httpGet.scheme',
+    '.spec.template.spec.containers[].terminationMessagePath',
+    '.spec.template.spec.containers[].terminationMessagePolicy',
+    '.spec.template.spec.dnsPolicy',
+    '.spec.template.spec.restartPolicy',
+    '.spec.template.spec.schedulerName',
+    '.spec.template.spec.terminationGracePeriodSeconds',
+    '.spec.template.spec.serviceAccount',
   ],
 }];
 
@@ -88,8 +111,8 @@ local _ignoreDifferences = {
     istiod: webhookCaBundleAndFailurePolicy('istio-validator-istio-system'),
   },
   monitoring: {
-    // prometheus-community alertmanager chart always renders subPath: null for extraSecretMounts.
-    alertmanager: alertmanagerSubPathNull,
+    // alertmanager subchart + ServerSideApply: kube defaults and subPath: null differ from rendered manifest.
+    alertmanager: alertmanagerSsaDefaults,
   },
   security: {
     // Re-check this list against rendered Kyverno CRDs when bumping the kyverno chart.


### PR DESCRIPTION
## Summary

- Expand `ignoreDifferences` for `monitoring-alertmanager` StatefulSet to cover all ServerSideApply default-field drift
- Add `namespace: monitoring` scoping to the ignore rule

## Problem

#2705 fixed `subPath: null` drift, but the monitoring app regressed to OutOfSync once bootstrap reconciled the Application CR. Additional SSA-defaulted fields (probes, `updateStrategy`, PVC retention policy, pod policy defaults) also differ from the rendered Helm manifest.

## Fix

Broaden jqPathExpressions on the alertmanager StatefulSet ignore rule, matching the pattern used for istio webhooks and reloader SSA drift.

## Test plan

- [x] `make test`
- [ ] Merge and confirm monitoring Application stays Synced/Healthy at master HEAD