### PR TITLE
fix(gateway): drop redundant sectionName on single HTTPS listener

### DIFF
--- a/helm-charts/blocky/templates/route-doh.yaml
+++ b/helm-charts/blocky/templates/route-doh.yaml
@@ -14,7 +14,6 @@ spec:
       kind: Gateway
       name: {{ $gatewayName }}
       namespace: {{ $gatewayNamespace }}
-      sectionName: https
   rules:
     - matches:
         - path:

--- a/helm-charts/openclaw/templates/route-internal.yaml
+++ b/helm-charts/openclaw/templates/route-internal.yaml
@@ -17,7 +17,6 @@ spec:
       kind: Gateway
       name: {{ $gatewayName }}
       namespace: {{ $gatewayNamespace }}
-      sectionName: https
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

Remove `sectionName: https` from Blocky DoH and OpenClaw HTTPRoutes now that the gateway exposes only one HTTP-compatible listener (`https:443`).

## Why

After #2718 removed the cleartext `:80` listener, pinning `sectionName: https` is redundant. Dropping it keeps routes consistent with other internal HTTPRoutes that attach to the default HTTPS listener.

## Test plan

- [x] `make test`