### PR TITLE
docs(gotcha): document the memory-fragmentation scheduling fix

### DIFF
--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -27,6 +27,14 @@
   CronJob child (see `runbooks/merge-policy.md` and
   `references/escalation.md`).
 - CronJob or backup Job failures → GitOps-fix or escalate.
+- Pod `Pending` with `Insufficient memory` on every node, even when
+  `kubectl describe node` shows real free memory somewhere: check every
+  container's request in the pod spec (multi-container pods must fit
+  entirely on one node) before assuming a real capacity shortfall — this
+  cluster runs a paired descheduler `HighNodeUtilization` +
+  kube-scheduler `MostAllocated` fix for exactly this scattered-memory
+  case. See `documentation/gotcha.md` ("Multi-Container Pods Fail to
+  Schedule Despite \"Enough\" Free Cluster Memory").
 
 ## Known data-durability gotchas
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Current cluster layout:
 - Flannel `wireguard-native` for pod networking
 - MetalLB + Envoy Gateway for service and ingress virtual IPs, with the Envoy Gateway controller in `envoy-gateway-system` and the ingress proxy in `gateway`
 - Istio ambient mesh with Kiali for service mesh observability
+- `kube-scheduler` bin-packs via `NodeResourcesFit`/`MostAllocated`,
+  paired with Descheduler's `HighNodeUtilization` profile, to
+  concentrate free memory onto one node instead of spreading it too
+  thin for larger pods to fit anywhere (see `documentation/gotcha.md`)
 
 ## Hardware
 
@@ -103,7 +107,7 @@ Three nodes form the control plane. Two nodes remain workers, including temporar
 | Monitoring   | [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server)                      | Scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines                                                                  |
 | Monitoring   | [Loki](helm-charts/monitoring)                                                                      | Log aggregation and query backend                                                                                                                                       |
 | Monitoring   | [Prometheus](helm-charts/monitoring)                                                                | Metrics collection and query backend                                                                                                                                    |
