### PR TITLE
fix(jung2bot): add explicit runAsUser to fix scale-up-database CronJob

### DIFF
--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -65,6 +65,13 @@ spec:
               image: curlimages/curl:8.21.0
               securityContext:
                 runAsNonRoot: true
+                # curlimages/curl's non-root user ("curl_user") is named, not
+                # numeric, in the image metadata. Kubelet cannot verify
+                # runAsNonRoot from a named user alone, so without an
+                # explicit numeric runAsUser the Job got stuck in
+                # CreateContainerConfigError. UID 100 is curlimages/curl's
+                # documented curl_user.
+                runAsUser: 100
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:


### PR DESCRIPTION
## Summary

Both `jung2bot` and `jung2bot-dev`'s `scale-up-database` CronJob pods
have been stuck in `CreateContainerConfigError` since this morning's
scheduled run:

```
Error: container has runAsNonRoot and image has non-numeric user
(curl_user), cannot verify user is non-root
```

`curlimages/curl:8.21.0`'s non-root user (`curl_user`) is named, not
numeric, in the image metadata, so kubelet cannot verify
`runAsNonRoot` from it alone. Adds an explicit `runAsUser: 100`
(curl_user's documented UID) -- same fix shape already applied to
`umami` and `teslamate` for the same class of gotcha.

## Test plan

- [x] `make test`
- [ ] Confirm the next scheduled `scale-up-database` run (or a manual
  trigger) starts cleanly post-merge