### PR TITLE
fix(longhorn): raise longhorn-csi-plugin memory limit again to 256Mi

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -44,12 +44,18 @@ longhorn:
     # with by far the most attached volumes (jellyfin + sftpgo). The 64Mi
     # limit only covered steady-state (~11-15Mi observed on other nodes) with
     # no headroom for mount/format-time spikes. Doubled to 128Mi.
+    # 2026-07-11 (second bump): 128Mi still OOMKilled on nuc-00 and, after
+    # raspberrypi-03 rejoined post-outage, on raspberrypi-03 too, both while a
+    # mass volume-reattach/resync was in progress cluster-wide -- steady-state
+    # stayed ~11-22Mi throughout, confirming this is a startup/reattach memory
+    # spike, not a steady leak. Raised to 256Mi for real headroom under
+    # concurrent reattach load rather than guessing again incrementally.
     systemManagedCSIComponentsResourceLimits: >-
       {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"128Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"128Mi","ephemeral-storage":"32Mi"}},
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"256Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"256Mi","ephemeral-storage":"32Mi"}},
       "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
   defaultBackupStore:


### PR DESCRIPTION
## Summary

- PR #2777 doubled the `longhorn-csi-plugin` memory limit from 64Mi to
  128Mi after an OOMKill on `nuc-00`.
- Live cluster check found it OOMKilling again at 128Mi -- on `nuc-00`
  again, and on `raspberrypi-03` too, which had just rejoined after an
  unrelated node outage and was mid mass-volume-reattach.
  `kubectl top` showed steady-state memory at ~11-22Mi throughout on
  the healthy replicas, confirming this is a startup/reattach memory
  spike under concurrent load, not a steady leak.
- Raised the limit to 256Mi for real headroom rather than doubling
  again incrementally.

## Test plan

- [x] `make test` passes
- [x] `helm template helm-charts/longhorn` renders the updated Setting
      cleanly
- [ ] `longhorn-csi-plugin` pods on `nuc-00`/`raspberrypi-03` stop
      restarting, volumes waiting on them (`home-assistant`,
      `changedetection-browser`, a teslamate CNPG replica) mount