### PR TITLE
fix(monitoring): bump k8s-ephemeral-storage-metrics image to 1.21.1

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -204,7 +204,7 @@ k8s-ephemeral-storage-metrics:
     enable: false
   image:
     repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-    tag: 1.21.0@sha256:73f2042ce8d144044ee967bb20db0bad22e2aaa999de48ce8589d3bec92ff165
+    tag: 1.21.1@sha256:33d77422cd327f9710ea204b53867e3465e76bf02d2574fe871e64a2b8b574a7
     imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

- PR #2837 (Renovate) bumped the `k8s-ephemeral-storage-metrics` chart to 1.21.1 -- a patch release with no template changes, only the chart's own default image tag moved.
- Bumps the pinned image tag/digest to `1.21.1` to keep image and chart aligned (verified genuinely multi-arch: arm64 + amd64).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the rendered image tag matches
- [ ] Confirm ArgoCD syncs cleanly and pod stays Ready