### PR TITLE
fix(changedetection): add explicit runAsUser for browser sidecar

### DIFF
--- a/helm-charts/changedetection/templates/browser-deployment.yaml
+++ b/helm-charts/changedetection/templates/browser-deployment.yaml
@@ -63,10 +63,14 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           securityContext:
-            # Image already defaults to the non-root "chrome" user (uid 1000, matches
-            # browser.profile.fsGroup); verified locally it still starts under
-            # cap-drop ALL with this enforced explicitly.
+            # The image's config User field is the name "chrome", not a
+            # numeric UID, so kubelet cannot verify runAsNonRoot without an
+            # explicit runAsUser -- without it the container gets stuck in
+            # CreateContainerConfigError. uid 1000 confirmed via
+            # `docker image inspect` and `docker run --entrypoint id`;
+            # matches browser.profile.fsGroup.
             runAsNonRoot: true
+            runAsUser: {{ .Values.browser.profile.fsGroup }}
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/helm-charts/umami/templates/deployment.yaml
+++ b/helm-charts/umami/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsNonRoot: true
+            # ghcr.io/umami-software/umami's non-root user ("nextjs") is
+            # named, not numeric, in the image metadata. Kubelet cannot
+            # verify runAsNonRoot from a named user alone, so without an
+            # explicit numeric runAsUser the rollout got stuck in
+            # CreateContainerConfigError. UID confirmed via `kubectl exec ...
+            # -- id` on a still-running pre-hardening pod.
+            runAsUser: 1001
+            runAsGroup: 65533
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
## Summary

- PR #2769 added `runAsNonRoot: true` to the `changedetection-browser`
  container. The existing comment assumed the image's default
  non-root user was enough, but `dgtlmoon/sockpuppetbrowser`'s image
  config `User` field is the name "chrome", not a numeric UID -- the
  same class of bug as `#2774` (httpbin), `#2776` (teslamate), and
  `#2778` (umami).
- This has been masked so far by an unrelated `longhorn-csi-plugin`
  CSI mount failure (`connection refused` to the CSI socket -- see
  `#2777`), which stuck the pod in `Init:0/1` before it ever reached
  this container. Once that CSI fix lands and volumes mount again,
  this container would hit `CreateContainerConfigError` next.
- Adds `runAsUser: 1000` (via the existing `browser.profile.fsGroup`
  value, matching the pattern already used by this chart's init/sidecar
  containers), confirmed via `docker image inspect --format
  '{{.Config.User}}'` (`chrome`) and `docker run --entrypoint id`
  (`uid=1000(chrome)`).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `runAsUser: 1000` renders alongside the
      existing `runAsNonRoot: true`
- [ ] Argo CD syncs (after `#2777` lands), `changedetection-browser`
      pod reaches Ready