### PR TITLE
fix(home-assistant): drop capabilities, keep root for s6-overlay

### DIFF
--- a/helm-charts/home-assistant/templates/deployment.yaml
+++ b/helm-charts/home-assistant/templates/deployment.yaml
@@ -27,6 +27,16 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          # No runAsNonRoot here: the upstream image's s6-overlay init needs to run
+          # as root (verified locally, it fails with "unable to setgid to root" and
+          # "unable to mkdir /run/s6" as a non-root user). allowPrivilegeEscalation
+          # and dropping capabilities are still safe on top of root, confirmed the
+          # container still starts and serves HTTP.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             # https://www.home-assistant.io/installation/linux#optimizations
             - name: DISABLE_JEMALLOC


### PR DESCRIPTION
## Summary

Part of the W3 container-hardening pass. Adds `allowPrivilegeEscalation:
false` and `capabilities.drop: [ALL]` to the home-assistant container.

Deliberately does **not** add `runAsNonRoot`: verified locally
(`docker run` against the pinned image digest) that the upstream
image's s6-overlay init requires root — it fails with "unable to setgid
to root" and "unable to mkdir /run/s6" under a non-root uid. Confirmed
the container still starts and serves HTTP (302 on `/`) as root once
`allowPrivilegeEscalation` is false and all capabilities are dropped,
with only a non-fatal DHCP-watcher warning (needs `CAP_NET_RAW`, not
required for core functionality).

## Test plan

- [x] `helm template` shows `allowPrivilegeEscalation: false` and
      `capabilities.drop: [ALL]` on the container.
- [x] Verified locally with `docker run --cap-drop ALL
      --security-opt no-new-privileges` against the pinned image digest:
      s6-overlay starts, HTTP responds 302.
- [x] `make test` passes.
- [ ] Live-cluster pod health after rollout not verified from this
      worktree.