### PR TITLE
fix(argocd): enable ServerSideDiff on monitoring Application

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -80,6 +80,10 @@ local alertmanagerSsaDefaults = [{
     '.spec.template.spec.schedulerName',
     '.spec.template.spec.terminationGracePeriodSeconds',
     '.spec.template.spec.serviceAccount',
+    '.spec.template.spec.volumes[].secret.defaultMode',
+    '.spec.volumeClaimTemplates[]?.apiVersion',
+    '.spec.volumeClaimTemplates[]?.kind',
+    '.spec.volumeClaimTemplates[]?.spec.volumeMode',
   ],
 }];
 
@@ -247,6 +251,7 @@ local monitoring = [
     name: 'monitoring',
     namespace: 'monitoring',
     helm: { valueFiles: _grafanaDashboards },
+    serverSideDiff: 'true',
     syncOptions: ['RespectIgnoreDifferences=true'],
     ignoreDifferences: _ignoreDifferences.monitoring.alertmanager,
   },


### PR DESCRIPTION
## Summary

- Enable `ServerSideDiff=true` on the monitoring Application (recommended with `ServerSideApply=true`)
- Extend alertmanager `ignoreDifferences` for `secret.defaultMode` and PVC template defaults

## Problem

After #2706 and #2707, monitoring stayed OutOfSync on `monitoring-alertmanager` despite broad ignore rules. Argo CD client-side diff still flagged SSA-defaulted secret `defaultMode` and PVC template fields.

## Fix

Use Argo CD ServerSideDiff for monitoring and cover the remaining alertmanager jqPaths.

## Test plan

- [x] `make test`
- [ ] Merge and confirm monitoring stays Synced/Healthy through prometheus config rollout