### PR TITLE
fix(changedetection): bump browser cleanup sidecar ephemeral-storage

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -58,13 +58,16 @@ browser:
       pullPolicy: IfNotPresent
     resources:
       # KRR 2026-07-05: profile cleanup sidecar peaked at ~100Mi during hourly prune runs.
+      # ephemeral-storage 2026-07-07: container_limit_percentage reported 100% at 16Mi
+      # (shared /profile/chromium volume usage attributed against this container's own
+      # tiny limit); pod-level peak is only ~20Mi. Bump to 64Mi for headroom.
       requests:
         cpu: 10m
         memory: 128Mi
-        ephemeral-storage: 16Mi
+        ephemeral-storage: 64Mi
       limits:
         memory: 128Mi
-        ephemeral-storage: 16Mi
+        ephemeral-storage: 64Mi
   env:
     SCREEN_WIDTH: "1920"
     SCREEN_HEIGHT: "1024"


### PR DESCRIPTION
## Summary

- `changedetection-browser`'s `cleanup-browser-metrics-loop` sidecar (a `find -delete` loop pruning stale Chromium profile metrics) reported 100% via `ephemeral_storage_container_limit_percentage` at its 16Mi limit.
- Pod-level peak ephemeral usage is only ~20Mi, so this is likely the shared `/profile/chromium` volume being attributed against this container's own tiny limit rather than a genuine overflow risk.
- Bumped ephemeral-storage from 16Mi to 64Mi for headroom. Memory is unchanged (128Mi, from the 2026-07-05 KRR pass).

Flagged by the hourly self-heal loop's right-sizing pass (Prometheus `k8s-ephemeral-storage-metrics`).

## Test plan

- [x] `make test` passes
- [ ] Confirm Argo CD syncs `changedetection` to the new revision
- [ ] Confirm `container_limit_percentage` drops well below 100% after rollout