### PR TITLE
Allow heartbeats through blocky workload and argocd-server waypoint policies

### DIFF
--- a/helm-charts/argocd-config/templates/authorization-policy.yaml
+++ b/helm-charts/argocd-config/templates/authorization-policy.yaml
@@ -2,6 +2,7 @@
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
+{{- $waypointPrincipal := "cluster.local/ns/istio-waypoints/sa/waypoint" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -19,10 +20,33 @@ spec:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
               - {{ $heartbeatPrincipal }}
+              - {{ $waypointPrincipal }}
       to:
         - operation:
             ports:
               - "80"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: argocd-server-workload
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+              - {{ $heartbeatPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "8080"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/helm-charts/blocky/templates/authorization-policy.yaml
+++ b/helm-charts/blocky/templates/authorization-policy.yaml
@@ -89,6 +89,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+              - {{ $heartbeatPrincipal }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
## Summary

Follow-up to #2710. Monitoring heartbeats (Grafana, Prometheus, Loki) and Umami/TeslaMate are healthy, but Blocky and Argo CD were still failing.

## Root cause

- **Blocky**: ambient waypoint enforces AuthorizationPolicy on pod selectors. The service policy allowed `/metrics` for heartbeats, but `blocky-workload` did not.
- **Argo CD**: ingress and heartbeat traffic reaches `argocd-server` pods on port 8080 through the waypoint. Only the metrics port (8083) had a workload allow rule, causing upstream connection termination (503).

## Changes

- Add heartbeats principal to `blocky-workload`
- Add `argocd-server-workload` policy for port 8080
- Allow waypoint principal on `argocd-server` service policy

## Test plan

- [x] `make test`
- [ ] After merge: `blocky-heartbeat` and `argocd-heartbeat` report healthy
- [ ] `probe_success` for `argocd.internal.siutsin.com` returns 1