### PR TITLE
docs(skills): publish self-healing skill and align right-sizing

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -18,22 +18,29 @@ no pass ran in the last 24 hours, or run it directly.
 
 ## Prerequisites
 
-Confirm before starting; stop and tell the user if any are missing:
+Confirm before starting. On failure: journal
+`### right-sizing pass` with `result: failed`, then stop and tell the user.
+Missing:
 
-- Cluster reachability: always prefer the Kubernetes MCP tools for cluster
-  interaction in this skill; fall back to `kubectl` only if MCP is
-  unavailable or errors (`kubectl cluster-info` reaching the otaru API VIP
+- Cluster reachability: prefer Kubernetes MCP; fall back to `kubectl` only if
+  MCP is unavailable or errors (`kubectl cluster-info` reaching VIP
   `192.168.10.50`).
-- `krr` on PATH (`krr --help`) — used for Part 1.
-- `gh` authenticated (`gh auth status`) — used for Part 2.
-- `helm` on PATH — `make test` needs it to render charts.
-- Repo checkout at `~/projects/github/siutsin/otaru`.
+- Prometheus ingress reachable (same URL as KRR below). Do not use
+  `*.svc.cluster.local` from off-cluster.
+- `krr` on PATH (`krr --help`) — Part 1.
+- `gh` authenticated (`gh auth status`) — Part 3.
+- `helm` on PATH — `make test` needs it.
+- Repo checkout present (work from it).
 
 ## When to run
 
-- Cluster healthy and journal has no right-sizing pass in the last 24 hours.
-- Sooner when workloads show OOMKills, probe failures, scheduling pressure, or
-  ephemeral-storage evictions / `DiskPressure`.
+- **Full pass** when the cluster is healthy and the journal has no
+  `### right-sizing pass` in the last 24 hours (see Journal).
+- **Merge-only resume** when the latest pass in 24 hours has `result: open`
+  and a `pr:` URL: continue that branch (Parts 3–4 only; skip Parts 1–2).
+- Sooner (full pass) when workloads show OOMKills, probe failures, scheduling
+  pressure, or ephemeral-storage evictions / `DiskPressure` — may run even if
+  self-heal is not fully green, if the user or a manual invoke asks.
 - Skip guarded workloads (see below) even when metrics suggest downsizing.
 
 ## Part 1 — CPU and memory (KRR)
@@ -41,14 +48,13 @@ Confirm before starting; stop and tell the user if any are missing:
 ### Collect recommendations
 
 Resolve `<prometheus-url-via-ingress>` from `httpRoutes.prometheus` in
-`helm-charts/monitoring/values.yaml` (hostname pattern in
-`templates/route-internal.yaml`: `https://<route-key>.internal.siutsin.com`).
-Do not use `*.svc.cluster.local` from off-cluster; use the ingress URL.
+`helm-charts/monitoring/values.yaml` and the hostname pattern in
+`helm-charts/monitoring/templates/route-internal.yaml` (HTTPS ingress for
+the prometheus route key). Do not hardcode the domain.
 
 ```bash
 krr simple -p <prometheus-url-via-ingress> -f json -q > /tmp/krr-otaru-$(date +%F).json
 ```
-
 ### Build the change set
 
 For each candidate workload in `helm-charts/**/values.yaml` (and chart templates
@@ -61,50 +67,13 @@ when resources live there):
 
 ### Helm chart rules
 
-See `AGENTS.md`:
-
-- Set memory requests equal to memory limits.
-- Do not set CPU limits unless the user explicitly asks.
-- Set explicit ephemeral-storage requests and limits.
-- Add an inline `# KRR YYYY-MM-DD:` comment for CPU/memory changes stating the observed peak/symptom and why the previous value was wrong.
+See `AGENTS.md`: memory request = limit; no CPU limits unless asked; explicit
+ephemeral-storage; add `# KRR YYYY-MM-DD:` on CPU/memory changes with peak and
+why the old value was wrong.
 
 KRR covers **CPU and memory only** — not ephemeral-storage.
 
-## Part 2 — GitOps PR
-
-1. Branch from `master`, edit only in-scope chart values/templates.
-2. Run `make test` and fix failures.
-3. Open one PR covering all safe changes for that pass (KRR + ephemeral-storage).
-4. Push the branch, watch CI to green, and address any review feedback. A
-    right-sizing PR may merge automatically once green when it is only
-    resource requests/limits/replicas on non-secret Helm values, `make test`
-    already passed, and no chart/template structural change, CRD change, or
-    secret-adjacent key is touched. Otherwise stop at green and leave the
-    merge to the user — for example CNPG/Longhorn topology or storage class
-    changes, multi-app bulk rewrites, or anything not confidently low-risk.
-
-## Part 3 — Verify rollout
-
-After merge (always prefer Kubernetes MCP tools; fall back to `kubectl` only
-if MCP is unavailable or errors):
-
-- Confirm Argo CD apps sync to the new revision for touched workloads.
-- Inspect pod `resources` and `lastState.terminated.reason` for OOMKill.
-- Watch upsized workloads for 24h (prometheus CPU/memory, browser, umami, etc.).
-
-### Hotfix regressions
-
-Open a follow-up PR immediately if rollout breaks a workload:
-
-- **OOM after downsize** — bump memory above the failing limit; comment exit code
-  and workload (for example happy OOMKill exit 137 at 640Mi → 896Mi).
-- **Init/exec format error on nuc-00** — arm64-only images on amd64; pin
-  `nodeSelector: kubernetes.io/arch: arm64` when charts use arm64-only digests.
-
-Journal each pass in `.scratchpad/SELF_HEALING.md` with KRR score, workloads
-changed, PR URL, and rollout result.
-
-## Part 4 — Ephemeral-storage (Prometheus)
+## Part 2 — Ephemeral-storage (Prometheus)
 
 KRR does not recommend ephemeral-storage. Use metrics from
 `k8s-ephemeral-storage-metrics` (subchart of `helm-charts/monitoring`) scraped
@@ -121,7 +90,8 @@ Query via the same `<prometheus-url-via-ingress>` as KRR (HTTP API or Grafana).
 | `ephemeral_storage_container_limit_percentage` | Usage vs configured limit                |
 | `ephemeral_storage_node_percentage`            | Node-level disk pressure context         |
 
-Compare configured limits with kube-state-metrics:
+Compare configured limits with kube-state-metrics (example namespace filter;
+replace `happy` with the workload under review):
 
 ```promql
 kube_pod_container_resource_limits{resource="ephemeral_storage", namespace="happy"}
@@ -160,3 +130,47 @@ topk(20, max_over_time(ephemeral_storage_pod_usage[14d]))
 - Exporter does not monitor generic ephemeral volumes (CSI-backed).
 - No CLI recommender — interpret PromQL peaks manually with headroom (~20–30%).
 - Combine ephemeral changes with KRR CPU/memory in the same PR when both apply.
+
+## Part 3 — GitOps PR
+
+1. Before opening, check journal `### right-sizing pass` `pr:` fields and
+  `gh pr list --state open` for an in-flight right-sizing PR; continue that
+  branch when one exists.
+2. Branch from `master` only when no in-flight PR; edit only in-scope chart
+  values/templates (KRR + ephemeral-storage from Parts 1–2).
+3. Run `make test` and fix failures (re-run after further commits on the same
+  branch).
+4. Open **one** PR for all safe changes this pass (or push to the continued
+  branch).
+5. Classify and merge per
+  `.claude/skills/self-healing/runbooks/merge-policy.md` only — no separate
+  matrix. After outcome, run
+  `.claude/skills/self-healing/runbooks/branch-cleanup.md`.
+
+## Part 4 — Verify rollout
+
+After merge (prefer Kubernetes MCP; fall back to `kubectl`):
+
+- Confirm Argo CD apps sync to the new revision for touched workloads.
+- Inspect pod `resources` and `lastState.terminated.reason` for OOMKill.
+- Note upsized workloads for a later cycle (prometheus CPU/memory, browser,
+  umami, etc.) — do **not** block the unattended run for 24 hours.
+
+### Hotfix regressions
+
+Open a follow-up PR immediately if rollout breaks a workload:
+
+- **OOM after downsize** — bump memory above the failing limit; comment exit code
+  and workload (for example happy OOMKill exit 137 at 640Mi → 896Mi).
+- **Init/exec format error on nuc-00** — arm64-only images on amd64; pin
+  `nodeSelector: kubernetes.io/arch: arm64` when charts use arm64-only digests.
+
+## Journal
+
+Always append a `### right-sizing pass` marker to
+`.scratchpad/SELF_HEALING.md` (even on prereq failure, no-op, or no chart
+changes) using the template in
+`.claude/skills/self-healing/SKILL.md` **Journal**. Allowed
+`result` values: `applied` | `no-op` | `held` | `open` | `failed`
+(`open` = PR in flight / CI re-check next cycle). Same redaction and
+no-commit rules as self-healing.

--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -55,6 +55,7 @@ the prometheus route key). Do not hardcode the domain.
 ```bash
 krr simple -p <prometheus-url-via-ingress> -f json -q > /tmp/krr-otaru-$(date +%F).json
 ```
