### PR TITLE
fix(kyverno-policy): allow external-secrets namespace to read its own Connect token

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -17,6 +17,8 @@ clusterSecretStorePolicy:
       - changedetection
     cloudflare-tunnel:
       - cloudflare-tunnel-credentials
+    external-secrets:
+      - 1Password Token
     gateway:
       - cloudflare-acme-verification-secret
       - heartbeats


### PR DESCRIPTION
## Summary

- PR #2791 added an `ExternalSecret` in the `external-secrets` namespace
  that reads the Connect token via the shared `ClusterSecretStore`.
- `restrict-onepassword-cluster-secret-store` blocks any namespace not
  on `clusterSecretStorePolicy.allowedNamespaces` -- `external-secrets`
  was never on it, so admission has been rejecting that `ExternalSecret`
  since the PR #2791 merge (`Application` stuck `OutOfSync`, sync
  operation retrying and failing on the Kyverno webhook).
- Adds `external-secrets: [1Password Token]`, matching the exact item
  name the `ExternalSecret` reads (`remoteRef.key`).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms `external-secrets` now appears in the
      generated policy's allowlist and gets its own
      `restrict-onepassword-keys-external-secrets` per-key policy
- [ ] After merge: `kubectl get externalsecret onepassword-connect-token
      -n external-secrets` reaches `SecretSynced`