### PR TITLE
fix(jsoncrack,umami,changedetection): harden securityContext

### DIFF
--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -63,6 +63,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           securityContext:
+            # Image already defaults to the non-root "chrome" user (uid 1000, matches
+            # browser.profile.fsGroup); verified locally it still starts under
+            # cap-drop ALL with this enforced explicitly.
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/helm-charts/jsoncrack/templates/deployment.yaml
+++ b/helm-charts/jsoncrack/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 100
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
           ports:
             - name: http

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -25,6 +25,12 @@ spec:
         - name: {{ .Values.name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}


### PR DESCRIPTION
## Summary

Part of the W3 container-hardening pass. Small batch of low-risk,
verified-safe additions across three unrelated apps:

- **jsoncrack**: adds `allowPrivilegeEscalation: false` and
  `capabilities.drop: [ALL]`. `runAsNonRoot`/`runAsUser: 100` were
  already set.
- **umami**: adds `runAsNonRoot`, `allowPrivilegeEscalation: false`, and
  `capabilities.drop: [ALL]`. Image already defaults to a non-root
  `nextjs` user.
- **changedetection**: adds `runAsNonRoot` to the browser
  (sockpuppetbrowser) container only. `allowPrivilegeEscalation` and
  `capabilities.drop` were already set there, and the init/cleanup-loop
  sidecars were already fully hardened. The main changedetection.io
  container is left as-is (already has the two standard fields) — no
  `runAsNonRoot` yet, since that image runs as root by default and the
  existing datastore PVC is currently owned by root; that needs the
  same ownership-migration care as the deferred
  `readOnlyRootFilesystem` work, not a same-PR change.

## Test plan

- [x] `helm template` on all three charts shows the expected
      `securityContext` fields on each container.
- [x] Verified locally with `docker run` against the pinned image
      digests: jsoncrack (uid 100) and umami (`nextjs` user) both start
      cleanly under `--cap-drop ALL`; sockpuppetbrowser starts cleanly
      as its default non-root `chrome` user under `--cap-drop ALL`.
- [x] `make test` passes.
- [ ] Live-cluster pod health after rollout not verified from this
      worktree.