### PR TITLE
fix(monitoring): wrap blackbox scrape file in scrape_configs key

### DIFF
--- a/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
+++ b/helm-charts/monitoring/templates/blackbox-probes-external-secret.yaml
@@ -16,27 +16,28 @@ spec:
           reloader.stakater.com/auto: "true"
       data:
         blackbox-scrape-config.yml: |
-          - job_name: blackbox-https
-            metrics_path: /probe
-            params:
-              module:
-                - http_2xx
-            static_configs:
-              - targets:
-                - {{`{{ .gateway_url | quote }}`}}
-                - {{`{{ .grafana_url | quote }}`}}
-                - {{`{{ .prometheus_url | quote }}`}}
-                - {{`{{ .argocd_url | quote }}`}}
-                - {{`{{ .umami_url | quote }}`}}
-            relabel_configs:
-              - source_labels:
-                  - __address__
-                target_label: __param_target
-              - source_labels:
-                  - __param_target
-                target_label: instance
-              - target_label: __address__
-                replacement: blackbox:9115
+          scrape_configs:
+            - job_name: blackbox-https
+              metrics_path: /probe
+              params:
+                module:
+                  - http_2xx
+              static_configs:
+                - targets:
+                  - {{`{{ .gateway_url | quote }}`}}
+                  - {{`{{ .grafana_url | quote }}`}}
+                  - {{`{{ .prometheus_url | quote }}`}}
+                  - {{`{{ .argocd_url | quote }}`}}
+                  - {{`{{ .umami_url | quote }}`}}
+              relabel_configs:
+                - source_labels:
+                    - __address__
+                  target_label: __param_target
+                - source_labels:
+                    - __param_target
+                  target_label: instance
+                - target_label: __address__
+                  replacement: blackbox:9115
   data:
     - secretKey: gateway_url
       remoteRef:


### PR DESCRIPTION
## Summary

- Wrap blackbox probe scrape config in `scrape_configs:` for Prometheus `scrape_config_files`

## Problem

Prometheus logged `cannot unmarshal !!seq into config.ScrapeConfigs` when loading `/etc/prometheus/secrets/blackbox/blackbox-scrape-config.yml`, so blackbox HTTPS probes were never scraped despite #2707 wiring the file into prometheus.yml.

## Test plan

- [x] `make test`
- [ ] After merge and ExternalSecret refresh, confirm `blackbox-https` targets are active