### PR TITLE
fix(httpbin): add explicit runAsUser to fix broken rollout

### DIFF
--- a/helm-charts/httpbin/templates/deployment.yaml
+++ b/helm-charts/httpbin/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
           image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
           securityContext:
             runAsNonRoot: true
+            # kong/httpbin's "httpbin" user is named, not numeric, in the image
+            # metadata, so kubelet cannot verify runAsNonRoot without an explicit
+            # numeric UID (CreateContainerConfigError otherwise). Confirmed via
+            # `kubectl exec ... -- id`: uid=10001(httpbin) gid=10001(httpbin).
+            runAsUser: 10001
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
## Summary

- PR #2767 added `runAsNonRoot: true` to the httpbin container without
  a numeric `runAsUser`.
- kong/httpbin's non-root user is named ("httpbin"), not numeric, in
  the image metadata -- kubelet cannot verify `runAsNonRoot` from a
  named user alone, so the new ReplicaSet is stuck in
  `CreateContainerConfigError` (old pods still running fine, so no
  outage, but the rollout can't complete).
- Adds `runAsUser: 10001`, confirmed via `kubectl exec` on a
  still-running pre-hardening pod (`id` -> `uid=10001(httpbin)`).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `runAsUser: 10001` renders alongside
      the existing `runAsNonRoot: true`
- [ ] Argo CD syncs, new httpbin ReplicaSet reaches Ready