### PR TITLE
fix(longhorn): raise longhorn-csi-plugin memory limit to 1Gi

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -69,12 +69,19 @@ longhorn:
     # requests-equal-limits convention deliberately for this one spiky
     # sidecar, confirmed with the user, to stop wasting ~2.2Gi of falsely
     # reserved cluster memory.
+    # 2026-07-11 (fifth bump, limit only): still OOMKilled at 512Mi on
+    # nuc-00 while jellyfin (13 PVCs -- by far the most of any workload in
+    # this cluster) mounted all of them at once. Since the request/limit
+    # split above means a bigger limit costs nothing in steady-state
+    # reservation, raised the ceiling generously to 1Gi to cover this
+    # cluster's worst-case concurrent-mount workload rather than
+    # incrementally re-testing smaller numbers again.
     systemManagedCSIComponentsResourceLimits: >-
       {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"512Mi","ephemeral-storage":"32Mi"}},
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"1Gi","ephemeral-storage":"32Mi"}},
       "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
   defaultBackupStore:


### PR DESCRIPTION
## Summary

- PR #2782 decoupled the request (64Mi) from the limit (512Mi), fixing
  the cluster-wide scheduling failure caused by over-reserving memory.
- The 512Mi limit itself is still not enough: `longhorn-csi-plugin`
  OOMKilled repeatedly on `nuc-00` while `jellyfin` (13 PVCs, by far
  the most of any workload in this cluster) mounted all of them
  concurrently.
- Since the request/limit split means a bigger limit costs nothing in
  steady-state memory reservation, raises the ceiling to 1Gi to cover
  this cluster's worst-case concurrent-mount workload.

## Test plan

- [x] `make test` passes
- [x] `helm template helm-charts/longhorn` renders the updated Setting
      cleanly
- [ ] `jellyfin` pod on `nuc-00` finishes mounting all 13 volumes and
      reaches Ready without further `longhorn-csi-plugin` OOMKills