### PR TITLE
Allow waypoint principal on blocky metrics AuthorizationPolicies

### DIFF
--- a/helm-charts/blocky/templates/authorization-policy.yaml
+++ b/helm-charts/blocky/templates/authorization-policy.yaml
@@ -5,6 +5,7 @@
 {{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
 {{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
 {{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
+{{- $waypointPrincipal := "cluster.local/ns/istio-waypoints/sa/waypoint" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -35,6 +36,7 @@ spec:
             principals:
               - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
               - {{ $heartbeatPrincipal }}
+              - {{ $waypointPrincipal }}
       to:
         - operation:
             methods:
@@ -90,6 +92,7 @@ spec:
             principals:
               - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
               - {{ $heartbeatPrincipal }}
+              - {{ $waypointPrincipal }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
Follow-up to #2712. Blocky heartbeats still 503; add waypoint principal to blocky service and workload metrics rules.