### PR TITLE
fix(blocky,httpbin): harden container securityContext

### DIFF
--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -43,6 +43,15 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 100
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # blocky's binary carries a cap_net_bind_service file capability so it
+              # can bind DNS port 53 as uid 100; verified locally that dropping this
+              # too makes `exec /app/blocky` fail with "operation not permitted".
+              add:
+                - NET_BIND_SERVICE
           image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
           ports:
             - name: dns-tcp

--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -33,6 +33,18 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # kong/httpbin's python3 binary carries a cap_net_bind_service file
+              # capability so its non-root "httpbin" user can bind port 80; verified
+              # locally that dropping this too breaks exec with "operation not
+              # permitted".
+              add:
+                - NET_BIND_SERVICE
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
## Summary

Part of the W3 container-hardening pass (kubescape C-0016/C-0017/C-0055
findings against ordinary app workloads). Adds `allowPrivilegeEscalation:
false` and `capabilities.drop: [ALL]` to blocky and httpbin, each with a
`NET_BIND_SERVICE` capability added back.

- **blocky**: already had `runAsNonRoot`/`runAsUser: 100` at container
  level. Verified locally that the blocky binary carries a
  `cap_net_bind_service` file capability required to bind DNS port 53 as
  a non-root uid; dropping ALL without adding it back breaks `exec` with
  "operation not permitted".
- **httpbin**: adds `runAsNonRoot` (the `kong/httpbin` image already
  defaults to a non-root `httpbin` user) plus the same capability
  handling. Verified locally that its `python3` binary carries the same
  file capability for binding port 80.

## Test plan

- [x] `helm template` on both charts shows `allowPrivilegeEscalation:
      false` and `capabilities.drop: [ALL]` (plus `add: [NET_BIND_SERVICE]`)
      on the container.
- [x] Verified locally with `docker run --user <non-root> --cap-drop ALL
      --cap-add NET_BIND_SERVICE` against the pinned image digests: both
      start and bind their ports; confirmed `--cap-drop ALL` alone (no
      add-back) breaks both.
- [x] `make test` passes.
- [ ] Live-cluster pod health after rollout not verified from this
      worktree (no automatic Argo CD sync triggered by this PR branch).