### PR TITLE
fix(monitoring): wire blackbox scrape config into prometheus chart

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -39,6 +39,13 @@ httpRoutes:
       port: 80
 
 prometheus:
+  scrapeConfigFiles:
+    - /etc/prometheus/secrets/blackbox/blackbox-scrape-config.yml
+  extraScrapeConfigs: |
+    - job_name: k8s-ephemeral-storage-metrics
+      static_configs:
+        - targets:
+            - k8s-ephemeral-storage-metrics.monitoring.svc.cluster.local:9100
   configmapReload:
     prometheus:
       resources: *smallResources
@@ -65,13 +72,6 @@ prometheus:
         mountPath: /etc/prometheus/secrets/blackbox
         secretName: blackbox-scrape-config
         readOnly: true
-    scrapeConfigFiles:
-      - /etc/prometheus/secrets/blackbox/blackbox-scrape-config.yml
-    extraScrapeConfigs: |
-      - job_name: k8s-ephemeral-storage-metrics
-        static_configs:
-          - targets:
-              - k8s-ephemeral-storage-metrics.monitoring.svc.cluster.local:9100
   alertmanager:
     enabled: true
     resources: *smallResources


### PR DESCRIPTION
## Summary

- Move `scrapeConfigFiles` and `extraScrapeConfigs` to the prometheus subchart root in monitoring values

## Problem

Blackbox probe URLs were synced to `blackbox-scrape-config` and mounted into the prometheus pod, but `scrapeConfigFiles` was nested under `prometheus.server` where the chart does not read it. Prometheus never loaded `blackbox-https` scrape targets.

## Fix

Place `scrapeConfigFiles` and `extraScrapeConfigs` at `prometheus.*` per prometheus-community chart `values.yaml` / `templates/cm.yaml`.

## Test plan

- [x] `make test`
- [x] `helm template` shows `scrape_config_files` in prometheus ConfigMap
- [ ] After merge, confirm `blackbox-https` targets appear in Prometheus