### PR TITLE
fix(jung2bot): harden container securityContext

### DIFF
--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -15,6 +15,12 @@ spec:
           containers:
             - name: off-work
               image: {{ .Values.cron.image.repository }}:{{ .Values.cron.image.tag }}
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               env:
                 - name: CRON_INTERVAL
                   value: {{ .Values.cron.offWork.env.cronInterval | quote }}
@@ -57,6 +63,12 @@ spec:
           containers:
             - name: scale-up-database
               image: curlimages/curl:8.21.0
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               command: [ "curl" ]
               args:
                 - "-v"

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3000
           livenessProbe:


### PR DESCRIPTION
## Summary

Part of the W3 container-hardening pass. Adds `runAsNonRoot`,
`allowPrivilegeEscalation: false`, and `capabilities.drop: [ALL]` to the
bot deployment and both CronJob containers (`off-work`,
`scale-up-database`). Applies to both the `jung2bot` and `jung2bot-dev`
namespaces, which share this chart via a `value/dev.yaml` overlay.

Verified locally with `docker run --cap-drop ALL
--security-opt no-new-privileges` against the pinned image digests:
the bot/cron images (uid 65532) and `curlimages/curl` (non-root
`curl_user`) show no capability-related failures.

May overlap with the parallel W1 image-tag-pinning work
(`fix/pin-image-tags`, #2762) touching the same `cron-job.yaml` for the
`scale-up-database` image tag — expect a rebase conflict there, to be
resolved by keeping both changes, not by dropping either.

## Test plan

- [x] `helm template` (default values and the `value/dev.yaml` overlay)
      shows the new fields on all three containers.
- [x] Verified locally per image digest as above.
- [x] `make test` passes.
- [ ] Live-cluster pod health after rollout not verified from this
      worktree.