### PR TITLE
perf(argocd): right-size repo-server memory to KRR peak

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -156,13 +156,22 @@ argo-cd:
       behavior:
         scaleDown:
           stabilizationWindowSeconds: 60
+    # KRR 2026-07-12: 14d peak 380Mi against a 768Mi request/limit (WARNING,
+    # ~2x headroom). Downsized to 512Mi, keeping ~35% margin over peak given
+    # the cold-cache render spikes noted on reposerver.parallelism.limit
+    # above. CPU is a separate, deferred item: KRR wants ~1.7 cores against
+    # the current 250m (CRITICAL), but all 4 arm64 nodes this pod can land
+    # on are already at 63-69% CPU requests, and a jump this size risks
+    # near-saturating whichever one it schedules on. CPU throttling
+    # degrades gracefully (unlike an OOM), so leaving this deferred is a
+    # smaller risk than following KRR blindly on a memory-tight cluster.
     resources:
       requests:
         cpu: 250m
-        memory: 768Mi
+        memory: 512Mi
         ephemeral-storage: 512Mi
       limits:
-        memory: 768Mi
+        memory: 512Mi
         ephemeral-storage: 512Mi
     readinessProbe:
       initialDelaySeconds: 10


### PR DESCRIPTION
## Summary
- Downsizes `argocd-repo-server` memory request/limit from 768Mi to 512Mi based on a 14-day KRR peak of 380Mi (WARNING severity).
- CPU stays deferred: KRR wants ~1.7 cores against the current 250m, but all 4 arm64 nodes this pod can land on are already at 63-69% CPU requests, so following that recommendation risks near-saturating whichever node it schedules on. Documented inline.

## Test plan
- [x] `make test` passes