### PR TITLE
fix(cnpg): bump umami barman-cloud sidecar memory to stop OOMKills

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -177,15 +177,18 @@ clusters:
         memory: 256Mi
         ephemeral-storage: 512Mi
     objectStore:
-      # Barman sidecar live usage ~44Mi; match plugin-barman-cloud controller sizing.
+      # 2026-07-06: 128Mi only covered idle WAL-archiving usage (~44Mi); every
+      # scheduled backup upload OOMKilled the sidecar (exit 137), failing 5
+      # consecutive backups over ~15h. Bump to 512Mi to match teslamate's
+      # equivalent sidecar, which has zero restarts and all backups completing.
       instanceSidecarResources:
         requests:
           cpu: 50m
-          memory: 128Mi
-          ephemeral-storage: 128Mi
+          memory: 512Mi
+          ephemeral-storage: 512Mi
         limits:
-          memory: 128Mi
-          ephemeral-storage: 128Mi
+          memory: 512Mi
+          ephemeral-storage: 512Mi
     storage:
       size: 2Gi
       storageClass: longhorn-crypto-global


### PR DESCRIPTION
## Summary

- `umami`'s CNPG `plugin-barman-cloud` sidecar (`objectStore.instanceSidecarResources`) had a 128Mi memory limit, sized only for idle WAL-archiving usage (~44Mi).
- Every scheduled backup upload OOMKilled the sidecar (exit 137), failing 5 consecutive scheduled backups over ~15 hours (2026-07-05 21:00 UTC through 2026-07-06 09:00 UTC). WAL archiving self-recovered within seconds each time, but no full backup ever completed.
- Bumped memory (and matching limit) from 128Mi to 512Mi to match `teslamate`'s equivalent sidecar, which has zero restarts and all scheduled backups completing.

Per the self-heal skill's escalation reference (`references/escalation.md`), resource-limit bumps are categorized as "usually safe without escalation" — the always-escalate CNPG list is restore/PITR/major-upgrade/delete/failover, none of which apply here. No data mutation, no CNPG cluster-lifecycle action.

## Test plan

- [x] `make test` passes
- [ ] Confirm Argo CD syncs the `cloudnative-pg-clusters` app to the new revision
- [ ] Confirm the next scheduled backup (12:00 UTC) completes successfully
- [ ] Confirm no further OOMKills on the `plugin-barman-cloud` sidecar