### PR TITLE
feat(k3s): configure kube-scheduler to bin-pack via MostAllocated

### DIFF
--- a/ansible/playbooks/k3s/000-init-cluster.yaml
+++ b/ansible/playbooks/k3s/000-init-cluster.yaml
@@ -11,6 +11,38 @@
     - include_tasks: ../rpi/pre_tasks/wait-for-ssh.yaml
 
   tasks:
+    - name: Configure kube-scheduler to bin-pack via MostAllocated
+      # Default LeastAllocated scoring keeps refilling whatever node
+      # descheduler's HighNodeUtilization just freed up, since it always
+      # prefers the emptiest node. MostAllocated flips that bias so freed
+      # headroom actually stays free. See documentation/gotcha.md and
+      # helm-charts/descheduler/values.yaml (added 2026-07-13 alongside
+      # this change) for the teslamate-verify-pitr scheduling incident
+      # that prompted this.
+      copy:
+        dest: /etc/rancher/k3s/scheduler-config.yaml
+        content: |
+          apiVersion: kubescheduler.config.k8s.io/v1
+          kind: KubeSchedulerConfiguration
+          clientConnection:
+            kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
+          profiles:
+            - schedulerName: default-scheduler
+              pluginConfig:
+                - name: NodeResourcesFit
+                  args:
+                    scoringStrategy:
+                      type: MostAllocated
+                      resources:
+                        - name: memory
+                          weight: 1
+                        - name: cpu
+                          weight: 1
+        owner: root
+        group: root
+        mode: '0644'
+      when: "'master' in group_names and inventory_hostname == groups['master'][0]"
+
     - name: Install k3s on the first master node
       # Enable anonymous authentication
       # https://stackoverflow.com/questions/74603633/k3s-allow-unauthenticated-access-to-oidc-endpoints
@@ -39,7 +71,9 @@
           --kube-apiserver-arg \
           --api-audiences=oidc.siutsin.com \
           --kube-apiserver-arg \
-          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
+          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks \
+          --kube-scheduler-arg \
+          --config=/etc/rancher/k3s/scheduler-config.yaml
       when: "'master' in group_names and inventory_hostname == groups['master'][0]"
       register: first_master_setup
       changed_when: first_master_setup.stdout is not search('No change detected so skipping service start')

--- a/ansible/playbooks/k3s/002-nodes.yaml
+++ b/ansible/playbooks/k3s/002-nodes.yaml
@@ -43,6 +43,38 @@
       delegate_facts: true
       run_once: true
 
+    - name: Configure kube-scheduler to bin-pack via MostAllocated
+      # Default LeastAllocated scoring keeps refilling whatever node
+      # descheduler's HighNodeUtilization just freed up, since it always
+      # prefers the emptiest node. MostAllocated flips that bias so freed
+      # headroom actually stays free. See documentation/gotcha.md and
+      # helm-charts/descheduler/values.yaml (added 2026-07-13 alongside
+      # this change) for the teslamate-verify-pitr scheduling incident
+      # that prompted this.
+      copy:
+        dest: /etc/rancher/k3s/scheduler-config.yaml
+        content: |
+          apiVersion: kubescheduler.config.k8s.io/v1
+          kind: KubeSchedulerConfiguration
+          clientConnection:
+            kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
+          profiles:
+            - schedulerName: default-scheduler
+              pluginConfig:
+                - name: NodeResourcesFit
+                  args:
+                    scoringStrategy:
+                      type: MostAllocated
+                      resources:
+                        - name: memory
+                          weight: 1
+                        - name: cpu
+                          weight: 1
+        owner: root
+        group: root
+        mode: '0644'
+      when: "'master' in group_names"
+
     - name: Install k3s on master nodes with LB_API_SERVER_IP
       # Enable anonymous authentication
       # https://stackoverflow.com/questions/74603633/k3s-allow-unauthenticated-access-to-oidc-endpoints
@@ -76,7 +108,9 @@
           --kube-apiserver-arg \
           --api-audiences=oidc.siutsin.com \
           --kube-apiserver-arg \
-          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks
+          --service-account-jwks-uri=https://oidc.siutsin.com/openid/v1/jwks \
+          --kube-scheduler-arg \
+          --config=/etc/rancher/k3s/scheduler-config.yaml
       retries: 5
       delay: 10
       register: k3s_master_install


### PR DESCRIPTION
## Summary

- Default `LeastAllocated` scoring always prefers the emptiest node,
  which directly fights `descheduler`'s `HighNodeUtilization`
  (added in #2804): that evicts pods from the least-loaded node to
  grow contiguous free memory there, but the default scheduler then
  immediately refills the same node since it's still the emptiest
  choice.
- Adds a `KubeSchedulerConfiguration` file to each master node (via
  `--kube-scheduler-arg=config=...`) enabling `NodeResourcesFit` with
  the `MostAllocated` strategy, weighted on memory and cpu, so freed
  headroom actually stays free.
- Prompted by `teslamate-verify-pitr`'s PITR verification Job (2Gi
  combined across 3 containers) repeatedly failing to schedule
  despite ~2-3GiB free in aggregate -- spread too thin across all 5
  nodes for any single one to fit it.

## Risk

This is a cluster-wide, ongoing behavioral change (not just a one-time
action) and requires restarting the k3s server process on all 3
control-plane nodes to apply. Discussed with the user directly before
implementing:

- **Rollout:** one node at a time via `ansible-playbook ... --limit
  <host>`, not the full fleet at once. A bad `KubeSchedulerConfiguration`
  could stop that node's k3s server from starting entirely (scheduler
  is embedded in the same process), recoverable via SSH rollback.
- **Ongoing:** `MostAllocated` changes placement bias for *every*
  future pod, not just consolidation. Could concentrate load onto
  whichever node is already fullest, and may reduce effective spread
  for workloads relying on soft pod anti-affinity.

## Test plan

- [x] `ansible-playbook --syntax-check` on both modified playbooks
- [x] `make test`
- [ ] Apply to the first master only (`--limit`), confirm k3s starts
  cleanly and the API/scheduler are healthy, before rolling to the
  other two
- [ ] Watch scheduling behaviour and node memory distribution over
  the following hours
- [ ] Re-test `teslamate-verify-pitr` scheduling once rolled out
  fully