### PR TITLE
fix(metallb): set resource requests/limits for frr-k8s components

### DIFF
--- a/helm-charts/metallb/values.yaml
+++ b/helm-charts/metallb/values.yaml
@@ -1,10 +1,6 @@
 namespace: metallb-system
 
 metallb:
-  frr-k8s:
-    prometheus:
-      serviceMonitor:
-        enabled: false
   _speakerResources: &speakerResources
     requests:
       cpu: 50m
@@ -13,6 +9,25 @@ metallb:
     limits:
       memory: 128Mi
       ephemeral-storage: 64Mi
+  frr-k8s:
+    prometheus:
+      serviceMonitor:
+        enabled: false
+    # Kyverno require-workload-resources (background scan) flagged the
+    # frr-k8s daemonset containers and the statuscleaner Deployment as
+    # missing resource requests/limits. No KRR data yet for these
+    # containers, so reuse the existing speaker sizing for consistency;
+    # revisit via /right-sizing once usage data is available.
+    frrk8s:
+      resources: *speakerResources
+      frr:
+        resources: *speakerResources
+      reloader:
+        resources: *speakerResources
+      frrMetrics:
+        resources: *speakerResources
+      frrStatus:
+        resources: *speakerResources
   speaker:
     resources: *speakerResources
     frr:


### PR DESCRIPTION
## Summary
- Kyverno's `require-workload-resources` background scan flagged the `metallb-frr-k8s` DaemonSet (controller, frr, reloader, frr-metrics, frr-status containers) and the `metallb-frr-k8s-statuscleaner` Deployment as missing resource requests/limits.
- Set requests/limits for all five, reusing the existing `speaker` sizing anchor for consistency since there is no KRR data yet for these containers.

## Test plan
- [x] `helm template` confirms resources render on the frr-k8s DaemonSet containers and both Deployments
- [x] `make test` passes (Helm chart validation, YAML, markdown, EditorConfig, Terraform/Terragrunt lint, zizmor)