+
 ### Build the change set
 
 For each candidate workload in `helm-charts/**/values.yaml` (and chart templates

--- a/.claude/skills/self-healing/SKILL.md
+++ b/.claude/skills/self-healing/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: "self-healing"
+description: >-
+  Investigate the otaru k3s home-lab cluster for unhealthy nodes, GitOps
+  reconciliation, workloads, storage, data plane, platform, ingress/mesh,
+  policy, and CI health; fix safe issues via GitOps PRs; escalate destructive
+  or database work. Invoke as /self-healing, including hourly loop schedules.
+metadata:
+  short-description: "otaru cluster self-healing runbooks and loop"
+---
+
+# Otaru Self-Healing
+
+> **Paths:** runbooks live under `runbooks/` and reference material lives
+> under `references/`. Read a runbook only when its category is reached in
+> the investigation order below; read a reference file only when relevant.
+
+Requires a kubeconfig reaching the cluster's API VIP over the local
+network — not usable from a machine without that network path (for example
+a CI runner or a remote devserver). Investigate the otaru home-lab `k3s`
+cluster, fix safe issues, and journal findings. Designed for hourly
+scheduled runs as well as manual invocation.
+
+Invoke as `/self-healing`.
+
+## Scope
+
+- **Cluster:** otaru bare-metal `k3s` on `192.168.10.0/24` (see the otaru
+  repo `README.md` and `references/cluster.md`).
+- **GitOps repo:** this repo — the reconciler syncs from it; durable fixes
+  belong here, not as orphaned live edits.
+- **Journal:** `.scratchpad/SELF_HEALING.md` at the repo root.
+- **Out of scope:** any machine without a kubeconfig reaching the API VIP.
+  If kubeconfig or the repo checkout is missing, stop and tell the user.
+
+## Runtime gate
+
+Before any cluster command or otaru repo write (**identity** only):
+
+1. Confirm you are working from an otaru repo checkout.
+2. Confirm the API server is the otaru VIP `192.168.10.50` (with or without
+    `:6443` — both forms are fine). Prefer Kubernetes MCP for this check
+    when available; otherwise `kubectl cluster-info`.
+3. Confirm `kubectl get nodes -o wide` (or MCP equivalent) lists all five
+    expected names (Ready or not): `raspberrypi-00`, `raspberrypi-01`,
+    `raspberrypi-02`, `raspberrypi-03`, `nuc-00`. Wrong or missing names mean
+    the wrong cluster — stop.
+
+If any identity check fails, stop. Do not mutate a cluster. NotReady nodes
+are handled in `runbooks/access-and-nodes.md` — do not treat them as a gate
+failure.
+
+**Tooling (soft):** the Postgres-operator CLI plugin (`kubectl cnpg version`)
+is required only for `runbooks/data-plane.md`. If it is missing, skip
+CNPG-specific checks, journal a note, and continue other categories.
+
+## Cluster inspection
+
+Prefer **Kubernetes MCP tools** for read-only diagnostics (list pods,
+events, Applications, logs, metrics) when they are available. Fall back to
+`kubectl` for the same checks or when MCP is unavailable. Exact resource
+checks in the runbooks remain the source of truth either way. Mutating
+operations stay GitOps-first (see Fixes).
+
+## Journal
+
+Write only when you find an issue or attempt a fix. Skip the journal when
+the cluster is healthy.
+
+Use simple, concise English. Every word must earn its place. Use local time
+in headings.
+
+Format:
+
+```markdown
+## <YYYY-MM-DD> <HH:MM>
+
+### issue <short title>
+
+- **symptom:** what you observed
+- **cause:** root cause if known; `unknown` if not
+- **action:** what you did, or `none — escalated`
+- **result:** `fixed` | `open` | `escalated`
+- **pr:** PR URL if a GitOps change was opened; omit if none
+```
+
+Right-sizing pass marker (always write when `/right-sizing` runs, even if
+healthy and no chart changes — used for the 24h gate):
+
+```markdown
+### right-sizing pass
+
+- **krr:** score or summary path
+- **workloads:** list changed or `none`
+- **pr:** URL or `none`
+- **result:** `applied` | `no-op` | `held` | `open` | `failed`
+```
+
+Rules:
+
+- Create `.scratchpad/SELF_HEALING.md` on first write if missing.
+- Append new sections at the end; do not rewrite history.
+- Never log secrets, tokens, or raw credential output. No Secret,
+  ExternalSecret, or PushSecret dumps; no `kubectl get secret -o yaml`;
+  no raw CI `--log-failed` dumps or pod env dumps. Summarise with
+  namespace, name, and key names only. Use `[REDACTED]` for values.
+  Reference paths instead of pasting values.
+- Do not commit or push the journal. Before any otaru commit, run
+  `git status` and abort if `.scratchpad/` is staged.
+
+## Investigation
+
+Read `references/escalation.md` and `runbooks/merge-policy.md` before
+live mutations. Read `references/cluster.md` and
+`references/escalation.md` before any otaru repo edit.
+
+Start by reading the last few journal entries. For each latest entry with
+`result: open` or `result: escalated`, re-check its symptom before new
+work. A run is healthy only when the checklist passes **and** every such
+entry is resolved or still correctly escalated.
+
+Then work through this checklist in order. On the first P0 (NotReady node
+or a GitOps reconciler reporting degraded), fix or escalate before
+lower-priority categories.
+
+Prerequisites: otaru repo checkout, kubeconfig reaching API VIP
+`192.168.10.50`.
+
+1. `runbooks/access-and-nodes.md` — cluster reachability, node readiness,
+    node pressure. **P0.**
+2. `runbooks/gitops-reconciliation.md` — reconciler health and drift.
+    **P0.**
+3. `runbooks/workloads.md` — pods, deployments, jobs.
+4. `runbooks/storage.md` — PVCs and volumes.
+5. `runbooks/data-plane.md` — database and storage backups (read-only).
+6. `runbooks/platform.md` — certificates and aggregated APIs.
+7. `runbooks/ingress-mesh.md` — gateway, load-balancer VIP reachability,
+    service mesh.
+8. `runbooks/policy.md` — admission policy failures.
+9. `runbooks/ci-cd.md` — scheduled workflow health.
+
+Prioritise: node NotReady → reconciler degraded → data-loss risk →
+user-facing app down → everything else.
+
+**End of every run** (healthy or not, PR or not): run
+`runbooks/branch-cleanup.md`.
+
+## Fixes
+
+Default to GitOps:
+
+1. Diagnose in the live cluster.
+2. Patch the otaru repo (`helm-charts/`, `argocd/`, manifests).
+3. Run `make test` in the otaru repo before opening a PR. If it fails on
+    unrelated drift, journal the failure and escalate — do not bypass
+    checks.
+4. Before opening, check journal `pr` and `gh pr list --state open` for the
+    same root cause; continue an in-flight PR when one exists.
+5. Branch, commit, push, open a PR.
+6. Classify and merge per `runbooks/merge-policy.md`. Journal the PR URL
+    and whether merge was auto or held.
+7. Immediately after this PR's outcome is known (merged, or held green for
+    the user), run `runbooks/branch-cleanup.md` — do not wait for the next
+    scheduled run. A PR can merge before you notice; continuing to commit
+    to a closed PR's branch wastes work.
+
+See `runbooks/merge-policy.md` for classification, allowlists, and live
+actions. See `runbooks/branch-cleanup.md` for cleanup and stuck-PR notes.
+
+## Escalate — do not auto-fix
+
+See `references/escalation.md` for the full table. In short: stop and ask
+the user to review whenever the change is destructive or irreversible —
+database restore/failover/major-upgrade, storage volume delete or crypto
+config, cluster lifecycle operations, infrastructure-as-code applies,
+secret rotation, or Application/resource deletes with prune.
+
+Log these as `result: escalated` with a clear symptom and recommended next
+step. Do not patch the repo or run destructive commands.
+
+## Loop mode
+
+When a scheduled run invokes this skill:
+
+- **Re-entrancy:** if a prior fire in this session is still running, skip
+  this fire (do not start a second investigation/PR loop in parallel).
+- Run the full investigation each time, including journal closure for
+  `open` / `escalated` entries.
+- If healthy, report that the cluster is healthy: nodes Ready, no
+  reconciler apps degraded, no lingering out-of-sync state without an
+  in-flight PR, no open journal issues (escalated items waiting on the
+  user are OK — mention them). Skip issue journal entries; still allow
+  right-sizing pass markers when `/right-sizing` runs.
+- If an issue persists, append a short update under the same `### issue`
+  title with changed `action` / `result`, or a new timestamped block with
+  delta only.
+- Before opening a PR, search journal `pr` fields for open issues with
+  the same root cause and run `gh pr list --state open`; continue that
+  branch/PR when one is already in flight.
+- Always end with `runbooks/branch-cleanup.md`.
+
+To bootstrap the hourly scheduled loop itself, see
+`runbooks/loop-bootstrap.md`.
+
+## Right-sizing
+
+Workload right-sizing is `.claude/skills/right-sizing` (`/right-sizing`).
+When the cluster is healthy:
+
+- **Full pass** (KRR + ephemeral + PR): if no `### right-sizing pass` in the
+  last 24 hours.
+- **Merge-only resume:** if the latest pass in 24 hours has
+  `result: open` and a `pr:` URL, invoke `/right-sizing` only to continue
+  that branch (CI re-check / merge-policy / branch-cleanup) — skip KRR and
+  ephemeral collection.
+
+Classify any PR with `runbooks/merge-policy.md`.
+
+## Skill maintenance
+
+If a run turns up something worth folding into this routine — a new
+runbook, a gotcha class not yet covered, a merge-policy correction, a
+troubleshooting technique that saved real time — edit the relevant file
+under `runbooks/` or `references/` directly (or add a new runbook file; the
+structure is designed to grow). Prefer short pointers into
+`documentation/gotcha.md` over copying long write-ups.
+Keep runbook and reference file names and headings capability-based rather
+than tied to the current product name (for example
+`gitops-reconciliation.md`, not `argocd.md`) so swapping a tool later is a
+content edit, not a restructure.
+
+## References
+
+- `references/cluster.md` — paths, network, namespaces.
+- `references/escalation.md` — safe vs escalate boundaries.
+- `runbooks/` — one file per investigation category, plus merge policy,
+  branch cleanup, and loop bootstrap.
+- `documentation/gotcha.md` — known issues and workarounds.

