### PR TITLE
fix(monitoring): bump k8s-ephemeral-storage-metrics image to 1.20.0

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -204,7 +204,7 @@ k8s-ephemeral-storage-metrics:
     enable: false
   image:
     repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-    tag: 1.19.2@sha256:77d7489bd280ed6340c17d886d47eeb70c0df7fc0d97a871045124b673032822
+    tag: 1.20.0@sha256:b1e0db4cc844eada588972656b0bd9a2594718f200b2f27de30631ff63457c19
     imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Chart bump #2824 moved `k8s-ephemeral-storage-metrics` to 1.20.0, changing the default readiness probe path from `/metrics` to `/health`.
- The image tag stayed pinned at `1.19.2`, which has no `/health` route, so new pods 404 on readiness and never go Ready.
- Bumps the pinned tag/digest to `1.20.0` (confirmed genuinely multi-arch: arm64 + amd64) to match the chart's probe expectations.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the rendered image tag and probe path now agree
- [ ] Confirm the ArgoCD-synced pod goes Ready and the `DeploymentUnavailable` alert clears