### PR TITLE
fix: bump ephemeral-storage limits for jsonnet-with-secret and grafana

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -252,10 +252,11 @@ argo-cd:
           requests:
             cpu: 100m
             memory: 128Mi
-            ephemeral-storage: 256Mi
+            # ephemeral-storage 2026-07-06: 14d pod peak ~286Mi exceeded the 256Mi limit (96.6% via ephemeral_storage_container_limit_percentage) — bump to 512Mi for headroom.
+            ephemeral-storage: 512Mi
           limits:
             memory: 128Mi
-            ephemeral-storage: 256Mi
+            ephemeral-storage: 512Mi
         volumeMounts:
           - mountPath: /var/run/argocd
             name: var-files

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -218,13 +218,14 @@ k8s-ephemeral-storage-metrics:
 grafana:
   resources:
     # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
+    # ephemeral-storage 2026-07-06: 14d peak ~50Mi against a 64Mi limit (80.6% via ephemeral_storage_container_limit_percentage) — bump to 128Mi for headroom.
     requests:
       cpu: 50m
       memory: 512Mi
-      ephemeral-storage: 64Mi
+      ephemeral-storage: 128Mi
     limits:
       memory: 512Mi
-      ephemeral-storage: 64Mi
+      ephemeral-storage: 128Mi
   downloadDashboards:
     resources: *smallResources
   initChownData:


### PR DESCRIPTION
## Summary

- `argocd-repo-server`'s `jsonnet-with-secret` CMP sidecar: 14-day pod ephemeral-storage peak reached ~286Mi against a 256Mi limit (96.6% via `ephemeral_storage_container_limit_percentage`). Bumped to 512Mi.
- `monitoring-grafana`: 14-day peak reached ~50Mi against a 64Mi limit (80.6%). Bumped to 128Mi.

Both were flagged by the hourly self-heal loop's right-sizing pass (Prometheus `k8s-ephemeral-storage-metrics`). Memory requests/limits are unchanged; only ephemeral-storage was adjusted.

## Test plan

- [x] `make test` passes
- [ ] Confirm Argo CD syncs `argocd` and `monitoring` apps to the new revision
- [ ] Confirm no ephemeral-storage-related evictions on these pods after rollout