### PR TITLE
fix(monitoring): bump k8s-ephemeral-storage-metrics image to 1.21.0

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -204,7 +204,7 @@ k8s-ephemeral-storage-metrics:
     enable: false
   image:
     repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-    tag: 1.20.0@sha256:b1e0db4cc844eada588972656b0bd9a2594718f200b2f27de30631ff63457c19
+    tag: 1.21.0@sha256:73f2042ce8d144044ee967bb20db0bad22e2aaa999de48ce8589d3bec92ff165
     imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

- PR #2828 (Renovate) bumped the `k8s-ephemeral-storage-metrics` chart dependency to 1.21.0.
- Confirmed the probe path change from #2824's incident is not repeated here: 1.21.0 just made the probe path configurable via `.Values.probes.readiness.path` / `.Values.probes.liveness.path`, still defaulting to `/health` / `/metrics`.
- Bumps the pinned image tag/digest to `1.21.0` to keep the image and chart aligned (verified genuinely multi-arch: arm64 + amd64), so we don't drift behind again.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the rendered image tag matches
- [ ] Confirm ArgoCD syncs cleanly and pod goes Ready