### PR TITLE
fix(envoy-gateway): split L2Advertisement so nuc-00 announces on eno1

### DIFF
--- a/helm-charts/envoy-gateway/templates/l2-advertisement.yaml
+++ b/helm-charts/envoy-gateway/templates/l2-advertisement.yaml
@@ -1,10 +1,17 @@
+{{- range .Values.l2AnnouncementPolicy.advertisements }}
+---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: {{ .Values.name }}
-  namespace: {{ .Values.metallbNamespace }}
+  name: {{ $.Values.name }}{{ with .nameSuffix }}-{{ . }}{{ end }}
+  namespace: {{ $.Values.metallbNamespace }}
 spec:
   ipAddressPools:
-    - {{ .Values.name }}
+    - {{ $.Values.name }}
+  {{- with .nodeSelectors }}
+  nodeSelectors:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   interfaces:
-    {{- toYaml .Values.l2AnnouncementPolicy.interface | nindent 4 }}
+    {{- toYaml .interfaces | nindent 4 }}
+{{- end }}

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -37,9 +37,33 @@ tls:
 serviceAllocation:
   selectorLabel: gateway.envoyproxy.io/owning-gateway-name
 
+# 2026-07-09: nuc-00's speaker logged "the specified interfaces used to
+# announce LB IP don't exist" for 192.168.10.51 whenever nuc-00 became the
+# announcing node, because nuc-00's NIC is eno1, not eth0 (Intel NUC naming
+# differs from the Raspberry Pis). The gateway VIP then had no working ARP
+# announcement from that node, making it unreachable from off-cluster clients
+# until leadership moved elsewhere. Split into per-node interfaces, mirroring
+# the working pattern already used for the API server VIP in
+# helm-charts/metallb-vip/values.yaml.
 l2AnnouncementPolicy:
-  interface:
-    - eth0
+  advertisements:
+    - interfaces:
+        - eth0
+      nodeSelectors:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - raspberrypi-00
+                - raspberrypi-01
+                - raspberrypi-02
+                - raspberrypi-03
+    - nameSuffix: nuc-00
+      interfaces:
+        - eno1
+      nodeSelectors:
+        - matchLabels:
+            kubernetes.io/hostname: nuc-00
 
 loadBalancerIPPool:
   cidr: 192.168.10.51/32


### PR DESCRIPTION
## Summary
- Root cause of the gateway VIP (192.168.10.51) being unreachable from
  off-cluster clients: the single L2Advertisement used
  `interfaces: [eth0]`, but nuc-00's NIC is `eno1`, not `eth0`. When nuc-00
  became the announcing node, its speaker logged "the specified interfaces
  used to announce LB IP dont exist" and had no working ARP announcement,
  so the router (and anything routing through it) got no response for
  that IP.
- Split into two L2Advertisements: one for the four Raspberry Pi nodes on
  `eth0`, one for nuc-00 on `eno1` — mirroring the working pattern already
  used for the API server VIP in `helm-charts/metallb-vip/values.yaml`.

## Test plan
- [x] `make test` passes
- [x] `helm template` confirms both L2Advertisement resources render
      correctly
- [ ] After merge: confirm nuc-00's metallb-speaker no longer logs the
      interface warning, and the gateway VIP stays reachable regardless
      of which node is currently announcing it