### PR TITLE
fix(envoy-gateway): set shutdown-manager sidecar resource limits

### DIFF
--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -15,5 +15,20 @@ spec:
         pod:
           affinity:
 {{ toYaml .Values.envoyProxy.affinity | indent 12 }}
+        # Envoy Gateway v1.8 has no first-class field for the
+        # shutdown-manager sidecar's resources (only its container image is
+        # configurable directly); a StrategicMerge patch on the rendered
+        # Deployment is the documented way to reach it.
+        # https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: shutdown-manager
+                      resources:
+{{ toYaml .Values.envoyProxy.shutdownManagerResources | indent 24 }}
       envoyService:
         name: {{ .Values.service.name }}

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -15,6 +15,21 @@ _shared:
     limits:
       memory: 256Mi
       ephemeral-storage: 128Mi
+  # Kyverno require-workload-resources (background scan) flagged the
+  # shutdown-manager sidecar in the gateway Deployment as missing memory
+  # and ephemeral-storage requests/limits (only a CPU request is applied
+  # by envoy-gateway's own hardcoded default). No KRR data yet for this
+  # container, so reuse its existing 10m CPU request and pair it with a
+  # memory/ephemeral-storage size similar to envoyGatewayResources above,
+  # since both are lightweight Go control-plane sidecars.
+  shutdownManagerResources: &shutdownManagerResources
+    requests:
+      cpu: 10m
+      memory: 32Mi
+      ephemeral-storage: 32Mi
+    limits:
+      memory: 32Mi
+      ephemeral-storage: 32Mi
 
 name: gateway
 namespace: gateway
@@ -102,3 +117,4 @@ envoyProxy:
                 gateway.networking.k8s.io/gateway-name: gateway
             topologyKey: kubernetes.io/hostname
   resources: *envoyProxyResources
+  shutdownManagerResources: *shutdownManagerResources


### PR DESCRIPTION
## Summary

- Kyverno's `require-workload-resources` background scan (Audit mode)
  flagged the `shutdown-manager` sidecar in the `gateway` Deployment as
  missing memory and ephemeral-storage requests/limits; only a
  hardcoded 10m CPU request applies today.
- Envoy Gateway v1.8 has no direct `EnvoyProxy` field for this
  container's resources, so add a `StrategicMerge` patch on the
  `envoyDeployment`, the mechanism documented at
  <https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/>.
- No KRR data exists yet for this container, so the change keeps the
  existing 10m CPU request and sizes memory/ephemeral-storage the same
  as the chart's other lightweight sidecar (`envoyGatewayResources`).

## Test plan

- [x] `helm template` on `helm-charts/envoy-gateway` renders the
  `EnvoyProxy` CR with the `patch.value` targeting
  `containers[name=shutdown-manager].resources` correctly.
- [x] `make test` passes.
- [ ] After merge, confirm via `kubectl get deploy -n gateway gateway
  -o jsonpath='{.spec.template.spec.containers[*].resources}'` that
  both `envoy` and `shutdown-manager` show full requests/limits, and
  that the `require-workload-resources` PolicyReport violation for
  this workload clears.