### PR TITLE
fix(external-secrets): run webhook with 2 replicas and a PDB

### DIFF
--- a/helm-charts/external-secrets/values.yaml
+++ b/helm-charts/external-secrets/values.yaml
@@ -22,6 +22,17 @@ external-secrets:
     <<: *preferredPodAntiAffinity
   resources: *resources
   webhook:
+    # 2026-07-12: ArgoCD ExternalSecret syncs failed with "no endpoints
+    # available for service external-secrets-webhook" during a night of
+    # cluster-wide pod restarts -- a single replica has zero redundancy for
+    # a validating webhook that gates every ExternalSecret apply. The
+    # anti-affinity above already spreads replicas across nodes, so a
+    # second replica gives real resilience against a single pod/node
+    # disruption.
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
     affinity:
       <<: *preferredPodAntiAffinity
     resources: *resources


### PR DESCRIPTION
## Summary
- `external-secrets-webhook` ran as a single replica with no PodDisruptionBudget. Any restart left a brief window with zero endpoints for the validating webhook, failing every ExternalSecret apply during that window.
- This is what caused the ArgoCD sync failures on `home-assistant`, `jung2bot`, and `jung2bot-dev` during last night's cluster-wide pod-restart churn (`no endpoints available for service "external-secrets-webhook"`).
- Bumps `webhook.replicaCount` to 2 and enables `webhook.podDisruptionBudget` (minAvailable: 1). Existing anti-affinity already spreads replicas across nodes.

## Test plan
- [x] `make test` passes