### PR TITLE
fix(teslamate): keep verify-pitr recovery pod off ambient dataplane

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -258,6 +258,15 @@ spec:
                   spec:
                     instances: 1
                     imageName: {{ .Values.backup.database.imageName }}
+                    inheritedMetadata:
+                      labels:
+                        # 2026-07-07: CNPG operator scrapes instance status over direct
+                        # pod HTTPS. Without this, the ephemeral recovery pod sits on
+                        # the ambient Istio dataplane (unlike production clusters, which
+                        # get this label via cloudnative-pg-clusters' inheritedMetadata
+                        # default) and the operator cannot reach it, leaving the cluster
+                        # permanently stuck in "Instance Status Extraction Error".
+                        istio.io/dataplane-mode: none
                     resources:
                       requests:
                         cpu: 250m


### PR DESCRIPTION
## Summary

- After yesterday's memory fix (#2728), the verify-pitr pipeline's `-1-full-recovery` Job now completes successfully (the actual restore works), but the recovered cluster gets permanently stuck in `Instance Status Extraction Error: HTTP communication issue` / `ServiceUnavailable` anyway.
- Root cause: the CNPG operator scrapes instance status by proxying directly to the pod over HTTPS on port 8000. Production clusters (via `cloudnative-pg-clusters`' `defaults.cluster.inheritedMetadata`) get `istio.io/dataplane-mode: none` so they stay off the ambient Istio dataplane for exactly this reason. The verify-pitr script builds its ephemeral recovery `Cluster` by hand (`kubectl apply` in a Job), so it never inherited that label — the pod sits on the ambient dataplane and the operator's direct pod-IP proxy call gets intercepted/blocked.
- Added the same `inheritedMetadata.labels.istio.io/dataplane-mode: none` directly to the ephemeral cluster spec in `verify-pitr.yaml`.

This explains both the original stuck-cluster symptom from two days ago (before the OOM fix was even identified) and today's recurrence after the memory fix — they were two separate bugs in the same pipeline.

## Test plan

- [x] `make test` passes
- [ ] Confirm tomorrow's scheduled verify-pitr run (`0 14 * * *` UTC) completes and the cluster reaches Healthy status, not stuck in `Instance Status Extraction Error`