### PR TITLE
fix(longhorn): raise longhorn-csi-plugin memory limit to stop OOMKill

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -40,12 +40,16 @@ longhorn:
     # lightweight sidecar reuses the same size as the gateway chart's
     # shutdown-manager sidecar; longhorn-csi-plugin itself (does actual
     # mount/format work) gets a slightly larger allowance.
+    # 2026-07-11: longhorn-csi-plugin OOMKilled (exit 137) on nuc-00, the node
+    # with by far the most attached volumes (jellyfin + sftpgo). The 64Mi
+    # limit only covered steady-state (~11-15Mi observed on other nodes) with
+    # no headroom for mount/format-time spikes. Doubled to 128Mi.
     systemManagedCSIComponentsResourceLimits: >-
       {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"64Mi","ephemeral-storage":"32Mi"}},
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"128Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"128Mi","ephemeral-storage":"32Mi"}},
       "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
   defaultBackupStore:


### PR DESCRIPTION
## Summary

- PR #2766 set memory requests/limits on Longhorn's system-managed CSI
  components via the `systemManagedCSIComponentsResourceLimits`
  Setting, sizing `longhorn-csi-plugin` at 64Mi with no KRR data
  available yet.
- `kubectl top` shows idle usage of ~11-15Mi on Raspberry Pi nodes, but
  `nuc-00` -- which has by far the most attached volumes (jellyfin +
  sftpgo PVCs) -- OOMKilled the container repeatedly (exit 137,
  `CrashLoopBackOff`) since 64Mi had no headroom for mount/format-time
  memory spikes.
- Doubles the request+limit to 128Mi.

## Test plan

- [x] `make test` passes
- [x] `helm template helm-charts/longhorn` renders the updated Setting
      cleanly
- [ ] Argo CD syncs, `longhorn-csi-plugin` pod on nuc-00 stops
      restarting