### PR TITLE
fix(teslamate): harden container securityContext

### DIFF
--- a/helm-charts/teslamate/templates/deployment.yaml
+++ b/helm-charts/teslamate/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       containers:
         - name: teslamate
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env: {{ toYaml .Values.deployment.env | nindent 12 }}
           envFrom: {{ toYaml .Values.deployment.envFrom | nindent 12 }}
           ports:


### PR DESCRIPTION
## Summary

Part of the W3 container-hardening pass. Adds `runAsNonRoot`,
`allowPrivilegeEscalation: false`, and `capabilities.drop: [ALL]` to the
main teslamate container. Verified locally the pinned image already
defaults to a `nonroot` user and starts cleanly under `--cap-drop ALL`
(only failed on missing test DB credentials, no capability/permission
errors).

The bundled `teslamate-grafana` subchart (upstream `grafana/grafana`
chart) already ships `runAsNonRoot`, `allowPrivilegeEscalation: false`,
and `capabilities.drop: [ALL]` by its own default values — confirmed via
`helm template` — so it needs no override in this repo.

## Test plan

- [x] `helm template helm-charts/teslamate` shows the new fields on the
      `teslamate` container, and confirms the `teslamate-grafana`
      subchart already has them by default.
- [x] Verified locally with `docker run --cap-drop ALL
      --security-opt no-new-privileges` against the pinned image digest:
      no capability-related failures.
- [x] `make test` passes.
- [ ] Live-cluster pod health after rollout not verified from this
      worktree.