--- a/.claude/skills/self-healing/references/cluster.md
+++ b/.claude/skills/self-healing/references/cluster.md
@@ -1,0 +1,84 @@
+# Otaru Cluster Reference
+
+## Paths
+
+All paths below are relative to the otaru repo root.
+
+| Item                 | Path (relative to repo root)                                                       |
+|----------------------|------------------------------------------------------------------------------------|
+| Self-healing journal | `.scratchpad/SELF_HEALING.md`                                                      |
+| Helm charts          | `helm-charts/`                                                                     |
+| Argo CD apps         | `argocd/`                                                                          |
+| Gotchas              | `documentation/gotcha.md`                                                          |
+| Secrets layout       | `documentation/secrets.md`                                                         |
+| LUKS unlock          | `documentation/luks_remote_unlock.md`                                              |
+| Local secrets        | Outside this repo, machine-local (see `documentation/secrets.md` for the boundary) |
+
+## Network
+
+| IP              | Role                             |
+|-----------------|----------------------------------|
+| `192.168.10.50` | Kubernetes API VIP               |
+| `192.168.10.51` | Internal ingress VIP             |
+| `192.168.10.60` | `raspberrypi-00` (control plane) |
+| `192.168.10.61` | `raspberrypi-01` (control plane) |
+| `192.168.10.62` | `raspberrypi-02` (control plane) |
+| `192.168.10.63` | `raspberrypi-03` (worker)        |
+| `192.168.10.80` | `nuc-00` (worker)                |
+
+Runtime gate (`SKILL.md`): all five node names above must exist. **Ready** is
+checked in `runbooks/access-and-nodes.md`, not at the gate.
+
+## kubectl
+
+Prefer Kubernetes MCP tools for read-only diagnostics when available; fall
+back to `kubectl` for the same checks. Use the otaru kubeconfig context. If
+multiple contexts exist, select the one that reaches `192.168.10.50` (API
+VIP). Port `:6443` may or may not appear in `cluster-info` output — match on
+host/VIP. Verify with:
+
+```bash
+kubectl cluster-info
+kubectl get nodes -o wide
+```
+
+## Validation
+
+Before opening a PR, from the repo root:
+
+```bash
+make test
+```
+
+## Useful namespaces
+
+| Namespace              | Contents                                              |
+|------------------------|-------------------------------------------------------|
+| `argocd`               | GitOps controller and Application CRs (Argo CD today) |
+| `longhorn-system`      | Block storage (Longhorn today); keep out of ambient   |
+| `cnpg-system`          | Postgres operator and clusters (CNPG today)           |
+| `monitoring`           | Metrics, dashboards, and logs                         |
+| `envoy-gateway-system` | Gateway controller (ingress P0)                       |
+| `gateway`              | Ingress proxy data plane (VIP `.51`)                  |
+| `istio-system`         | Service mesh (P2 unless app symptom ties to it)       |
+| `cert-manager`         | TLS certificate operator                              |
+| `external-secrets`     | External secrets sync operator                        |
+| `kyverno`              | Admission policy engine                               |
+| `keda`                 | Event-driven autoscaling; keep out of ambient         |
+| `metallb-system`       | LoadBalancer VIP announcer (L2)                       |
+
+## Reconciler notes
+
+Sync waves and prune behaviour live in Helm chart / Application annotations.
+Check them before any destructive sync suggestion. Application deletes and
+force sync with prune are escalate-only (`references/escalation.md`).
+
+## Node and storage pointers
+
+- NotReady after hardware replace: stale
+  `kube-system/<node>.node-password.k3s` — escalate
+  (`documentation/gotcha.md`).
+- LUKS unlock / reboot policy: `AGENTS.md`,
+  `documentation/luks_remote_unlock.md`, `runbooks/access-and-nodes.md`.
+- Longhorn ambient, trim, stuck delete: `documentation/gotcha.md`,
+  `runbooks/storage.md`.

