### PR TITLE
fix(longhorn): raise longhorn-csi-plugin memory limit to 2Gi

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -76,12 +76,26 @@ longhorn:
     # reservation, raised the ceiling generously to 1Gi to cover this
     # cluster's worst-case concurrent-mount workload rather than
     # incrementally re-testing smaller numbers again.
+    # 2026-07-11 (sixth bump): still OOMKilled at 1Gi. Investigated upstream
+    # before bumping again: Longhorn has no setting to throttle concurrent
+    # mount/attach operations (checked the full values.yaml schema -- the
+    # only concurrency limits are for replica rebuilds, backups, and engine
+    # upgrades), and there is no official per-volume memory sizing formula
+    # for this container (Longhorn's docs cite ~256Mi/TB for a different
+    # component's in-memory read index; two related upstream issues,
+    # longhorn/longhorn#12225 and #6645, confirm CSI/manager memory scaling
+    # is a known, unresolved, undocumented area). jellyfin's combined PVC
+    # size is ~1.4TB (13 volumes, one at 320Gi, six at 120Gi) -- by far the
+    # largest single-node volume footprint in this cluster (everything else
+    # is single-digit-Gi). With no smarter lever available, raised to 2Gi,
+    # sized for this cluster's actual heaviest workload rather than another
+    # blind doubling.
     systemManagedCSIComponentsResourceLimits: >-
       {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"1Gi","ephemeral-storage":"32Mi"}},
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"2Gi","ephemeral-storage":"32Mi"}},
       "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
   defaultBackupStore:


### PR DESCRIPTION
## Summary

- PR #2783 raised the limit to 1Gi, but it still OOMKilled on `nuc-00`
  while `jellyfin` (13 PVCs, ~1.4TB combined, up to 320Gi per volume)
  mounted all of them concurrently.
- Investigated upstream before bumping again rather than guessing:
  Longhorn has no setting to throttle concurrent mount/attach
  operations (checked the full `values.yaml` schema -- the only
  concurrency limits are for replica rebuilds, backups, and engine
  upgrades), and there is no official per-volume memory sizing formula
  for this container. `longhorn/longhorn#12225` and `#6645` confirm
  CSI/manager memory scaling is a known, unresolved, undocumented area
  upstream.
- `jellyfin`'s combined PVC size (~1.4TB) is by far the largest
  single-node volume footprint in this cluster (everything else is
  single-digit-Gi). With no smarter lever available, raises the limit
  to 2Gi, sized for this cluster's actual heaviest workload.

## Test plan

- [x] `make test` passes
- [x] `helm template helm-charts/longhorn` renders the updated Setting
      cleanly
- [ ] `jellyfin` pod on `nuc-00` finishes mounting all 13 volumes and
      reaches Ready without further `longhorn-csi-plugin` OOMKills