### PR TITLE
feat(argocd): enable orphaned-resources monitoring on default AppProject

### DIFF
--- a/helm-charts/argocd-config/templates/app-project.yaml
+++ b/helm-charts/argocd-config/templates/app-project.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: {{ .Values.namespace }}
+spec:
+  orphanedResources:
+    warn: true
+    ignore:
+      # Every namespace's implicit service-account root CA bundle, recreated
+      # by the API server rather than tracked in git.
+      - group: ""
+        kind: ConfigMap
+        name: kube-root-ca.crt
+      # Kyverno background-scan output, regenerated continuously per
+      # namespace/cluster and never git-tracked.
+      - group: wgpolicyk8s.io
+        kind: PolicyReport
+      - group: wgpolicyk8s.io
+        kind: ClusterPolicyReport
+      # cert-manager's transient ACME workflow objects: a CertificateRequest
+      # is created per issuance/renewal, an Order/Challenge per ACME
+      # handshake. Only the parent Certificate is git-tracked.
+      - group: cert-manager.io
+        kind: CertificateRequest
+      - group: cert-manager.io
+        kind: Order
+      - group: cert-manager.io
+        kind: Challenge
+      # Longhorn's internal per-volume runtime state, created and destroyed
+      # by longhorn-manager as volumes attach/detach/rebuild. Only the
+      # higher-level Node/Setting/RecurringJob CRs are git-tracked.
+      - group: longhorn.io
+        kind: Engine
+      - group: longhorn.io
+        kind: Replica
+      - group: longhorn.io
+        kind: Volume
+      - group: longhorn.io
+        kind: InstanceManager
+      - group: longhorn.io
+        kind: ShareManager
+      - group: longhorn.io
+        kind: BackingImageManager


### PR DESCRIPTION
## Summary

- Add a git-tracked `AppProject` for `default` in `helm-charts/argocd-config` — today the `default` project only exists as Argo CD's implicit auto-created project, since every Application in `helm-charts/argocd-bootstrap` uses `project: default` but no `AppProject` manifest exists anywhere in the repo.
- Turn on `spec.orphanedResources.warn: true` so untracked cluster objects surface in the Argo CD UI/API instead of going unnoticed, without pruning anything (warn-only).
- Seed the `ignore` list with resource kinds confirmed live on the cluster that are legitimately never git-tracked, so the signal starts usable rather than pure noise:
  - `ConfigMap/kube-root-ca.crt` (per-namespace, recreated by the API server)
  - `wgpolicyk8s.io` `PolicyReport`/`ClusterPolicyReport` (Kyverno background-scan output; 889 live instances)
  - `cert-manager.io` `CertificateRequest`/`Order`/`Challenge` (transient ACME workflow objects; only the parent `Certificate` is git-tracked)
  - `longhorn.io` `Engine`/`Replica`/`Volume`/`InstanceManager`/`ShareManager`/`BackingImageManager` (Longhorn's internal per-volume runtime state; confirmed 26/32/26/5 live instances respectively for the first four). Longhorn's `Node`/`Setting`/`RecurringJob` CRs are deliberately left out of the ignore list since those are git-tracked via `helm-charts/longhorn-config` and should still be caught if drift occurs.

Chosen `helm-charts/argocd-config` over `helm-charts/argocd-bootstrap` because that chart already owns argocd-server-scoped configuration objects (`AuthorizationPolicy`, `ExternalSecret`, `HTTPRoute`), whereas `argocd-bootstrap` only defines Applications.

## Test plan

- [x] `helm template helm-charts/argocd-config` renders the new `AppProject` cleanly.
- [x] `make update-helm-deps && make test` passes (YAML syntax, markdown lint, Helm chart validation including Argo CD manifest rendering, Terraform/Terragrunt lint, EditorConfig compliance, zizmor audit).
- [x] `git status` confirms only `helm-charts/argocd-config/templates/app-project.yaml` is new; no other files changed.