### PR TITLE
feat(kyverno-policy): add require-container-hardening policy

### DIFF
--- a/helm-charts/kyverno-policy/templates/require-container-hardening-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-container-hardening-policy.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.requireContainerHardeningPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-container-hardening
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-allow-privilege-escalation-false
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+{{- with .Values.requireContainerHardeningPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+          - resources:
+              namespaces:
+                - monitoring
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: prometheus-node-exporter
+{{- end }}
+      validate:
+        allowExistingViolations: true
+        failureAction: Audit
+        message: Containers must set allowPrivilegeEscalation to false.
+        pattern:
+          spec:
+            =(initContainers):
+              - securityContext:
+                  allowPrivilegeEscalation: "false"
+            containers:
+              - securityContext:
+                  allowPrivilegeEscalation: "false"
+    - name: require-drop-all-capabilities
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+{{- with .Values.requireContainerHardeningPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+          - resources:
+              namespaces:
+                - monitoring
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: prometheus-node-exporter
+{{- end }}
+      validate:
+        allowExistingViolations: true
+        failureAction: Audit
+        message: Containers must drop the ALL capability.
+        foreach:
+          - list: request.object.spec.[initContainers, containers][]
+            deny:
+              conditions:
+                all:
+                  - key: ALL
+                    operator: AnyNotIn
+                    value: "{{ "{{" }} element.securityContext.capabilities.drop[] || `[]` {{ "}}" }}"
+  validationFailureAction: Audit
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -80,3 +80,11 @@ requireImageTagPolicy:
     - kube-public
     - kube-system
     - kyverno
+
+requireContainerHardeningPolicy:
+  enabled: true
+  excludedNamespaces:
+    - longhorn-system
+    - istio-system
+    - metallb-system
+    - kube-system


### PR DESCRIPTION
## Summary

Shared-hotspot piece of the W3 container-hardening pass. Adds a new
Audit-mode `ClusterPolicy`
(`helm-charts/kyverno-policy/templates/require-container-hardening-policy.yaml`)
checking that every Pod's containers set `allowPrivilegeEscalation:
false` and `capabilities.drop` including `ALL`, mirroring this chart's
existing `require-workload-resources` style plus the shape of the
upstream Kyverno pod-security-standards policies
(`disallow-privilege-escalation`, `disallow-capabilities-strict`).

Excludes the privileged system namespaces (`longhorn-system`,
`istio-system`, `metallb-system`, `kube-system`) plus
`monitoring-prometheus-node-exporter` specifically by label (not the
whole `monitoring` namespace), so other monitoring workloads stay
covered. `readOnlyRootFilesystem` is intentionally left out of this
policy pending per-app verification (open question in the hardening
tracker).

Gated by a new top-level `requireContainerHardeningPolicy` key in
`helm-charts/kyverno-policy/values.yaml`, appended after the existing
`barmanObjectStorePolicy` block to keep the diff additive. May conflict
on rebase with the parallel W1 `requireImageTagPolicy` key
(`feat/require-image-tag-policy`, #2764), which appends at the same
spot — resolve by keeping both blocks.

## Test plan

- [x] `helm template helm-charts/kyverno-policy` renders the policy with
      the expected excludes and rules.
- [x] Verified with the `kyverno` CLI (`kyverno apply policy.yaml
      --resource pods.yaml`) against fixture Pods: compliant Pods pass,
      Pods missing either field fail with the right rule, Pods with
      `capabilities.add: [NET_BIND_SERVICE]` still pass, Pods in excluded
      namespaces are skipped, and a `monitoring` Pod with a different
      label is correctly still caught (not masked by the node-exporter
      exclude).
- [x] `make test` passes.