--- a/.claude/skills/self-healing/references/escalation.md
+++ b/.claude/skills/self-healing/references/escalation.md
@@ -1,0 +1,53 @@
+# Escalation Guide
+
+When in doubt, escalate. The user prefers a short alert over a bad auto-fix.
+
+This file owns **secrets boundaries** and **always-escalate** classes only.
+Unattended-edit allowlists, trivial merge rules, and the closed live-action
+list live in `runbooks/merge-policy.md` — do not fork them here.
+
+## Secrets
+
+**Escalate** any change that touches credentials or secret material:
+
+- Keys or paths matching `password`, `token`, `secret`, `credential`,
+  `apiKey`, `privateKey`, `existingSecret`, `dockerconfigjson`,
+  `tls.key`, `connectionString`, `op://`, or entries in
+  `documentation/secrets.md`
+- `ExternalSecret` / `PushSecret` source keys or remote refs
+- Any file under the machine-local secrets store described in
+  `documentation/secrets.md` (outside this repo)
+
+When a `values.yaml` edit is borderline for secrets, escalate (or hold the
+merge).
+
+## Always escalate
+
+- **Database operator** — restore, PITR, major upgrade, delete, failover, PVC
+  **resize or delete** on DB volumes, operator topology changes.
+- **Storage** — volume delete, restore, recurring-job backup target changes,
+  crypto secret rotation, stuck-volume webhook work.
+- **Disk encryption / nodes** — unlock (`make unlock`), hardware replace,
+  stale node-password cleanup, plain reboot of LUKS-root nodes.
+- **Cluster ops** — full teardown, version upgrade, reboot-all maintenance
+  (`make nuke`, `make upgrade`, `make maintenance`), etcd repair, k3s
+  reinstall.
+- **Mass impact** — cluster-wide restart, draining **multiple** nodes, bulk
+  deletes across namespaces.
+- **Infrastructure as code** — any Terraform/OpenTofu/Terragrunt apply,
+  Ansible setup/disk-encryption playbooks.
+- **Secrets** — editing chart secret payloads, password-manager items,
+  ExternalSecret source keys.
+- **GitOps controller** — Application/resource delete, force sync with prune,
+  disabling auto-sync permanently.
+- **Data loss** — any command that deletes PVCs, PVs, namespaces with state,
+  or object-storage backups.
+- **Jobs** — failed CronJob, backup Job, or Job whose command touches data or
+  secrets.
+
+## GitOps reminder
+
+The GitOps controller reconciles from the base branch (HEAD). A live
+`kubectl edit` without a matching PR will drift and may be reverted.
+Escalate if the only apparent fix is a one-off live patch with no clear
+GitOps follow-up.

