### PR TITLE
fix(metallb): disable unused frr-k8s BGP backend

### DIFF
--- a/helm-charts/metallb/values.yaml
+++ b/helm-charts/metallb/values.yaml
@@ -9,25 +9,9 @@ metallb:
     limits:
       memory: 128Mi
       ephemeral-storage: 64Mi
-  frr-k8s:
-    prometheus:
-      serviceMonitor:
-        enabled: false
-    # Kyverno require-workload-resources (background scan) flagged the
-    # frr-k8s daemonset containers and the statuscleaner Deployment as
-    # missing resource requests/limits. No KRR data yet for these
-    # containers, so reuse the existing speaker sizing for consistency;
-    # revisit via /right-sizing once usage data is available.
-    frrk8s:
-      resources: *speakerResources
-      frr:
-        resources: *speakerResources
-      reloader:
-        resources: *speakerResources
-      frrMetrics:
-        resources: *speakerResources
-      frrStatus:
-        resources: *speakerResources
+  # No BGP peers configured (L2Advertisement only) -- BGP backend unused.
+  frrk8s:
+    enabled: false
   speaker:
     resources: *speakerResources
     frr:


### PR DESCRIPTION
## Summary
- This cluster only uses L2Advertisement (ARP/NDP) for VIP failover -- there are no BGPPeer or BGPAdvertisement resources anywhere in the repo or live cluster.
- The frr-k8s BGP backend daemonset has therefore never done any actual routing work; L2 advertisement is handled entirely by the speaker daemonset, independent of frrk8s.
- Set `frrk8s.enabled: false` to stop running it. This removes the `metallb-frr-k8s` DaemonSet and `metallb-frr-k8s-statuscleaner` Deployment from every node.
- Also drops the resource-limit config added in #2753 for those containers, since they no longer exist.

## Test plan
- [x] `helm template` confirms the frr-k8s DaemonSet, statuscleaner Deployment, and frr-k8s webhook Service no longer render; speaker, controller, CRDs, and the main validating webhook are unaffected
- [x] `make test` passes (Helm chart validation, YAML, markdown, EditorConfig, Terraform/Terragrunt lint, zizmor)
- [ ] Confirm live: after ArgoCD syncs, VIP ARP/NDP failover still works as expected (speaker-only, no BGP dependency)