### PR TITLE
fix(umami): add explicit runAsUser to fix broken rollout

### DIFF
--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsNonRoot: true
+            # ghcr.io/umami-software/umami's non-root user ("nextjs") is
+            # named, not numeric, in the image metadata. Kubelet cannot
+            # verify runAsNonRoot from a named user alone, so without an
+            # explicit numeric runAsUser the rollout got stuck in
+            # CreateContainerConfigError. UID confirmed via `kubectl exec ...
+            # -- id` on a still-running pre-hardening pod.
+            runAsUser: 1001
+            runAsGroup: 65533
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
## Summary

- PR #2769 added `runAsNonRoot: true` to the umami container without a
  numeric `runAsUser`.
- `ghcr.io/umami-software/umami`'s non-root user ("nextjs") is named,
  not numeric, in the image metadata -- kubelet cannot verify
  `runAsNonRoot` from a named user alone, so the new ReplicaSet is
  stuck in `CreateContainerConfigError` (old pod still running fine,
  so no outage, but the rollout can't complete).
- Adds `runAsUser: 1001` / `runAsGroup: 65533`, confirmed via
  `kubectl exec` on a still-running pre-hardening pod
  (`id` -> `uid=1001(nextjs) gid=65533(nogroup)`).
- Same root cause as #2774 (httpbin) and #2776 (teslamate).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `runAsUser: 1001` / `runAsGroup: 65533`
      render alongside the existing `runAsNonRoot: true`
- [ ] Argo CD syncs, new umami ReplicaSet reaches Ready