### PR TITLE
fix(teslamate): add explicit runAsUser to fix broken rollout

### DIFF
--- a/helm-charts/teslamate/templates/deployment.yaml
+++ b/helm-charts/teslamate/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
           image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
           securityContext:
             runAsNonRoot: true
+            # ghcr.io/teslamate-org/teslamate's non-root user ("nonroot") is
+            # named, not numeric, in the image metadata. Kubelet cannot verify
+            # runAsNonRoot from a named user alone, so without an explicit
+            # numeric runAsUser the rollout got stuck in
+            # CreateContainerConfigError. UID confirmed via `kubectl exec ...
+            # -- id` on a still-running pre-hardening pod.
+            runAsUser: 10000
+            runAsGroup: 10001
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
## Summary

- PR #2770 added `runAsNonRoot: true` to the teslamate container without
  a numeric `runAsUser`.
- `ghcr.io/teslamate-org/teslamate`'s non-root user ("nonroot") is
  named, not numeric, in the image metadata -- kubelet cannot verify
  `runAsNonRoot` from a named user alone, so the new ReplicaSet is stuck
  in `CreateContainerConfigError` (old pod still running fine, so no
  outage, but the rollout can't complete).
- Adds `runAsUser: 10000` / `runAsGroup: 10001`, confirmed via
  `kubectl exec` on a still-running pre-hardening pod
  (`id` -> `uid=10000(nonroot) gid=10001(nonroot)`).
- Same root cause as #2774 (httpbin). Documented as a general gotcha in
  `documentation/gotcha.md`.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `runAsUser: 10000` / `runAsGroup: 10001`
      render alongside the existing `runAsNonRoot: true`
- [ ] Argo CD syncs, new teslamate ReplicaSet reaches Ready