### PR TITLE
fix(longhorn): backfill resource limits for CSI components

### DIFF
--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -15,5 +15,20 @@ spec:
         pod:
           affinity:
 {{ toYaml .Values.envoyProxy.affinity | indent 12 }}
+        # Envoy Gateway v1.8 has no first-class field for the
+        # shutdown-manager sidecar's resources (only its container image is
+        # configurable directly); a StrategicMerge patch on the rendered
+        # Deployment is the documented way to reach it.
+        # https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: shutdown-manager
+                      resources:
+{{ toYaml .Values.envoyProxy.shutdownManagerResources | indent 24 }}
       envoyService:
         name: {{ .Values.service.name }}

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -15,6 +15,21 @@ _shared:
     limits:
       memory: 256Mi
       ephemeral-storage: 128Mi
+  # Kyverno require-workload-resources (background scan) flagged the
+  # shutdown-manager sidecar in the gateway Deployment as missing memory
+  # and ephemeral-storage requests/limits (only a CPU request is applied
+  # by envoy-gateway's own hardcoded default). No KRR data yet for this
+  # container, so reuse its existing 10m CPU request and pair it with a
+  # memory/ephemeral-storage size similar to envoyGatewayResources above,
+  # since both are lightweight Go control-plane sidecars.
+  shutdownManagerResources: &shutdownManagerResources
+    requests:
+      cpu: 10m
+      memory: 32Mi
+      ephemeral-storage: 32Mi
+    limits:
+      memory: 32Mi
+      ephemeral-storage: 32Mi
 
 name: gateway
 namespace: gateway
@@ -102,3 +117,4 @@ envoyProxy:
                 gateway.networking.k8s.io/gateway-name: gateway
             topologyKey: kubernetes.io/hostname
   resources: *envoyProxyResources
+  shutdownManagerResources: *shutdownManagerResources

--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -29,6 +29,25 @@ longhorn:
     storageReservedPercentageForDefaultDisk: "0"
     snapshotMaxCount: "250"
     autoCleanupSnapshotWhenDeleteBackup: true
+    # Kyverno require-workload-resources (background scan) flagged
+    # Deployment/csi-attacher, csi-provisioner, csi-resizer, csi-snapshotter,
+    # and the longhorn-csi-plugin/node-driver-registrar/longhorn-liveness-probe
+    # containers of the longhorn-csi-plugin DaemonSet as missing memory and
+    # ephemeral-storage requests/limits. These are system-managed components
+    # created directly by longhorn-manager, not by this Helm chart's
+    # templates, so this Longhorn Setting (a JSON object keyed by component
+    # name) is the only supported way to size them. No KRR data yet, so each
+    # lightweight sidecar reuses the same size as the gateway chart's
+    # shutdown-manager sidecar; longhorn-csi-plugin itself (does actual
+    # mount/format work) gets a slightly larger allowance.
+    systemManagedCSIComponentsResourceLimits: >-
+      {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
+      "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
+      "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
+      "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"64Mi","ephemeral-storage":"32Mi"}},
+      "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
+      "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
   defaultBackupStore:
     backupTarget: ~
     backupTargetCredentialSecret: b2-secret


### PR DESCRIPTION
## Summary

- Kyverno's `require-workload-resources` background scan (Audit mode)
  flagged the system-managed CSI sidecars in `longhorn-system` as
  missing memory and ephemeral-storage requests/limits: Deployments
  `csi-attacher`, `csi-provisioner`, `csi-resizer`, `csi-snapshotter`,
  and all three containers of the `longhorn-csi-plugin` DaemonSet.
- None of these are rendered by this chart's own templates —
  `longhorn-manager` creates them at runtime — so the only supported
  Helm-level knob is the `systemManagedCSIComponentsResourceLimits`
  Longhorn Setting (a JSON object keyed by component name).
- No KRR data exists yet, so each lightweight sidecar reuses the
  gateway chart's `shutdown-manager` sizing, with a small increase for
  `longhorn-csi-plugin` itself (does actual mount/format work).

Not resolved by this change — no `values.yaml` field or Longhorn
Setting exists for these in the vendored 1.12.0 chart, verified by
reading its templates directly:

- `longhorn-manager` DaemonSet's second container
  (`pre-pull-share-manager-image`)
- `longhorn-driver-deployer` and `longhorn-ui` Deployments
- `engine-image-ei-*` DaemonSet
- `backup`/`trim` CronJobs

## Test plan

- [x] `helm template` on `helm-charts/longhorn` renders the
  `longhorn-manager` ConfigMap with a valid JSON
  `system-managed-csi-components-resource-limits` setting (parsed and
  verified with `python3 -m json.tool`).
- [x] `make test` passes.
- [ ] After merge, confirm via `kubectl get deploy,daemonset -n
  longhorn-system ...` that the listed CSI workloads show requests/
  limits once `longhorn-manager` reconciles the new Setting, and that
  their `require-workload-resources` PolicyReport violations clear.