### PR TITLE
docs(right-sizing): drop dangling reference to uncommitted loop command

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -14,7 +14,7 @@ Right-size cluster workloads on the otaru home-lab. The cluster is memory-tight 
 apply **both** downsizes and upsizes in the same PR when safe.
 
 Invoke as `/right-sizing`. Called from the hourly self-heal loop when healthy and
-no pass ran in the last 24 hours (see `.claude/commands/otaru-self-heal-loop.md`).
+no pass ran in the last 24 hours.
 
 ## When to run
 


### PR DESCRIPTION
## Summary
- `right-sizing/SKILL.md` referenced `.claude/commands/otaru-self-heal-loop.md`,
  but that file is intentionally kept local (excluded via
  `git/info/exclude`) rather than committed.
- Removed the dangling reference so committed docs do not depend on an
  uncommitted file.

## Test plan
- [x] `make test` passes