### PR TITLE
fix(images): pin jung2bot and kubernetes-mcp-server images off latest

### DIFF
--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -56,7 +56,7 @@ spec:
         spec:
           containers:
             - name: scale-up-database
-              image: curlimages/curl
+              image: curlimages/curl:8.21.0
               command: [ "curl" ]
               args:
                 - "-v"

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -2,6 +2,10 @@ name: k8s-mcp
 namespace: kubernetes-mcp-server
 
 kubernetes-mcp-server:
+  image:
+    registry: quay.io
+    repository: containers/kubernetes_mcp_server
+    version: v0.0.63
   ingress:
     enabled: false
   service:


### PR DESCRIPTION
## Summary

- Pin the `jung2bot`/`jung2bot-dev` `scale-up-database` CronJob's
  `curlimages/curl` image to `8.21.0` (was untagged, implicit `latest`).
  The image is hardcoded in the shared `jung2bot` chart template, so this
  one line fixes both the prod and dev deployments.
- Pin `kubernetes-mcp-server`'s upstream OCI subchart image to
  `quay.io/containers/kubernetes_mcp_server:v0.0.63` (was inheriting the
  subchart's default `latest` tag) via the correct `image.registry` /
  `image.repository` / `image.version` override keys.

Found via a kubescape/popeye cluster audit (popeye `POP-101`).

## Test plan

- `helm template helm-charts/jung2bot` and the `jung2bot-dev` overlay
  (`-f helm-charts/jung2bot/value/dev.yaml`) both show
  `curlimages/curl:8.21.0` for `scale-up-database`.
- `helm template helm-charts/kubernetes-mcp-server` shows
  `quay.io/containers/kubernetes_mcp_server:v0.0.63`.
- Verified `v0.0.63` is the current tag on quay.io (matches the latest
  `containers/kubernetes-mcp-server` GitHub release) and `8.21.0` is the
  current stable `curlimages/curl` Docker Hub tag.
- `make test` passes.