### PR TITLE
feat(descheduler): repave Deployment pods older than 2 days

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -22,6 +22,20 @@ descheduler:
             args:
               podRestartThreshold: 100
               includingInitContainers: true
+          # Added 2026-07-14: repave Deployment-owned pods every 2 days so
+          # they periodically pick up node patches and don't accumulate
+          # slow memory creep. Scoped to ReplicaSet-owned pods only (a
+          # Deployment-managed pod's immediate ownerReference kind is
+          # ReplicaSet, not Deployment) so CronJob/Job pods, StatefulSets
+          # (CNPG, Longhorn), and DaemonSets are never touched by this.
+          - name: PodLifeTime
+            args:
+              maxPodLifeTimeSeconds: 172800 # 2 days
+              states:
+                - Running
+              ownerKinds:
+                include:
+                  - ReplicaSet
           - name: LowNodeUtilization
             args:
               thresholds:
@@ -39,6 +53,7 @@ descheduler:
           deschedule:
             enabled:
               - RemovePodsHavingTooManyRestarts
+              - PodLifeTime
       # Added 2026-07-13: LowNodeUtilization is a no-op when every node sits
       # above its 50% targetThreshold at once (our steady state -- all 5
       # nodes run 83-97% memory requests), since it needs an already-


### PR DESCRIPTION
## Summary

Adds the `PodLifeTime` plugin to descheduler's `default` profile,
evicting `Running` pods older than 2 days so they periodically pick
up node patches and don't accumulate slow memory creep.

Scoped to `ReplicaSet`-owned pods only (`ownerKinds.include:
[ReplicaSet]`) -- a Deployment-managed pod's immediate
`ownerReference` kind is `ReplicaSet`, not `Deployment` -- so
CronJob/Job pods, StatefulSets (CNPG, Longhorn), and DaemonSets are
never touched by this.

## Test plan

- [x] `helm template` confirms it renders correctly
- [x] `make test`
- [ ] Watch descheduler logs post-merge for `PodLifeTime` eviction
  activity