--- a/.claude/skills/self-healing/runbooks/access-and-nodes.md
+++ b/.claude/skills/self-healing/runbooks/access-and-nodes.md
@@ -1,0 +1,60 @@
+# Access and Nodes
+
+Prerequisites: otaru repo checkout, kubeconfig reaching API VIP
+`192.168.10.50` (port optional; see runtime gate in `SKILL.md`).
+
+## Checks
+
+- `kubectl cluster-info` — API server host is `192.168.10.50`?
+- `kubectl get nodes -o wide` — all five expected names present and Ready?
+- Node pressure: `DiskPressure`, `MemoryPressure`, and `PIDPressure` must be
+  **False** on every node. Prefer custom-columns / jsonpath on
+  `.status.conditions` (or MCP); use `kubectl describe node` only when
+  drilling into a True condition.
+
+## NotReady triage (P0)
+
+Journal **any** NotReady node as P0 before lower-priority categories.
+
+**Reachability.** Ping the node IP from `references/cluster.md`. If the host
+is dark (no ping, no SSH) but power may still be on, do not assume a clean
+reboot — see hardware gotchas below.
+
+**LUKS / initramfs.** Several nodes use LUKS-encrypted root
+(`luks_root_nodes` in `ansible/inventory.yaml`). After a reboot they sit in
+initramfs until unlock and will not rejoin without intervention.
+
+- **Forbidden unattended:** `reboot`, `shutdown`, `systemctl reboot`,
+  `kubectl debug` reboot paths, or Ansible's generic `reboot` module. See
+  `AGENTS.md` Node Reboot Policy.
+- **Escalate unlock / planned reboot** to the user. Documented paths:
+  `make unlock <node-name>` when initramfs dropbear is already waiting;
+  `make maintenance` for rolling LUKS-aware reboots. Details:
+  `documentation/luks_remote_unlock.md`, `documentation/gotcha.md`.
+
+**Hardware replace + stale node password.** If a node was replaced in place
+and reuses the same name, look for `kube-system/<node>.node-password.k3s`
+(see `documentation/gotcha.md`). **Escalate** — do not delete the secret
+unattended (wrong-host risk).
+
+**Known host NIC hang (`nuc-00`).** Onboard Intel 82579V (`eno1`, `e1000e`)
+can hit `Detected Hardware Unit Hang`: host stays up, network dies, kubelet
+goes NotReady. Recovery is a power cycle then `make unlock nuc-00` (LUKS).
+Escalate; do not plain-reboot. See `documentation/gotcha.md` (e1000e
+section).
+
+**RPi5 Wi-Fi association loop.** `status_code=16` / endless
+`CTRL-EVENT-ASSOC-REJECT` is a firmware/AP-rate-limit issue; rebooting the
+node alone often fails. Escalate; see `documentation/gotcha.md`.
+
+**Otherwise** journal symptoms (conditions, events, last heartbeat) and
+escalate with a recommended next step.
+
+## Pressure
+
+- Any pressure condition **True** → journal and treat as P0
+  storage/capacity risk; GitOps-fix or escalate.
+
+## Healthy
+
+- All Ready, no pressure → continue to the next runbook.

--- a/.claude/skills/self-healing/runbooks/branch-cleanup.md
+++ b/.claude/skills/self-healing/runbooks/branch-cleanup.md
@@ -1,0 +1,39 @@
+# Branch Cleanup
+
+Trivial PRs auto-merge and usually clean up remotes; non-trivial PRs hold at
+green for the user, and squash-merges still leave local branches with
+`: gone]` remotes either way. Run this:
+
+- Immediately after every PR's outcome is known.
+- Once at the end of **every** self-healing run, whether invoked manually
+  or via a scheduled loop, regardless of cluster health and even if no PR
+  was opened this run — a safety net for anything merged since the last
+  run.
+
+## Steps
+
+1. `git fetch --prune origin`
+2. `git branch -vv` — local branches whose remote shows `: gone]` had
+    their upstream deleted (a "delete branch after merge" repo setting
+    fires on merge).
+3. For each `gone` branch, confirm it is actually merged — do not trust
+    ancestry alone (`git merge-base --is-ancestor` can say "no" for a
+    squash merge even though the PR merged, since squash rewrites the
+    commit onto the base branch). Check via
+    `gh pr list --state merged --head <branch> --json number,state,mergedAt`.
+4. Delete only branches with a confirmed merged PR: `git branch -D <branch>`
+    (`-D` because squash-merged history means `-d` will refuse even though
+    the branch is genuinely done).
+5. Never delete the branch checked out for an in-flight PR, or any branch
+    whose PR is not yet merged.
+
+## If CI/PR state looks stuck
+
+If CI checks or `gh pr view` look stuck on a stale commit across multiple
+pushes (the same `head.sha` keeps showing despite `git ls-remote` confirming
+the push landed), do not assume a sync delay or client-side caching bug.
+Check `gh api repos/<owner>/<repo>/pulls/<number> -q '.state, .merged'`
+first — the PR has very likely already merged or closed, and every push
+after that point went to a dead branch. Reopen from the current base branch
+with the missing diff (`git diff <old_head>..<new_head> -- <path> | git
+apply -`) rather than pushing further commits to the closed PR's branch.

--- a/.claude/skills/self-healing/runbooks/ci-cd.md
+++ b/.claude/skills/self-healing/runbooks/ci-cd.md
@@ -1,0 +1,33 @@
+# CI/CD Health
+
+Scheduled workflows can fail silently for a long time — nothing in the
+cluster reflects a broken automation until a human notices. Check for it
+directly rather than only reacting to reports.
+
+## Checks
+
+Discover scheduled workflows under the repo root:
+
+```bash
+# list workflow files that declare an on.schedule trigger
+rg -l 'schedule:' .github/workflows
+```
+
+For each matching file, check recent runs:
+
+```bash
+gh run list --workflow <file> --limit 5 --json conclusion,status,displayTitle,createdAt
+```
+
+Three or more consecutive `failure` conclusions means it is silently broken,
+not flaky.
+
+## Triage
+
+- Diagnose via `gh run view <id> --log-failed`.
+- A transient infrastructure error (network 5xx during a tool download,
+  runner setup failure) unrelated to the workflow content just needs
+  `gh run rerun <id> --failed` — do not treat it as a code problem.
+- Otherwise GitOps-fix the workflow file. Treat workflow / CI-config
+  edits as **non-trivial** (stop at green for the user) unless the change
+  is a pure syntax nit with no trigger/permission/secret impact.

