### PR TITLE
fix(longhorn): disable unused default StorageClass

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -19,6 +19,8 @@ longhorn:
     jobEnabled: false
   persistence:
     defaultClass: false
+    # No PVC references this class -- everything uses longhorn-crypto-global.
+    createStorageClass: false
   defaultSettings:
     allowCollectingLonghornUsageMetrics: false
     defaultReplicaCount: 2


### PR DESCRIPTION
## Summary

- The upstream Longhorn chart creates a default `longhorn` StorageClass
  regardless of `persistence.defaultClass`.
- No PVC in this repo references it -- everything targets
  `longhorn-crypto-global`, our own encrypted default class.
- Sets `persistence.createStorageClass: false` to stop creating it.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the `longhorn-storageclass` ConfigMap
      (which renders the StorageClass) no longer renders