### PR TITLE
feat(external-secrets): let ESO manage the Connect token after bootstrap

### DIFF
--- a/documentation/secrets.md
+++ b/documentation/secrets.md
@@ -96,6 +96,15 @@ replace-with-connect-token
 
 Keep this as a single token value.
 
+Only needed once for the very first bootstrap of a cluster. After that,
+`onepassword-connect-token` (namespace `external-secrets`) is managed by an
+`ExternalSecret` that reads `op://github-otaru/1Password Token/credential`
+via the same `ClusterSecretStore` it authenticates — rotate by updating that
+1Password item, not by re-running the bootstrap `kubectl create secret`
+step. If the live token is ever invalidated before the new value is synced
+(revoked, expired, leaked), this self-referential sync breaks and the
+Secret needs the manual bootstrap step again to re-seed it.
+
 ## `etcd/ca.pem`
 
 Example:

--- a/helm-charts/external-secrets/templates/connect-token-external-secret.yaml
+++ b/helm-charts/external-secrets/templates/connect-token-external-secret.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.integrations.clusterSecretStore }}
+# Keeps the 1Password Connect token itself in sync via ESO once the initial
+# value has been manually seeded (see documentation/secrets.md and
+# ansible/playbooks/k3s/004-bootstrap.yaml). This is self-referential: ESO
+# uses the current token in this Secret to authenticate to Connect, then
+# overwrites the same Secret with whatever value is now in 1Password. If the
+# current token is ever invalidated externally (revoked, expired, leaked)
+# before a working replacement is in place, this loop breaks and the Secret
+# needs a manual re-seed, same as the very first bootstrap.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  target:
+    creationPolicy: Owner
+  data:
+    - remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: "1Password Token"
+        metadataPolicy: None
+        property: credential
+      secretKey: token
+{{- end }}


### PR DESCRIPTION
## Summary

- `onepassword-connect-token` (namespace `external-secrets`) has been a
  manually-bootstrapped Secret with no ongoing management -- rotating it
  meant a manual `kubectl create secret ... | kubectl apply -f -`.
- Adds an `ExternalSecret` that reads the Connect token from its
  1Password item via the existing `ClusterSecretStore` and writes it back
  into the same Secret name/key the `ClusterSecretStore` itself
  authenticates with.
- After this merges, rotating the token going forward is a 1Password edit,
  not a `kubectl` command.

## Self-referential bootstrap, on purpose

This is deliberately self-referential: ESO authenticates to Connect using
whatever token is *currently* in the Secret, then overwrites that same
Secret with the current value from 1Password. That only works while the
live token stays valid -- if it's ever invalidated externally (revoked,
expired, or leaked) before a working replacement has synced, this loop
breaks and the Secret needs the manual bootstrap step again to re-seed it.
Documented this trade-off in `documentation/secrets.md`. The manual
bootstrap step in `ansible/playbooks/k3s/004-bootstrap.yaml` still stays
as-is -- it remains the correct path for a from-scratch cluster bootstrap,
where no ExternalSecret can function yet.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the `ExternalSecret` renders with the
      correct `remoteRef`/`secretKey` wiring
- [ ] After merge: confirm `kubectl get externalsecrets -n
      external-secrets onepassword-connect-token` reaches `SecretSynced`
      and `kubectl get clustersecretstore onepassword-secret-store`
      stays `Valid`