--- a/.claude/skills/self-healing/runbooks/data-plane.md
+++ b/.claude/skills/self-healing/runbooks/data-plane.md
@@ -1,0 +1,33 @@
+# Data Plane
+
+Database and storage backups. Today that is CloudNativePG (CNPG) for
+Postgres and Longhorn for block storage — update the commands below if
+either is ever replaced. Read-only for the database operator here — no
+mutations (see `references/escalation.md`).
+
+## Checks
+
+- `kubectl get cluster -A` then `kubectl cnpg status <name> -n <ns>` per
+  cluster.
+- `kubectl get scheduledbackup,backup -A` — any failed or missing recent
+  CNPG backups?
+- `kubectl -n longhorn-system get recurringjobs.longhorn.io` — jobs
+  present? Any failed backup Jobs or pods in `longhorn-system`?
+- `kubectl get externalsecrets -A` — any not `Ready`?
+
+## Triage
+
+- CNPG healthy → continue.
+- Backup failing, replica lag, or instance down → journal and
+  **escalate** (no CNPG mutations).
+- **Barman / WAL archiving `exit status 4`:** often disk full on the
+  instance PVC. Recovery paths that delete DB PVCs or pods are
+  **escalate** only — never unattended. See `documentation/gotcha.md`.
+- Failed Longhorn recurring backup Jobs → **escalate**.
+- ExternalSecret not `Ready`: only `force-sync` under the live-action
+  rules in `runbooks/merge-policy.md` (concrete upstream-change proof
+  required). Otherwise GitOps-fix or escalate if source keys or
+  `values.yaml` secret payloads need edits.
+
+PVC **resize** or delete on database volumes is always escalate (see
+`references/escalation.md`), even when space pressure is obvious.

--- a/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
+++ b/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
@@ -1,0 +1,26 @@
+# GitOps Reconciliation
+
+This cluster currently reconciles from Git via Argo CD. If that ever changes
+(for example a FluxCD migration), update the commands below in place — the
+category and its place in the investigation order do not need to change.
+
+## Checks
+
+- `kubectl -n argocd get applications.argoproj.io` — any `Degraded`,
+  `Unknown`, or `OutOfSync`?
+- For unhealthy apps, read sync status and recent events before acting.
+
+## Triage
+
+- `Degraded` or `Unknown` → P0; diagnose then GitOps-fix or escalate.
+- `OutOfSync` for more than one hourly loop cycle with no in-flight PR →
+  investigate drift; GitOps-fix when the live diff is wrong, otherwise
+  escalate if sync needs prune/force.
+- **`Unknown` + `fork/exec ... jsonnet: exec format error`:** the
+  jsonnet CMP sidecar image may be arm64-only while the repo-server landed
+  on amd64 (`nuc-00`). Prefer pinning `argocd.repoServer` to
+  `kubernetes.io/arch: arm64` in GitOps (see recent journal / chart), not a
+  force-sync.
+- Before suggesting Application deletes or prune/force sync, check Helm
+  chart / Application annotations for **sync waves** and prune behaviour.
+  Destructive sync is escalate-only (`references/escalation.md`).

--- a/.claude/skills/self-healing/runbooks/ingress-mesh.md
+++ b/.claude/skills/self-healing/runbooks/ingress-mesh.md
@@ -1,0 +1,36 @@
+# Ingress and Mesh
+
+## P0 path: Gateway
+
+- `kubectl get gateway,httproute -A` — backends unhealthy or routes not
+  attached? Check `envoy-gateway-system` and `gateway` pods (user-facing
+  ingress VIP `192.168.10.51`).
+
+### Load-balancer VIP reachability
+
+Gateway/HTTPRoute `Programmed`/`Attached` and pod `Running` can all be true
+while the LoadBalancer VIP itself is silently unreachable at L2. On this
+cluster the LoadBalancer is MetalLB — grep
+`kubectl -n metallb-system logs -l app=metallb,component=speaker --tail=200`
+for `"the specified interfaces used to announce LB IP don't exist"`.
+
+This fires whenever a node's real NIC name does not match the
+`L2Advertisement`'s `interfaces` list for the pool it is announcing — see
+`documentation/gotcha.md` for the exact node/interface mismatch on this
+cluster (`nuc-00` uses `eno1`, Pis use `eth0`). GitOps-fix by splitting
+the `L2Advertisement` per node (`nodeSelectors` + the correct `interfaces`
+value for that node). For the API VIP (`.50`) mirror
+`helm-charts/metallb-vip/values.yaml`; for the gateway VIP (`.51`) mirror
+the L2Advertisement split in `helm-charts/envoy-gateway` (same per-node
+interface pattern).
+
+If speaker logs are clean but a VIP still flaps unreachable from off-cluster
+clients, also consider RPi ARP/promisc issues documented in
+`documentation/gotcha.md` — host networking fixes are **escalate** (not
+unattended GitOps).
+
+## P2 path: Service mesh
+
+- `kubectl -n istio-system get pods` — mesh dashboard or ambient components
+  not ready (Istio on this cluster). Do not fix; skip the journal unless an
+  app symptom ties to mesh (then journal as `open`).

