### PR TITLE
docs(self-healing): fold in tonight's lessons

### DIFF
--- a/.claude/skills/self-healing/runbooks/data-plane.md
+++ b/.claude/skills/self-healing/runbooks/data-plane.md
@@ -19,7 +19,20 @@ mutations (see `references/escalation.md`).
 
 - CNPG healthy → continue.
 - Backup failing, replica lag, or instance down → journal and
-  **escalate** (no CNPG mutations).
+  **escalate** (no CNPG mutations) — unless the user explicitly approves
+  a live fix (see `references/escalation.md`'s interim-fix exception).
+- **Instance `CrashLoopBackOff` on a faulted/unrecoverable PVC:** first
+  check `kubectl get cluster.postgresql.cnpg.io <name> -n <ns> -o
+  jsonpath='{.status.currentPrimary} {.status.instancesStatus}'` — if the
+  cluster already failed over to a healthy primary and
+  `ContinuousArchiving`/`LastBackupSucceeded` conditions are `True`, the
+  database service itself is not down, only that one instance. With user
+  approval, `kubectl cnpg destroy <cluster> <instance-number> -n <ns>`
+  removes the broken instance's pod and PVC together and lets the
+  operator recreate it fresh, streaming from the healthy primary — this
+  is the CNPG-native recovery path, not a manual PVC/pod delete. The
+  operator may recreate it under a new, higher instance number rather
+  than reusing the destroyed one.
 - **Barman / WAL archiving `exit status 4`:** often disk full on the
   instance PVC. Recovery paths that delete DB PVCs or pods are
   **escalate** only — never unattended. See `documentation/gotcha.md`.

--- a/.claude/skills/self-healing/runbooks/storage.md
+++ b/.claude/skills/self-healing/runbooks/storage.md
@@ -9,6 +9,15 @@
   and webhook errors mentioning `mutator.longhorn.io` /
   `validator.longhorn.io` — often ambient mesh on `longhorn-system` (see
   gotchas).
+- **Node disk over-provisioning:** `kubectl get nodes.longhorn.io <node> -n
+  longhorn-system -o json` → `.status.diskStatus.<disk>.scheduledReplica`
+  (sum the values) vs `.storageMaximum` minus the disk's
+  `storageReserved`. A new replica failing to schedule
+  (`longhorn.io/volume-scheduling-error` on the PV, or a
+  `FailedScheduling`/"Scheduling space condition failed" event) with real
+  free bytes still available (`storageAvailable`) means the *declared*
+  sizes already scheduled there exceed the allowed limit — not an actually
+  full disk.
 
 ## Triage
 
@@ -29,3 +38,27 @@
   dm-crypt `allow-discards`; recovery is `make trim` / `make maintenance`,
   not a privileged always-on DaemonSet. Escalate; do not reintroduce
   `cypto-volume-allow-discards`. See `documentation/gotcha.md`.
+- **Moving a single-replica volume off an over-provisioned node** (only
+  with user approval — this is a live storage mutation): patch
+  `spec.evictionRequested: true` on the Replica CR on the node to vacate
+  (`kubectl patch replicas.longhorn.io <replica> -n longhorn-system --type
+  merge -p '{"spec":{"evictionRequested":true}}'`). Longhorn schedules a
+  new replica elsewhere and rebuilds; confirm via the volume's Engine
+  `status.replicaModeMap` that the new replica reached `RW` before
+  treating the source as replaceable — `evictionRequested` can reset to
+  `false` on its own once the rebuild completes without Longhorn actually
+  deleting the source replica object, so a manual `kubectl delete
+  replicas.longhorn.io <old-replica>` may still be needed to finish
+  vacating it. The consuming pod does not need to restart.
+- **Faulted single-replica volume with zero live replicas:** eviction
+  needs a live source and does not apply. Check
+  `auto-salvage` (`kubectl get settings.longhorn.io auto-salvage -n
+  longhorn-system`) and the longhorn-manager logs for that volume name —
+  `"Bringing up 0 replicas for auto-salvage"` means Longhorn itself
+  found nothing recoverable at that attempt. Re-check current
+  `status.robustness` before concluding data loss: a replica that failed
+  from node disk pressure (not corruption) can self-recover on a later
+  attempt with `salvageExecuted: false` — a stale single reading is not
+  proof of permanent loss. If it stays faulted, a completed backup
+  (`kubectl get backups.longhorn.io -n longhorn-system`) is the escalation
+  path, not a forced restart of the dead replica.

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -10,6 +10,11 @@
 - `kubectl get deploy,sts,ds -A` — not fully available?
 - **Jobs:** `kubectl get jobs -A` — any `Failed` or `Running` beyond
   expected duration?
+- **Alerts:** `curl -s <prometheus-url-via-ingress>/api/v1/alerts` (same
+  URL resolution as `right-sizing`'s KRR step) — any `firing` alerts. A
+  pod stuck `CrashLoopBackOff` still reports phase `Running` and can look
+  fine at a glance if this step is skipped, especially on an abbreviated
+  hourly check; run it every pass, not just on a full sweep.
 
 ## Triage
 


### PR DESCRIPTION
## Summary

Skill/runbook updates from tonight's investigation session, per the
self-healing skill's own maintenance guidance (fold in techniques that
saved real time or gaps that caused a miss).

- `workloads.md`: check Prometheus alerts every pass. A `CrashLoopBackOff`
  pod reports phase `Running`, so an abbreviated hourly check that only
  looked at pod phase missed a real umami CNPG failure until the user
  pointed at firing alerts directly.
- `storage.md`: document the Longhorn disk over-provisioning diagnosis
  (declared/scheduled replica size vs real disk capacity) and the
  single-replica eviction-based migration technique used tonight to move
  volumes off an over-provisioned node, including the "eviction flag can
  reset without deleting the source replica" gotcha.
- `data-plane.md`: document `kubectl cnpg destroy` as the CNPG-native
  recovery path for a CrashLoopBackOff instance sitting on a faulted PVC,
  gated on confirming the cluster already failed over safely and on user
  approval.

No cluster/chart changes -- skill instructions only, zero deployment
risk.

## Test plan

- [x] `make test` passes (markdown lint included)