### PR TITLE
fix(cnpg): give barman-cloud restore sidecar more memory headroom

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -100,21 +100,14 @@ defaults:
     schedule: "0 0 */3 * * *"
   objectStore:
     retentionPolicy: 30d
-    # 2026-07-06: 512Mi covers backup uploads and WAL archiving fine, but the
-    # teslamate verify-pitr pipeline's plugin-barman-cloud sidecar kept dying
-    # (8 consecutive attempts) while restoring an 852Mi database at 512Mi.
-    # A full restore needs more headroom than incremental backup/archive
-    # traffic. Bumped to 1Gi for every cluster using this shared default
-    # (applies to teslamate directly; umami keeps its own explicit override
-    # below since it never performs a restore in production).
     instanceSidecarResources:
       requests:
         cpu: 50m
-        memory: 1Gi
-        ephemeral-storage: 1Gi
+        memory: 512Mi
+        ephemeral-storage: 512Mi
       limits:
-        memory: 1Gi
-        ephemeral-storage: 1Gi
+        memory: 512Mi
+        ephemeral-storage: 512Mi
 
 clusters:
   # https://cloudnative-pg.io/documentation/current/recovery/#restoring-into-a-cluster-with-a-backup-section
@@ -135,6 +128,24 @@ clusters:
     labels:
       cnpg.io/reload: "true"
       cnpg.io/skipEmptyWalArchiveCheck: "true"
+    objectStore:
+      # 2026-07-06: the shared 512Mi default is fine for backup uploads and
+      # WAL archiving, but the teslamate verify-pitr pipeline's
+      # plugin-barman-cloud sidecar kept dying (8 consecutive attempts)
+      # while restoring an 852Mi database at 512Mi. A full restore needs
+      # more headroom than incremental traffic. Scoped to teslamate only,
+      # not the shared default, since umami never performs a restore in
+      # production and stays lean at 512Mi. This also bumps teslamate's two
+      # always-on production sidecars, since they share this same
+      # ObjectStore with the verify-pitr recovery path.
+      instanceSidecarResources:
+        requests:
+          cpu: 50m
+          memory: 1Gi
+          ephemeral-storage: 1Gi
+        limits:
+          memory: 1Gi
+          ephemeral-storage: 1Gi
     namespace: teslamate
     postgresql:
       <<: *postgresql

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -100,14 +100,21 @@ defaults:
     schedule: "0 0 */3 * * *"
   objectStore:
     retentionPolicy: 30d
+    # 2026-07-06: 512Mi covers backup uploads and WAL archiving fine, but the
+    # teslamate verify-pitr pipeline's plugin-barman-cloud sidecar kept dying
+    # (8 consecutive attempts) while restoring an 852Mi database at 512Mi.
+    # A full restore needs more headroom than incremental backup/archive
+    # traffic. Bumped to 1Gi for every cluster using this shared default
+    # (applies to teslamate directly; umami keeps its own explicit override
+    # below since it never performs a restore in production).
     instanceSidecarResources:
       requests:
         cpu: 50m
-        memory: 512Mi
-        ephemeral-storage: 512Mi
+        memory: 1Gi
+        ephemeral-storage: 1Gi
       limits:
-        memory: 512Mi
-        ephemeral-storage: 512Mi
+        memory: 1Gi
+        ephemeral-storage: 1Gi
 
 clusters:
   # https://cloudnative-pg.io/documentation/current/recovery/#restoring-into-a-cluster-with-a-backup-section


### PR DESCRIPTION
## Summary

- The shared `defaults.objectStore.instanceSidecarResources` (512Mi) already covers backup uploads and WAL archiving fine for both `teslamate` and `umami` (confirmed via #2723 for umami).
- The `teslamate` verify-pitr pipeline's `plugin-barman-cloud` sidecar OOM'd repeatedly during an actual restore: 8 consecutive pod attempts, every one killed on the same container, until the recovery Job hit its backoff limit and failed. The database being restored is only 852Mi, but a full restore evidently needs more headroom than incremental backup/archive traffic.
- Bumped the shared default from 512Mi to 1Gi. This applies automatically to `teslamate` (both its production backups and the verify-pitr restore path, since both reference the same `b2-backup` ObjectStore). `umami` keeps its own explicit 512Mi override since it never performs a restore in production and has been running cleanly at that size.

## Test plan

- [x] `make test` passes
- [ ] Confirm Argo CD syncs `cloudnative-pg-clusters` to the new revision
- [ ] Confirm the next `teslamate` verify-pitr run (daily, `0 14 * * *`) completes without the sidecar dying