### PR TITLE
Make Telegram alert notifications human-friendly

### DIFF
--- a/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
+++ b/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
@@ -19,7 +19,7 @@ spec:
           global:
             resolve_timeout: 5m
           templates:
-            - /etc/alertmanager/templates/*.tmpl
+            - '/etc/alertmanager/templates/*.tmpl'
           route:
             receiver: telegram
             group_by:

--- a/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
+++ b/helm-charts/monitoring/templates/alertmanager-external-secret.yaml
@@ -18,6 +18,8 @@ spec:
         alertmanager.yml: |
           global:
             resolve_timeout: 5m
+          templates:
+            - /etc/alertmanager/templates/*.tmpl
           route:
             receiver: telegram
             group_by:
@@ -32,6 +34,7 @@ spec:
               telegram_configs:
                 - bot_token: '{{`{{ .telegram_bot_token }}`}}'
                   chat_id: {{`{{ .telegram_chat_id }}`}}
+                  message: '{{`{{ "{{" }} template "otaru.telegram.message" . {{ "}}" }}`}}'
                   send_resolved: true
                   parse_mode: HTML
   data:

--- a/helm-charts/monitoring/templates/alertmanager-telegram-template.yaml
+++ b/helm-charts/monitoring/templates/alertmanager-telegram-template.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-telegram-templates
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/component: alertmanager
+data:
+  otaru-telegram.tmpl: |
+    {{`{{ define "otaru.telegram.message" }}`}}
+    {{`{{- $status := .Status -}}`}}
+    {{`{{- $severity := .CommonLabels.severity -}}`}}
+    {{`{{- $alertname := .CommonLabels.alertname -}}`}}
+    {{`{{- if eq $status "firing" -}}`}}
+    {{`{{- if eq $severity "critical" -}}`}}
+    {{`🔴 <b>{{ $alertname }}</b>`}}
+    {{`{{- else -}}`}}
+    {{`⚠️ <b>{{ $alertname }}</b>`}}
+    {{`{{- end -}}`}}
+    {{`{{- else -}}`}}
+    {{`✅ <b>Resolved: {{ $alertname }}</b>`}}
+    {{`{{- end -}}`}}
+    {{`{{- if $severity }} ({{ $severity }}){{ end }}`}}
+
+    {{`{{ range $index, $alert := .Alerts }}`}}
+    {{`{{- if gt $index 0 }}`}}
+
+    ──────────────
+    {{`{{- end }}`}}
+    {{`{{- with $alert.Annotations.title }}`}}
+    {{`<b>{{ . }}</b>`}}
+    {{`{{- end }}`}}
+    {{`{{- with $alert.Annotations.summary }}`}}
+    {{`{{ . }}`}}
+    {{`{{- end }}`}}
+    {{`{{- with $alert.Annotations.description }}`}}
+
+    {{`<i>{{ . }}</i>`}}
+    {{`{{- end }}`}}
+    {{`{{- if or $alert.Labels.namespace $alert.Labels.pod $alert.Labels.deployment $alert.Labels.node }}`}}
+    {{`{{- if and $alert.Labels.namespace $alert.Labels.pod }}`}}
+
+    {{`📦 {{ $alert.Labels.namespace }}/{{ $alert.Labels.pod }}{{- if $alert.Labels.node }} · {{ $alert.Labels.node }}{{ end }}`}}
+    {{`{{- else if and $alert.Labels.namespace $alert.Labels.deployment }}`}}
+
+    {{`📦 {{ $alert.Labels.namespace }}/{{ $alert.Labels.deployment }}`}}
+    {{`{{- else if $alert.Labels.node }}`}}
+
+    {{`🖥 {{ $alert.Labels.node }}`}}
+    {{`{{- end }}`}}
+    {{`{{ end }}`}}
+    {{`{{ end }}`}}

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -87,6 +87,14 @@ prometheus:
         mountPath: /etc/secrets/alertmanager
         secretName: alertmanager-telegram-config
         readOnly: true
+    extraVolumes:
+      - name: alertmanager-telegram-templates
+        configMap:
+          name: alertmanager-telegram-templates
+    extraVolumeMounts:
+      - name: alertmanager-telegram-templates
+        mountPath: /etc/alertmanager/templates
+        readOnly: true
   kube-state-metrics:
     resources: *smallResources
   prometheus-node-exporter:
@@ -129,48 +137,54 @@ prometheus:
               labels:
                 severity: warning
               annotations:
-                summary: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has unavailable replicas
-                description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} reports {{ $value }} unavailable replica(s) for more than 10 minutes.
+                title: Deployment has unavailable replicas
+                summary: "{{ $labels.deployment }} in {{ $labels.namespace }}"
+                description: "{{ $value | humanize }} replica(s) have been unavailable for over 10 minutes. Check pod status and events."
             - alert: PodNotReady
               expr: kube_pod_status_ready{condition="true"} == 0 and on(namespace, pod) kube_pod_status_phase{phase="Running"} == 1
               for: 15m
               labels:
                 severity: warning
               annotations:
-                summary: Pod {{ $labels.namespace }}/{{ $labels.pod }} is not ready
-                description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been running but not ready for more than 15 minutes.
+                title: Pod stuck not ready
+                summary: "{{ $labels.pod }} in {{ $labels.namespace }}"
+                description: "The pod is running but failing readiness checks for over 15 minutes. Check container logs and probe settings."
             - alert: ScrapeTargetDown
               expr: up == 0
               for: 10m
               labels:
                 severity: warning
               annotations:
-                summary: Prometheus scrape target {{ $labels.job }} is down
-                description: Target {{ $labels.instance }} in job {{ $labels.job }} has been unreachable for more than 10 minutes.
+                title: Metrics scrape failing
+                summary: "{{ $labels.job }} — {{ $labels.instance }}"
+                description: "Prometheus has been unable to collect metrics from this target for over 10 minutes."
             - alert: NodeNotReady
               expr: kube_node_status_condition{condition="Ready",status="true"} == 0
               for: 5m
               labels:
                 severity: critical
               annotations:
-                summary: Node {{ $labels.node }} is not ready
-                description: Node {{ $labels.node }} has been NotReady for more than 5 minutes.
+                title: Cluster node not ready
+                summary: "{{ $labels.node }}"
+                description: "This node has been NotReady for over 5 minutes. Workloads on it may be evicted."
             - alert: CertificateExpiringSoon
               expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < 7 * 24 * 3600
               for: 1h
               labels:
                 severity: warning
               annotations:
-                summary: Certificate {{ $labels.name }} in {{ $labels.namespace }} expires soon
-                description: Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 7 days.
+                title: TLS certificate expiring soon
+                summary: "{{ $labels.name }} in {{ $labels.namespace }}"
+                description: "This certificate expires in less than 7 days. Plan renewal before it lapses."
             - alert: BlackboxProbeFailed
               expr: probe_success{job="blackbox-https"} == 0
               for: 5m
               labels:
                 severity: warning
               annotations:
-                summary: Blackbox probe failed for {{ $labels.instance }}
-                description: HTTPS probe to {{ $labels.instance }} has been failing for more than 5 minutes.
+                title: External endpoint health check failing
+                summary: "{{ $labels.instance }}"
+                description: "The HTTPS health probe has failed for over 5 minutes. Check the service, ingress, and TLS."
 
 prometheus-blackbox-exporter:
   fullnameOverride: blackbox


### PR DESCRIPTION
## Summary

Telegram alerts were using Alertmanager's default format, dumping every Prometheus label (Helm chart metadata, scrape job details, UIDs, etc.). This replaces that with a compact HTML template and clearer alert copy.

## Changes

- Add `otaru.telegram.message` Alertmanager template (ConfigMap) with severity emoji, title, summary, description, and only relevant context (namespace/pod/node)
- Wire the template into Alertmanager via ExternalSecret `message` field
- Mount the template ConfigMap on the Alertmanager pod
- Rewrite annotations for all 6 `cluster-health` alerts: `DeploymentUnavailable`, `PodNotReady`, `ScrapeTargetDown`, `NodeNotReady`, `CertificateExpiringSoon`, `BlackboxProbeFailed`

## Example (before → after)

**Before:**
```
Alerts Firing:
Labels:
 - alertname = PodNotReady
 - app_kubernetes_io_component = metrics
 ... (15 more labels)
Annotations:
 - description = Pod monitoring/ephemeral-metrics-check has been running...
Source: http://monitoring-prometheus-server-...
```

**After:**
```
⚠️ PodNotReady (warning)

Pod stuck not ready
ephemeral-metrics-check in monitoring

The pod is running but failing readiness checks for over 15 minutes. Check container logs and probe settings.

📦 monitoring/ephemeral-metrics-check · raspberrypi-01
```