### PR TITLE
fix(ci): install editorconfig-checker in auto-update-heartbeats workflow

### DIFF
--- a/.github/workflows/auto-update-heartbeats.yaml
+++ b/.github/workflows/auto-update-heartbeats.yaml
@@ -58,6 +58,15 @@ jobs:
           terragrunt-version: latest
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install editorconfig-checker
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v3.6.1 --repo editorconfig-checker/editorconfig-checker --pattern 'ec-linux-amd64.tar.gz' --output /tmp/ec.tar.gz
+          tar -xzf /tmp/ec.tar.gz -C /tmp bin/ec-linux-amd64
+          chmod +x /tmp/bin/ec-linux-amd64
+          sudo mv /tmp/bin/ec-linux-amd64 /usr/local/bin/ec
+
       - name: Install zizmor
         run: pip install zizmor
 


### PR DESCRIPTION
## Summary
- The `Auto Update Heartbeats` scheduled workflow has failed every daily
  run since at least 2026-06-25 (15 consecutive failures) at the
  `make test` step: `lint-editorconfig` requires `editorconfig-checker`,
  which this workflow never installed (unlike `test.yaml`).
- Added the same install step used in `test.yaml` (download `ec` binary
  from the `editorconfig-checker/editorconfig-checker` release).

## Test plan
- [x] `make test` passes locally
- [ ] Next scheduled run (or a manual `workflow_dispatch`) completes past
  the `Run tests` step