### PR TITLE
docs(readme): bump Kubernetes version badge to v1.36.2+k3s1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # otaru
 
-![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.35.5+k3s1-blue)
+![Kubernetes Version](https://img.shields.io/badge/Kubernetes-v1.36.2+k3s1-blue)
 [![Cluster Health](https://img.shields.io/static/v1?label=Cluster%20Health&message=WebGazer&color=brightgreen)](https://www.webgazer.io/s?id=493)
 
 > Over-Engineering at Its Finest


### PR DESCRIPTION
## Summary

Control-plane nodes picked up v1.36.2+k3s1 as a side effect of the
kube-scheduler MostAllocated rollout (the install script always
pulls latest-stable when re-run without a pinned version). Badge
now reflects the control-plane version. Worker nodes
(`nuc-00`, `raspberrypi-03`) remain on v1.35.5+k3s1 for now.

## Test plan

- [x] `make test`