### PR TITLE
Allow heartbeats operator through Istio auth for failing probes

### DIFF
--- a/helm-charts/argocd-config/templates/authorization-policy.yaml
+++ b/helm-charts/argocd-config/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -17,6 +18,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:

--- a/helm-charts/blocky/templates/authorization-policy.yaml
+++ b/helm-charts/blocky/templates/authorization-policy.yaml
@@ -4,6 +4,7 @@
 {{- $monitoring := .Values.monitoring | default dict -}}
 {{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
 {{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -33,6 +34,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             methods:

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -25,6 +25,7 @@ spec:
             principals:
               - {{ $gatewayPrincipal }}
               - cluster.local/ns/kiali/sa/kiali
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:

--- a/helm-charts/teslamate/templates/authorization-policy.yaml
+++ b/helm-charts/teslamate/templates/authorization-policy.yaml
@@ -2,6 +2,7 @@
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $gatewayPrincipal := printf "cluster.local/ns/%s/sa/%s" $gatewayNamespace $gatewayName -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 {{- $databaseName := regexReplaceAll "-rw\\..*$" .Values.database.host "" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -19,6 +20,7 @@ spec:
         - source:
             principals:
               - {{ $gatewayPrincipal }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:

--- a/helm-charts/umami/templates/authorization-policy.yaml
+++ b/helm-charts/umami/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -17,6 +18,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
## Summary

WebGazer status page 493 was still reporting unhealthy because several heartbeats were failing internal health checks with HTTP 403 from Istio AuthorizationPolicy.

Blackbox HTTPS probes (Grafana, Prometheus, Argo CD, Umami) were already `up`; the gap was the in-cluster heartbeats operator pinging service endpoints every 5 minutes and reporting to WebGazer.

## Root cause

The heartbeats operator service account (`heartbeats-operator-system/heartbeats-operator-controller-manager`) was missing from AuthorizationPolicies on:

- `monitoring-grafana` (Grafana heartbeat)
- `umami`
- `teslamate`
- `blocky` `/metrics`
- `argocd-server`

Prometheus and Loki already allowed this principal; Grafana was the remaining monitoring component.

Argo CD additionally had a bad target URL in 1Password (`:8080` instead of service port `:80`), causing EOF. Updated the `heartbeats` item directly.

## Changes

- Add heartbeat principal to the AuthorizationPolicies above
- Updated 1Password `argocd-target-endpoint` to use port 80 (outside git)

## Test plan

- [x] `make test`
- [ ] After merge: confirm all Heartbeat CRs show `healthy: true`
- [ ] WebGazer status page 493 turns green within one heartbeat interval (~5m)