### PR TITLE
feat(gateway): run Envoy data plane with 2 replicas for HA

### DIFF
--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -8,8 +8,12 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyDeployment:
+        replicas: {{ .Values.envoyProxy.replicas }}
         container:
           resources:
 {{ toYaml .Values.envoyProxy.resources | indent 12 }}
+        pod:
+          affinity:
+{{ toYaml .Values.envoyProxy.affinity | indent 12 }}
       envoyService:
         name: {{ .Values.service.name }}

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -62,4 +62,19 @@ envoy-gateway:
             type: GatewayNamespace
 
 envoyProxy:
+  # 2026-07-07: single-replica Envoy data plane meant every public request
+  # (including WebGazer/blackbox uptime probes) depended on one pod with no
+  # failover. Bumped to 2 with anti-affinity so a brief hiccup on one node
+  # does not cause a visible gap for any app behind this shared gateway.
+  replicas: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: envoy
+                gateway.networking.k8s.io/gateway-name: gateway
+            topologyKey: kubernetes.io/hostname
   resources: *envoyProxyResources


### PR DESCRIPTION
## Summary

- Investigated two brief (~1 minute) uptime-probe blips reported by an external monitor on umami's public analytics endpoint today. Envoy access logs showed no errors during either window (every logged request, including the monitor's own, returned 200) -- the failure never reached a completed request.
- Found the actual gap: the `gateway` Deployment (Envoy data plane handling all public ingress, not just umami) runs as a single replica with no failover, while the database tier behind it is already HA (2 CNPG instances). A brief hiccup on that one pod (GC pause, connection handling blip, resource contention) would cause exactly this kind of gap without ever generating an access-log error, and there's no second instance to fail over to.
- Bumped `envoyProxy.replicas` to 2 in the `EnvoyProxy` CR, with preferred pod anti-affinity (matching the pattern already used for `cloudflare-tunnel`) so the two replicas land on different nodes.

## Cost

- Additional ~256Mi memory / 100m CPU for the second Envoy container, plus the shutdown-manager sidecar's usual footprint.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the rendered `EnvoyProxy` has `replicas: 2` and the anti-affinity block
- [ ] Confirm Argo CD syncs `envoy-gateway` and the `gateway` Deployment scales to 2/2 Ready pods on different nodes
- [ ] Confirm all existing HTTPRoutes continue serving correctly with 2 replicas