-| Scheduling   | [Descheduler](https://github.com/kubernetes-sigs/descheduler)                                       | Evicts pods for optimal cluster node utilisation                                                                                                                        |
+| Scheduling   | [Descheduler](https://github.com/kubernetes-sigs/descheduler)                                       | Evicts pods for optimal cluster node utilisation; runs a `HighNodeUtilization` profile to consolidate the least-loaded node's pods elsewhere                           |
 | Scheduling   | [k8s-cleaner](https://github.com/gianlucam76/k8s-cleaner)                                           | Automated failed pod cleanup and periodic workload repaving                                                                                                             |
 | Scheduling   | [KEDA](https://keda.sh/)                                                                            | Event Driven Autoscaler                                                                                                                                                 |
 | Scheduling   | [Reloader](https://github.com/stakater/Reloader)                                                    | Watch changes in ConfigMap and Secret and do rolling upgrades                                                                                                           |

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1037,3 +1037,145 @@ already busy cluster.
 [longhorn-issue]: https://github.com/longhorn/longhorn/issues/4143
 [longhorn-12225]: https://github.com/longhorn/longhorn/issues/12225
 [longhorn-6645]: https://github.com/longhorn/longhorn/issues/6645
+
+---
+
+## Multi-Container Pods Fail to Schedule Despite "Enough" Free Cluster Memory
+
+**Problem:** `teslamate-verify-pitr`'s daily PITR (point-in-time-recovery)
+verification Job repeatedly got stuck `Pending` for hours, failing with
+`0/5 nodes are available: 5 Insufficient memory`, even though the cluster
+had roughly 2-3GiB of memory free in aggregate at the time. The obvious
+assumption -- "the job barely needs any memory, why is this failing?" --
+was also wrong: the visible CronJob controller container only requests
+128Mi, but it spins up a separate, dynamically-created recovery pod with
+**three** containers (`bootstrap-controller` 512Mi,
+`plugin-barman-cloud` 1Gi, `full-recovery` 512Mi) totalling **2Gi**, and
+all three must land on the same node. Manually re-running the job
+(`kubectl create job --from=cronjob/teslamate-verify-pitr ...`) confirmed
+it failing live, ruling out a one-off fluke.
+
+**Why it happens:** free memory was real but scattered -- every node
+individually had less than 2GiB free, even though summed together there
+was enough. This is a distribution problem, not a capacity problem, and
+it's made structurally worse by two Kubernetes defaults fighting each
+other:
+
+- `kube-scheduler`'s default `NodeResourcesFit` scoring strategy is
+  `LeastAllocated`, which always prefers placing new pods on the
+  emptiest node.
+- Descheduler's `LowNodeUtilization` strategy (this cluster's original
+  config) is a no-op once every node is simultaneously above its
+  `targetThresholds` -- it needs an already-underutilized node to land
+  evicted pods on, and a cluster running hot everywhere never has one.
+- Even after adding descheduler's `HighNodeUtilization` strategy (which
+  *does* evict pods off the least-loaded node to grow contiguous free
+  space there), the default `LeastAllocated` scheduler bias immediately
+  refills that same node with new pods, since it's still the emptiest
+  choice available. Confirmed live: evicting several pods from the
+  least-loaded node only netted a partial, temporary improvement before
+  the scheduler placed replacements straight back onto it.
+
+### Symptoms: Scattered-Memory Scheduling Failures
+
+- `FailedScheduling` events citing `Insufficient memory` (or `cpu`/`pods`)
+  across **all** nodes, for a Job or Deployment that "shouldn't" need
+  that much.
+- `kubectl describe node <node>` shows meaningful free memory on
+  individual nodes, but always less than the failing pod's *combined*
+  container requests -- check every container in the pod spec, not just
+  the one you expect, since sidecars/init containers add up.
+- Descheduler logs (`kubectl logs -n descheduler -l
+  app.kubernetes.io/name=descheduler`) show `HighNodeUtilization`
+  evicting pods, but the same or similar pods reappear on the same node
+  shortly after in `kubectl get pods -A -o wide`.
+- Node memory-request percentages sit in a narrow, uniformly-high band
+  (e.g. 83-97%) across every node -- no single node is meaningfully more
+  free than the rest.
+
+### Resolution: Pair Descheduler's HighNodeUtilization With a MostAllocated Scheduler
+
+Two changes, both required -- one alone just causes eviction churn
+without net progress:
+
+1. **`helm-charts/descheduler/values.yaml`** -- add a second profile
+    (`HighNodeUtilization` cannot share a profile with
+    `LowNodeUtilization`; they have opposite goals) that evicts pods from
+    whichever node is below a memory threshold, to be rescheduled
+    elsewhere:
+
+    ```yaml
+    - name: consolidate
+      pluginConfig:
+        - name: DefaultEvictor
+          args:
+            podProtections:
+              defaultDisabled:
+                - PodsWithLocalStorage
+        - name: HighNodeUtilization
+          args:
+            thresholds:
+              cpu: 100
+              memory: 90
+              pods: 100
+      plugins:
+        balance:
+          enabled:
+            - HighNodeUtilization
+    ```
+
+2. **`kube-scheduler` config** -- flip the default `LeastAllocated`
+    scoring to `MostAllocated`, so newly-scheduled pods actively prefer
+    already-fuller nodes instead of refilling whatever descheduler just
+    freed up:
+
+    ```yaml
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    clientConnection:
+      kubeconfig: /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
+    profiles:
+      - schedulerName: default-scheduler
+        pluginConfig:
+          - name: NodeResourcesFit
+            args:
+              scoringStrategy:
+                type: MostAllocated
+                resources:
+                  - name: memory
+                    weight: 1
+                  - name: cpu
+                    weight: 1
+    ```
+
+    On k3s, this file must exist on disk on every control-plane node
+    *before* the server starts, referenced via
+    `--kube-scheduler-arg --config=<path>` on the `curl ... | sh -s -`
+    install command (see `ansible/playbooks/k3s/000-init-cluster.yaml`
+    and `002-nodes.yaml`). Applying it means restarting the k3s server
+    process (scheduler is embedded in the same binary as the API server)
+    on every control-plane node -- roll out **one node at a time**, not
+    all at once, and confirm each one starts cleanly
+    (`journalctl -u k3s`, look for `"Starting Kubernetes Scheduler"` with
+    no immediately-following fatal errors) before moving to the next.
+
+Applied together, node memory usage stops being uniform: the
+least-loaded node keeps getting emptier (consolidation actually sticks)
+while the rest absorb the difference. Verified live in this incident --
+the previously-failing Job's pod scheduled and completed successfully
+immediately after rollout, with no other change needed.
+
+### Gotcha During Rollout: Transient API VIP Blip
+
+Restarting all 3 control-plane nodes' k3s processes (even one at a time)
+can briefly disrupt the cluster's API VIP if it is itself backed by a
+MetalLB-announced `LoadBalancer` Service (see
+[k3s-apiserver-loadbalancer][k3s-apiserver-loadbalancer]) rather than a
+static IP -- `metallb-controller`'s L2 announcement election can lag by
+under a minute while it re-settles after a node it was scheduled on
+restarts. Confirmed via direct `https://<node-ip>:6443/livez` checks on
+every master that the cluster itself was never actually down, only the
+VIP's announcement was briefly stale. No action needed; it resolves on
+its own once MetalLB's speakers re-converge.
+
+[k3s-apiserver-loadbalancer]: https://github.com/siutsin/k3s-apiserver-loadbalancer


### PR DESCRIPTION
## Summary

Full write-up of tonight's `teslamate-verify-pitr` scheduling
incident and its fix, so future passes recognise the pattern
directly instead of re-deriving it:

- `documentation/gotcha.md`: new entry covering the symptom
  (multi-container pod stuck `Pending` with `Insufficient memory`
  despite real aggregate free capacity), why descheduler's
  `HighNodeUtilization` alone can't fix it (default `LeastAllocated`
  scheduler bias immediately refills whatever it frees up), the
  paired fix (descheduler `consolidate` profile + kube-scheduler
  `MostAllocated`), rollout steps, and the transient API VIP blip
  observed during the 3-master rollout.
- `.claude/skills/self-healing/runbooks/workloads.md`: pointer to
  the new entry so a future stuck-Pending pod gets checked against
  this pattern before assuming a real capacity shortfall.
- `README.md`: notes the `kube-scheduler`/descheduler pairing as a
  permanent architecture decision, not just a one-off fix.

No cluster or chart changes; documentation only.

## Test plan

- [x] `make test`