### PR TITLE
feat(descheduler): add HighNodeUtilization to consolidate free memory

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -39,6 +39,37 @@ descheduler:
           deschedule:
             enabled:
               - RemovePodsHavingTooManyRestarts
+      # Added 2026-07-13: LowNodeUtilization is a no-op when every node sits
+      # above its 50% targetThreshold at once (our steady state -- all 5
+      # nodes run 83-97% memory requests), since it needs an already-
+      # underutilized node to land evicted pods on. HighNodeUtilization
+      # solves the actual problem this cluster hits: combined free memory
+      # exists (~2-3GiB) but is spread too thin across all 5 nodes for a
+      # single multi-container pod's request to fit anywhere (confirmed
+      # live: teslamate-verify-pitr's 2Gi combined request failed to
+      # schedule despite nuc-00 alone showing ~1GiB free). This
+      # consolidates lightly-loaded nodes' pods onto busier ones, growing
+      # contiguous free space on whichever node is currently least
+      # utilized (usually nuc-00) instead of leaving slack scattered.
+      # HighNodeUtilization and LowNodeUtilization cannot share one
+      # profile (opposite goals), hence the separate profile here.
+      - name: consolidate
+        pluginConfig:
+          - name: DefaultEvictor
+            args:
+              podProtections:
+                defaultDisabled:
+                  - PodsWithLocalStorage
+          - name: HighNodeUtilization
+            args:
+              thresholds:
+                cpu: 100
+                memory: 90
+                pods: 100
+        plugins:
+          balance:
+            enabled:
+              - HighNodeUtilization
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

- `LowNodeUtilization` alone can't help our steady-state memory
  pressure: it requires an already-underutilized node (below its
  20% threshold) to land evicted pods on, and every node in this
  cluster sits at 83-97% memory requests simultaneously -- so it's
  a no-op today.
- Confirmed live that `teslamate-verify-pitr`'s recovery Job (3
  containers, 2Gi combined memory request) fails to schedule even
  though the cluster has roughly 2-3GiB of memory free in aggregate,
  because that slack is spread too thin across all 5 nodes for any
  single one to fit the pod.
- Adds a second descheduler profile with `HighNodeUtilization`,
  which consolidates lightly-loaded nodes' pods onto busier ones --
  growing contiguous free space on whichever node is least utilized
  (currently `nuc-00`) instead of leaving slack scattered.
- `HighNodeUtilization` and `LowNodeUtilization` cannot share one
  profile (opposite goals), hence the separate `consolidate` profile.

## Test plan

- [x] `make test`
- [x] `helm template` confirms both profiles render correctly
- [ ] Watch descheduler logs post-merge for eviction activity and
  confirm memory headroom actually concentrates onto one node
- [ ] Re-test `teslamate-verify-pitr` scheduling once headroom
  improves