### PR TITLE
fix(longhorn): set resource requests/limits for longhorn-manager

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -6,6 +6,15 @@ longhorn:
     serviceAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9500"
+    # KRR 2026-07-10: peak ~115m cpu / 403Mi mem over 14d; was unset.
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 512Mi
+        ephemeral-storage: 64Mi
   preUpgradeChecker:
     jobEnabled: false
   persistence:


### PR DESCRIPTION
## Summary

- KRR flagged the `longhorn-manager` DaemonSet container as having no
  CPU/memory requests or limits set at all (chart default).
- 14-day peak observed: ~115m CPU, ~403Mi memory.
- Sets requests/limits with headroom (150m CPU, 512Mi memory, 64Mi
  ephemeral-storage) per KRR guidance.

## Notes

Most other longhorn-system components flagged by the same Kyverno
`require-workload-resources` audit (csi-attacher, csi-provisioner,
csi-resizer, csi-snapshotter, longhorn-driver-deployer, longhorn-ui,
longhorn-csi-plugin, engine-image, trim) have no `values.yaml` resources
hook in the upstream chart at all -- some are created dynamically by
longhorn-manager at runtime rather than templated by Helm. Out of scope
for this PR.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `resources` renders correctly on the
      `longhorn-manager` container
- [ ] Argo CD syncs `longhorn` app to this revision, pod restarts clean,
      no OOMKill