### PR TITLE
fix(argocd,openclaw): correct mispinned single-arch digests, drop arm64 pins

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -135,13 +135,6 @@ argo-cd:
     metrics:
       enabled: true
     replicas: 1
-    # The jsonnet-with-secret CMP sidecar (ghcr.io/siutsin/images/go-jsonnet)
-    # ships an arm64-only binary. On the amd64 nuc-00 node the jsonnet binary
-    # fails with "exec format error", which breaks manifest generation for the
-    # bootstrap and private apps. Pin the repo-server to arm64 nodes so the
-    # sidecar architecture always matches.
-    nodeSelector:
-      kubernetes.io/arch: arm64
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -160,8 +153,8 @@ argo-cd:
     # ~2x headroom). Downsized to 512Mi, keeping ~35% margin over peak given
     # the cold-cache render spikes noted on reposerver.parallelism.limit
     # above. CPU is a separate, deferred item: KRR wants ~1.7 cores against
-    # the current 250m (CRITICAL), but all 4 arm64 nodes this pod can land
-    # on are already at 63-69% CPU requests, and a jump this size risks
+    # the current 250m (CRITICAL), but the nodes this pod can land on are
+    # already at 63-69% CPU requests, and a jump this size risks
     # near-saturating whichever one it schedules on. CPU throttling
     # degrades gracefully (unlike an OOM), so leaving this deferred is a
     # smaller risk than following KRR blindly on a memory-tight cluster.
@@ -256,7 +249,7 @@ argo-cd:
         securityContext:
           runAsNonRoot: true
           runAsUser: 999
-        image: ghcr.io/siutsin/images/go-jsonnet:v0.22.0-rc1-202603220524@sha256:5261f61f4f94b17cfb92ddcf7518c36a909366657a8cfff16a91d7b277a19de8
+        image: ghcr.io/siutsin/images/go-jsonnet:v0.22.0-rc1-202603220524@sha256:7ae80ae8875c82a2bbb239ad476146188435eea0c46d6ee5f55a32b84221ce7f
         resources:
           requests:
             cpu: 100m

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -3,7 +3,7 @@ namespace: openclaw
 
 image:
   repository: ghcr.io/openclaw/openclaw
-  tag: 2026.5.22@sha256:1a5b25794693e2d3a3bfe1ef6a6061634bf44704c4650d65934e19f018664ced
+  tag: 2026.5.22@sha256:dcfd148777401d1bbdc63eab5c2f280bbfa912dfb1818566f9d66bb96ffb3f95
   pullPolicy: IfNotPresent
 
 service:
@@ -24,10 +24,6 @@ gateway:
       windowMs: 60000
       lockoutMs: 300000
       exemptLoopback: true
-
-# Pin to arm64: busybox and openclaw images are arm64-only; rollout to nuc-00 (amd64) failed init with exec format error.
-nodeSelector:
-  kubernetes.io/arch: arm64
 
 persistence:
   claimName: openclaw-pvc
@@ -140,7 +136,7 @@ resources:
 initContainer:
   image:
     repository: busybox
-    tag: 1.38.0@sha256:8f2ffdcb46f1b83e46665954ec130e497b979db766854f79ca9eee43242b7e4c
+    tag: 1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

User noticed today's two stuck-Pending incidents (node-exporter, then argocd-repo-server) both hit arm64-only nodeSelectors and asked why so many images would be missing amd64 -- that shouldn't be common. Investigation found it isn't: three pinned digests were actually the arm64 *child manifest* of a multi-arch index, not the index itself -- the same bug already fixed once in `changedetection` (#2810).

- `ghcr.io/openclaw/openclaw:2026.5.22` -- confirmed multi-arch (amd64 + arm64), was pinned to the arm64 child digest.
- `busybox:1.38.0` (openclaw init container) -- confirmed multi-arch (amd64, arm64, arm, 386, ppc64le, s390x, riscv64), same mispin.
- `ghcr.io/siutsin/images/go-jsonnet` (argocd-repo-server CMP sidecar) -- the "arm64-only" comment was accurate when written, but the image has since gained an amd64 build. Confirmed via GHCR manifest.

None of these are actually arm64-only. The mispinned digests forced both `openclaw` and `argocd-repo-server` onto `kubernetes.io/arch: arm64`, which is exactly why neither could fall back to `nuc-00` (amd64, plenty of headroom) during today's memory-saturation incidents. Re-pinned to the correct index digests and removed both now-unnecessary nodeSelectors.

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms rendered images use the new digests and no `nodeSelector` remains
- [ ] Confirm ArgoCD syncs cleanly and both pods stay Ready (may land on any node now, including nuc-00)