--- a/.claude/skills/self-healing/runbooks/loop-bootstrap.md
+++ b/.claude/skills/self-healing/runbooks/loop-bootstrap.md
@@ -1,0 +1,70 @@
+# Starting the Hourly Loop
+
+Start an hourly **session-only** self-healing loop for the otaru cluster in
+the current agent session.
+
+## Why session-only
+
+This loop runs live `kubectl` actions and opens PRs. A durable, disk-persisted
+schedule can be loaded and fired by every agent session open on this repo,
+causing concurrent runs, duplicate PRs, and git races. Keep it session-only
+so exactly one session drives it. Re-run this bootstrap in whichever session
+you want to own the loop.
+
+## Steps
+
+**Step 1. List existing jobs.** List scheduled jobs (Claude: `CronList`).
+Note any recurring job whose prompt contains `self-healing`.
+
+**Step 2. Create the new session schedule first.** Create a recurring,
+**non-durable** job. The non-durable flag is the anti-concurrency invariant —
+do not omit it. Prefer **create-new, then delete-old** so a failed create does
+not leave the loop unscheduled. Never leave two matching jobs after step 3.
+
+Claude (`CronCreate`) example:
+
+```text
+cron:      37 * * * *   (hourly, off the :00/:30 marks)
+recurring: true
+durable:   false        (session-only; must not persist to disk)
+prompt:
+  1) if a prior fire in this session is still running, skip this fire.
+  2) run /self-healing (full investigation + fixes per merge-policy).
+  3) if healthy: full /right-sizing when no ### right-sizing pass in 24h;
+  or merge-only resume when latest pass is result: open with a pr: URL.
+  4) report start/end datetime and time until the job expires.
+```
+
+Other agent platforms: use the equivalent session-only / non-durable /
+non-persisted schedule API with the same cron expression and prompt intent. If
+the platform has no non-durable mode, do not start a multi-session schedule —
+stop and tell the user.
+
+**Step 3. Delete the old matching job** (if any) only after the new job is
+confirmed (Claude: `CronDelete`). Re-running this bootstrap renews the expiry
+window.
+
+**Step 4. Confirm** the job ID, the `37 * * * *` cadence, session-only
+(`durable: false`), auto-expiry (Claude: **7 days**), and how to cancel
+sooner (`CronDelete <id>`).
+
+**Step 5. Run once now.** Invoke `/self-healing` immediately. If healthy and
+no `### right-sizing pass` in the last 24 hours, invoke `/right-sizing` in the
+same session. Report start/end and time remaining until expiry.
+
+The scheduler platform caps recurring jobs at a fixed auto-expiry (Claude: 7
+days). Re-run this bootstrap before the window elapses to renew.
+
+## Unattended PR rule
+
+Scheduled fires are unattended. Classify and merge **every** GitOps fix —
+including right-sizing — per `runbooks/merge-policy.md`. Escalation-list
+issues get no PR. That file is the single source of truth.
+
+## Notes
+
+- Do not create a durable/disk-persisted job from this bootstrap unless the
+  user explicitly asks for a single-session exception.
+- Needs a kubeconfig to the otaru API VIP on the local network; stop if the
+  checkout or kubeconfig is missing.
+- Prefer `/self-healing` and this bootstrap runbook as the only entrypoints.

