### PR TITLE
feat(kyverno): add require-image-tag policy

### DIFF
--- a/helm-charts/kyverno-policy/templates/require-image-tag-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-image-tag-policy.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.requireImageTagPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-tag
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-container-image-tag
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+{{- with .Values.requireImageTagPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+{{- end }}
+      validate:
+        allowExistingViolations: true
+        failureAction: Audit
+        message: Containers must use an explicit image tag rather than an implicit latest.
+        pattern:
+          spec:
+            =(initContainers):
+              - image: "*:*"
+            containers:
+              - image: "*:*"
+    - name: disallow-latest-image-tag
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+{{- with .Values.requireImageTagPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+{{- end }}
+      validate:
+        allowExistingViolations: true
+        failureAction: Audit
+        message: Containers must not use the mutable latest image tag.
+        pattern:
+          spec:
+            =(initContainers):
+              - image: "!*:latest"
+            containers:
+              - image: "!*:latest"
+  validationFailureAction: Audit
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -72,3 +72,11 @@ barmanObjectStorePolicy:
         - b2-backup
       credentialSecrets:
         - b2-backup-credentials
+
+requireImageTagPolicy:
+  enabled: true
+  excludedNamespaces:
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - kyverno


### PR DESCRIPTION
## Summary

- Add a new `require-image-tag` Kyverno `ClusterPolicy`
  (`helm-charts/kyverno-policy/templates/require-image-tag-policy.yaml`)
  with two audit-only rules: containers must have an explicit image tag
  (`*:*`), and must not use the mutable `latest` tag. `Audit` mode,
  `allowExistingViolations: true`, matching the existing
  `require-workload-resources` policy's shape.
- Gate it behind a new `requireImageTagPolicy.enabled` key in
  `helm-charts/kyverno-policy/values.yaml`, appended at the end of the
  file to avoid clashing with other in-flight edits to the same file.

Follow-up to #2762 (image tag pins), so this cannot silently reappear.
Since the policy is audit-only, PR ordering between the two does not
matter.

## Test plan

- `helm template helm-charts/kyverno-policy --show-only
  templates/require-image-tag-policy.yaml` renders cleanly.
- `helm lint helm-charts/kyverno-policy` passes.
- `make test` passes.