### PR TITLE
Bump changedetection-browser memory to 1408Mi

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -75,12 +75,13 @@ browser:
     MAX_CONCURRENT_CHROME_PROCESSES: "1"
   resources:
     # KRR 2026-07-05: Playwright browser peaked at ~1.08Gi during Amazon watch fetches; 1Gi left ~6Mi headroom.
+    # KRR 2026-07-09: 14-day peak grew to ~1.28Gi, exceeding the 1152Mi limit set above. Bumped to 1408Mi for headroom.
     requests:
       cpu: 50m
-      memory: 1152Mi
+      memory: 1408Mi
       ephemeral-storage: 1Gi
     limits:
-      memory: 1152Mi
+      memory: 1408Mi
       ephemeral-storage: 1Gi
 
 service:


### PR DESCRIPTION
## Summary
- KRR right-sizing pass (2026-07-09): the Playwright browser sidecar's
  14-day memory peak grew to ~1.28Gi, exceeding the 1152Mi limit set on
  2026-07-05. Bumped requests/limits to 1408Mi for headroom.

## Test plan
- [x] `make test` passes