--- a/.claude/skills/self-healing/runbooks/merge-policy.md
+++ b/.claude/skills/self-healing/runbooks/merge-policy.md
@@ -1,0 +1,104 @@
+# Trivial vs Non-Trivial (Merge Policy)
+
+Classify every GitOps PR before deciding its merge policy. When in doubt,
+treat it as non-trivial. This file owns the **unattended edit list**,
+**trivial/non-trivial classification**, and **closed live-action allowlist**.
+`references/escalation.md` owns only escalate / secrets / destructive
+boundaries.
+
+## Merge procedure
+
+After branch, commit, push, and PR open:
+
+1. Watch CI to green. Prefer
+  `gh pr checks <number> --watch --fail-fast` (see `AGENTS.md`). In
+  **unattended/loop** mode bound the wait (for example stop after ~15
+  minutes, journal `result: open` with the PR URL, and re-check next cycle).
+  Do not park the whole hourly fire on an unbounded watch.
+2. Address review feedback if any.
+3. Then apply the class below.
+
+### Trivial — auto-merge once green
+
+- Prefer `/pr-autofix` with default auto-merge when that skill is available
+  (Claude).
+- Otherwise enable GitHub auto-merge after green, for example:
+  `gh pr merge <number> --auto --squash` (or the repo's usual merge method).
+- Journal the PR URL and that merge was auto.
+
+### Non-trivial — stop at green
+
+- Prefer `/pr-autofix auto_merge=false` when available.
+- Otherwise watch CI to green (with the same unattended timeout rule), then
+  **do not merge**. Surface the PR URL and leave the merge to the user.
+- Journal the PR URL and that merge was held.
+
+Never invent a different merge path per agent session. Escalation-list issues
+do not open a PR.
+
+Before opening a PR for a known root cause, also check
+`gh pr list --state open --search "<short cause>"` (and the journal `pr`
+field) and continue an in-flight PR when one already covers it.
+
+## Trivial
+
+Merge automatically once green when **all** of the following hold:
+
+- Diff is only an allowed unattended edit (see below)
+- No secret-adjacent keys or paths (see `references/escalation.md`)
+- No chart/template structural rewrite, CRD change, or GitOps controller
+  Application delete/disable/prune-force
+- **Single concern:** one app, one shared value, **or** one right-sizing
+  pass whose every hunk is only resource requests/limits/replicas (multi-chart
+  resource-only is still one concern). Not a mixed bulk rewrite of unrelated
+  concerns.
+- Tests already passed for this branch (`make test` before open; CI green)
+
+## Non-trivial
+
+Push, watch CI to green, address review feedback, then stop and leave the
+merge to the user. Includes: anything outside the allowlist, borderline
+`values.yaml` edits, database/storage backup changes that are not pure
+resource/image/probe/sync-wave tweaks (topology, schedule, storage class,
+PVC size, crypto, restore), mesh/gateway policy, cluster-wide policy-chart
+rewrites, multi-app bulk edits of **non-resource** fields, or any fix not
+confidently low-risk. Pure resource/image pins on a database or storage chart
+remain trivial when they meet the bullets above.
+
+## Allowed unattended GitOps edits
+
+Trivial when they alone form the PR: resource requests/limits, replicas
+within PDB bounds, probe tweaks, public image tag pins, sync-wave fixes,
+dashboard/log retention unrelated to backup storage, non-secret feature
+flags that do not change exposure/auth/privilege, and manifest nits to
+satisfy an **existing** policy (no policy chart rewrite). Do not auto-merge
+`hostNetwork`, privileged `securityContext`, Service exposure, or auth
+flag changes — treat those as non-trivial. See `references/escalation.md`
+for the secrets boundary.
+
+## Live mutations
+
+Do not `kubectl apply`, `patch`, or `edit` live resources. Escalate live
+patches unless the user explicitly approves a time-boxed interim fix.
+
+Closed live-action allowlist (journal each one):
+
+- Delete a `CrashLoopBackOff` or stuck `Failed` pod when a Deployment (or
+  ReplicaSet-owned) controller will recreate it — **not** StatefulSet pods
+  unless the user approves. Confirm the Job/pod is not a backup or CronJob
+  child before delete.
+- Delete a failed one-off `Job` only after confirming it is not a backup /
+  CronJob run (see `references/escalation.md`).
+- `kubectl rollout restart` for a misbehaving Deployment when config is
+  already correct in Git.
+- Annotate ExternalSecret / PushSecret `force-sync` only when there is a
+  concrete upstream-change proof (known rotation, user note, or verified
+  upstream version bump). Do not thrash force-sync on a guess.
+- Scale a Deployment **down** only as far as the PDB allows, and **up** at
+  most +1 replica above the current ready count unless the user approves a
+  larger step. Prefer GitOps replica changes over live scale when practical.
+
+No other live mutations. Escalate everything else.
+
+After a GitOps fix merges, wait for the reconciler's auto-sync and re-check
+the symptom.

--- a/.claude/skills/self-healing/runbooks/platform.md
+++ b/.claude/skills/self-healing/runbooks/platform.md
@@ -1,0 +1,24 @@
+# Platform
+
+## Checks
+
+- `kubectl get certificates -A` — any not `Ready`?
+- `kubectl get apiservice` — metrics or HPA / external-metrics APIs
+  unavailable?
+  - `v1beta1.metrics.k8s.io` (metrics-server)
+  - `v1beta1.external.metrics.k8s.io` (KEDA, when installed)
+
+## Triage
+
+- Certificate `Issuing` or a recent event → wait one cycle, re-check.
+- Certificate stuck `not Ready` beyond one cycle → GitOps-fix the
+  `Certificate` or issuer config, or escalate if DNS/LUKS/secret rotation
+  is involved.
+- **APIService `FailedDiscoveryCheck` / EOF to pod IPs** while adapter pods
+  look Running: often ambient redirection on kube-apiserver → aggregated
+  API paths.
+  - metrics-server: pods in `monitoring` must keep
+    `istio.io/dataplane-mode: none` (chart values); GitOps-fix or
+    escalate a rollout restart after label fix.
+  - KEDA: `keda` namespace must stay `ambient: false`.
+  - Full symptom/resolution detail: `documentation/gotcha.md`.

--- a/.claude/skills/self-healing/runbooks/policy.md
+++ b/.claude/skills/self-healing/runbooks/policy.md
@@ -1,0 +1,15 @@
+# Policy
+
+Kyverno enforces admission policy on this cluster today; if that changes,
+update the commands below.
+
+## Checks
+
+- `kubectl get clusterpolicyreports,policyreports -A` — policy failures
+  blocking workloads?
+
+## Triage
+
+- Policy deny on a new or changed workload → GitOps-fix the manifest or
+  chart to comply.
+- Cluster-wide policy chart change → escalate.

--- a/.claude/skills/self-healing/runbooks/storage.md
+++ b/.claude/skills/self-healing/runbooks/storage.md
@@ -1,0 +1,31 @@
+# Storage
+
+## Checks
+
+- `kubectl get pvc -A` — any `Pending` or `Lost`?
+- `kubectl -n longhorn-system get volumes.longhorn.io` — any `faulted` or
+  `degraded`?
+- Workloads stuck in `ContainerCreating` with `AttachVolume.Attach failed`
+  and webhook errors mentioning `mutator.longhorn.io` /
+  `validator.longhorn.io` — often ambient mesh on `longhorn-system` (see
+  gotchas).
+
+## Triage
+
+- Read `documentation/gotcha.md` before acting on Longhorn.
+- `Pending` PVC → check events; GitOps storage-class or quota fix, or
+  escalate.
+- `faulted` / `degraded` volume → journal and **escalate** unless
+  `documentation/gotcha.md` documents a safe rollout restart only (no
+  volume delete, no crypto change).
+- **Ambient on Longhorn:** `longhorn-system` must stay outside ambient
+  (`ambient: false` in `helm-charts/namespaces/values.yaml`). If labels
+  drifted on, escalate label cleanup + manager restart — do not delete
+  volumes. See `documentation/gotcha.md`.
+- **Volume stuck `deleting`:** webhook/validation blocks are documented in
+  `documentation/gotcha.md`. Removing webhook rules and force-deleting
+  volumes is **always escalate** (data loss).
+- **Encrypted volume space not reclaimed after delete/trim:** missing
+  dm-crypt `allow-discards`; recovery is `make trim` / `make maintenance`,
+  not a privileged always-on DaemonSet. Escalate; do not reintroduce
+  `cypto-volume-allow-discards`. See `documentation/gotcha.md`.

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -1,0 +1,37 @@
+# Workloads
+
+## Checks
+
+- `kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded`
+- Scan `kubectl get pods -A -o wide` (grep or read the table) for
+  `CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`,
+  `CreateContainerConfigError`, or high `RESTARTS` — phase `Running` hides
+  these from the field-selector above.
+- `kubectl get deploy,sts,ds -A` — not fully available?
+- **Jobs:** `kubectl get jobs -A` — any `Failed` or `Running` beyond
+  expected duration?
+
+## Triage
+
+- Owned `CrashLoopBackOff` pod → allowlisted delete (see
+  `runbooks/merge-policy.md` for what counts as a safe live action).
+- `ImagePullBackOff` / `ErrImagePull` → GitOps-fix public image tags or
+  digests only. Registry auth / `imagePullSecrets` / pull-secret failures
+  → **escalate** (do not dump Secret YAML; see journal redaction rules).
+- Failed one-off Job → delete only after confirming it is not a backup or
+  CronJob child (see `runbooks/merge-policy.md` and
+  `references/escalation.md`).
+- CronJob or backup Job failures → GitOps-fix or escalate.
+
+## Known data-durability gotchas
+
+- **changedetection watch list wipe:** pinning
+  `ghcr.io/dgtlmoon/changedetection.io:latest@sha256:...` allows mutable
+  `latest` + migrations (or a volume reformat) to reseed defaults. Longhorn
+  backup for `changedetection-vol` has been weekly with `retain: 1`, so a
+  bad state can overwrite the only restore point within a week. Prefer
+  concrete version tags; escalate restore; treat watch data as
+  low-durability until retention is deepened. See `documentation/gotcha.md`.
+- **`latest` / floating tags on stateful apps:** when diagnosing sudden
+  empty config or default data after a restart, check for floating tags
+  and thin backup retention before assuming app logic alone failed.


### PR DESCRIPTION
## Summary

- Publish `.claude/skills/self-healing/` (investigation runbooks, merge policy, loop bootstrap, escalation).
- Align `.claude/skills/right-sizing` with shared merge/journal contracts; resolve Prometheus URL from charts without hardcoding domains.
- Session-only loop bootstrap (`durable: false`), GitOps-first fixes, LUKS/escalation safety, and right-sizing handoff.

## Test plan

- [x] `make test` locally
- [ ] CI green on this PR