### PR TITLE
feat: add CI check preventing mispinned single-arch image digests

### DIFF
--- a/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
+++ b/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
@@ -16,11 +16,15 @@ category and its place in the investigation order do not need to change.
 - `OutOfSync` for more than one hourly loop cycle with no in-flight PR →
   investigate drift; GitOps-fix when the live diff is wrong, otherwise
   escalate if sync needs prune/force.
-- **`Unknown` + `fork/exec ... jsonnet: exec format error`:** the
-  jsonnet CMP sidecar image may be arm64-only while the repo-server landed
-  on amd64 (`nuc-00`). Prefer pinning `argocd.repoServer` to
-  `kubernetes.io/arch: arm64` in GitOps (see recent journal / chart), not a
-  force-sync.
+- **`Unknown` + `fork/exec ... jsonnet: exec format error`:** almost
+  certainly a mispinned single-arch digest on the jsonnet CMP sidecar
+  image, not a genuine arch limitation — see `documentation/gotcha.md`
+  ("A Pinned Digest Can Silently Be Single-Arch, Not Multi-Arch" →
+  "Recurrence: Forced Architecture Pins Masking the Same Bug"). Verify
+  and re-pin to the multi-arch index digest; do **not** add a
+  `kubernetes.io/arch` nodeSelector as the fix — that masks the bug and
+  can itself cause stuck-`Pending` rollouts once that architecture's
+  nodes fill up (same doc entry, 2026-07-18 incident).
 - Before suggesting Application deletes or prune/force sync, check Helm
   chart / Application annotations for **sync waves** and prune behaviour.
   Destructive sync is escalate-only (`references/escalation.md`).

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -35,6 +35,19 @@
   kube-scheduler `MostAllocated` fix for exactly this scattered-memory
   case. See `documentation/gotcha.md` ("Multi-Container Pods Fail to
   Schedule Despite \"Enough\" Free Cluster Memory").
+- Pod `Pending` with `Insufficient memory` on **every node of one
+  architecture** while a node of the other architecture (`nuc-00`,
+  amd64) sits well under capacity: check `kubectl get pod -o
+  jsonpath='{.spec.nodeSelector}'` for a `kubernetes.io/arch` pin before
+  treating this as a real capacity shortfall — it may be an
+  architecture pin that only exists because of a mispinned single-arch
+  digest, not a genuine constraint. See `documentation/gotcha.md` ("A
+  Pinned Digest Can Silently Be Single-Arch, Not Multi-Arch" →
+  "Recurrence"). If the arch pool genuinely is full and the pin is
+  legitimate (or a fix is out of scope for this pass), a safe live
+  remediation is evicting one redundant pod from a same-pool node with
+  PDB headroom (multi-replica Deployment, `kubectl get pdb` allows the
+  disruption) to free enough room — it will reschedule on its own.
 
 ## Known data-durability gotchas
 

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,12 @@ check-yaml: ## Check YAML syntax in key files
 	@yq eval '.' ansible/inventory.yaml > /dev/null
 	@echo "$(GREEN)YAML syntax check passed!$(NC)"
 
+.PHONY: check-image-digests
+check-image-digests: ## Verify pinned image digests reference the multi-arch index, not a single-arch child manifest
+	@echo "$(GREEN)Checking pinned image digests...$(NC)"
+	@bash $(HACK_DIR)/check-image-digests.sh
+	@echo "$(GREEN)Image digest check passed!$(NC)"
+
 .PHONY: check-markdown
 check-markdown: ## Check Markdown files with markdownlint-cli2
 	@echo "$(GREEN)Checking Markdown files...$(NC)"
@@ -264,7 +270,9 @@ format-python: poetry-install ## Format Python code with black
 	@echo "$(GREEN)Python code formatting complete!$(NC)"
 
 .PHONY: test
-test: validate-argocd-manifest check-yaml lint-editorconfig lint-terraform lint-terragrunt check-markdown lint-zizmor validate-helm-charts ## Run all validation and quality checks
+test: validate-argocd-manifest check-yaml lint-editorconfig lint-terraform \
+	lint-terragrunt check-markdown lint-zizmor validate-helm-charts \
+	check-image-digests ## Run all validation and quality checks
 	@echo "$(GREEN)All validation and quality checks passed!$(NC)"
 
 # Utility targets

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1262,6 +1262,43 @@ Re-pin the chart to that digest. Cross-check it matches what a node of
 each architecture actually has cached as a multi-platform index before
 considering it confirmed.
 
+### Recurrence: Forced Architecture Pins Masking the Same Bug
+
+The same mispinning recurred three more times, discovered on
+2026-07-18 while investigating two separate stuck-`Pending` incidents
+(`monitoring-prometheus-node-exporter` and `argocd-repo-server`, both
+`FailedScheduling` on insufficient memory): `ghcr.io/openclaw/openclaw`,
+`busybox:1.38.0` (openclaw's init container), and
+`ghcr.io/siutsin/images/go-jsonnet` (the `argocd-repo-server` CMP
+sidecar) were all pinned to their arm64 child manifest instead of the
+index. Because these images were believed arm64-only, `openclaw` and
+`argocd-repoServer` both carried a `nodeSelector: kubernetes.io/arch:
+arm64`, which is exactly what turned an ordinary memory-pressure
+scheduling squeeze into a stuck rollout: neither pod could fall back to
+`nuc-00` (amd64) even when it had free headroom. One of the three --
+`go-jsonnet` -- had a comment stating it "ships an arm64-only binary"
+that was accurate when written; the image gained a real amd64 build
+later and nobody revisited the pin or the nodeSelector. Removing the
+mispinned digest and the nodeSelector let the next rollout land on
+`nuc-00` immediately, confirming the fix.
+
+**Lesson:** an "arch-only" comment on an image pin is a claim about the
+image at the time it was written, not a durable fact. Treat any
+`nodeSelector: kubernetes.io/arch` on a workload as a hypothesis to
+re-verify, not a permanent constraint -- especially once the underlying
+digest has been re-pinned to a real multi-arch index.
+
+### Prevention: Automated CI Check
+
+`hack/check-image-digests.sh` (wired into `make test` as
+`check-image-digests`) scans every `helm-charts/**/*.yaml` for pinned
+`repository:tag@digest` references, queries each image's registry for
+the tag's current manifest, and fails the build if a pinned digest
+matches a single-platform child manifest of an index rather than the
+index itself. Network or auth failures against a registry are reported
+as warnings, not build failures, so a transient registry hiccup doesn't
+block unrelated PRs -- only a confirmed mispin does.
+
 ---
 
 ## ArgoCD Cannot Sync Some Large CRDs -- No Safe Fix Found, Accepted As-Is

--- a/hack/check-image-digests.sh
+++ b/hack/check-image-digests.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+
+# Verify pinned image digests reference the multi-arch index, not a
+# single-arch child manifest. A digest captured on an arm64 machine (e.g.
+# via `docker inspect`) can silently resolve to the arm64 child manifest of
+# a multi-arch image instead of the index digest. The pin then works by
+# accident until the pod is scheduled onto a different architecture, where
+# it fails with "exec format error". See documentation/gotcha.md ("A
+# Pinned Digest Can Silently Be Single-Arch, Not Multi-Arch").
+
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/common.sh"
+
+CHARTS_DIR="${1:-./helm-charts}"
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/check-image-digests.XXXXXX")
+PINS_FILE="${TEMP_DIR}/pins"
+FAILURES_FILE="${TEMP_DIR}/failures"
+HEADER_FILE="${TEMP_DIR}/headers"
+BODY_FILE="${TEMP_DIR}/body"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+if ! command_exists yq; then
+    exit_with_error "yq is not installed or not in PATH"
+fi
+
+if ! command_exists jq; then
+    exit_with_error "jq is not installed or not in PATH"
+fi
+
+if ! directory_exists "$CHARTS_DIR"; then
+    exit_with_error "Charts directory '$CHARTS_DIR' does not exist"
+fi
+
+INLINE_IMAGE_RE='image:[[:space:]]*[a-zA-Z0-9][a-zA-Z0-9./_-]*:[a-zA-Z0-9._-]+@sha256:[0-9a-f]{64}'
+MANIFEST_ACCEPT="application/vnd.oci.image.index.v1+json,"
+MANIFEST_ACCEPT="$MANIFEST_ACCEPT application/vnd.docker.distribution.manifest.list.v2+json,"
+MANIFEST_ACCEPT="$MANIFEST_ACCEPT application/vnd.oci.image.manifest.v1+json,"
+MANIFEST_ACCEPT="$MANIFEST_ACCEPT application/vnd.docker.distribution.manifest.v2+json"
+
+collect_pins() {
+    local file="$1"
+    local line repository tag_digest registry
+
+    # Structured `{registry?, repository, tag}` maps, anywhere in the tree.
+    # Field separator is `|`, not tab: POSIX `read` treats tab as IFS
+    # whitespace and silently strips/collapses leading empty fields even
+    # when IFS is set to only a tab, which would corrupt the empty-registry
+    # case. `|` never appears in a repository, tag, or digest string.
+    while IFS='|' read -r registry repository tag_digest; do
+        if [ -z "$repository" ]; then
+            continue
+        fi
+        if [ -n "$registry" ]; then
+            repository="${registry}/${repository}"
+        fi
+        printf '%s|%s|%s\n' "$repository" "$tag_digest" "$file" >> "$PINS_FILE"
+    done < <(
+        yq eval-all \
+            '[..] | .[] | select(tag == "!!map")
+            | select(has("tag") and has("repository"))
+            | [(.registry // ""), .repository, .tag] | join("|")' \
+            "$file" 2>/dev/null || true
+    )
+
+    # Inline single-line form: image: repo:tag@sha256:digest
+    while IFS= read -r line; do
+        if [ -z "$line" ]; then
+            continue
+        fi
+        line="${line#*image:}"
+        line="$(echo "$line" | sed -E 's/^[[:space:]]+//')"
+        repository="${line%%:*}"
+        tag_digest="${line#*:}"
+        printf '%s|%s|%s\n' "$repository" "$tag_digest" "$file" >> "$PINS_FILE"
+    done < <(grep -oE "$INLINE_IMAGE_RE" "$file" 2>/dev/null || true)
+}
+
+registry_host_and_path() {
+    local repository="$1"
+    local first rest
+
+    if [[ "$repository" == ghcr.io/* ]]; then
+        echo "ghcr.io" "${repository#ghcr.io/}"
+        return
+    fi
+    if [[ "$repository" != */* ]]; then
+        echo "registry-1.docker.io" "library/${repository}"
+        return
+    fi
+    first="${repository%%/*}"
+    rest="${repository#*/}"
+    if [[ "$first" == *.* || "$first" == *:* ]]; then
+        if [ "$first" = "docker.io" ]; then
+            echo "registry-1.docker.io" "$rest"
+        else
+            echo "$first" "$rest"
+        fi
+        return
+    fi
+    echo "registry-1.docker.io" "$repository"
+}
+
+fetch_token() {
+    local host="$1" repo_path="$2" scope
+
+    scope="repository:${repo_path}:pull"
+    case "$host" in
+        ghcr.io)
+            curl -fsS "https://ghcr.io/token?service=ghcr.io&scope=${scope}" 2>/dev/null \
+                | jq -r '.token // empty' 2>/dev/null || true
+            ;;
+        registry-1.docker.io)
+            curl -fsS "https://auth.docker.io/token?service=registry.docker.io&scope=${scope}" 2>/dev/null \
+                | jq -r '.token // empty' 2>/dev/null || true
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# Prints "OK", "WARN: <message>", or "FAIL: <message>" on stdout. Never
+# returns non-zero -- every internal failure is captured and reported as
+# WARN so a transient registry hiccup cannot abort the whole check.
+check_pin() {
+    local repository="$1" tag="$2" digest="$3" source="$4"
+    local host repo_path token index_digest media_type arch
+
+    read -r host repo_path <<< "$(registry_host_and_path "$repository" || true)"
+    token=$(fetch_token "$host" "$repo_path" || true)
+
+    if ! curl -fsS -D "$HEADER_FILE" \
+        -H "Accept: $MANIFEST_ACCEPT" \
+        ${token:+-H "Authorization: Bearer $token"} \
+        "https://${host}/v2/${repo_path}/manifests/${tag}" -o "$BODY_FILE" 2>/dev/null; then
+        echo "WARN: ${repository}:${tag} -- could not verify (registry request failed); skipping"
+        return 0
+    fi
+
+    index_digest=$( (grep -i '^docker-content-digest:' "$HEADER_FILE" || true) | tr -d '\r' | awk '{print $2}')
+    media_type=$(jq -r '.mediaType // ""' "$BODY_FILE" 2>/dev/null || echo "")
+
+    case "$media_type" in
+        application/vnd.oci.image.index.v1+json|application/vnd.docker.distribution.manifest.list.v2+json)
+            ;;
+        *)
+            # No multi-arch index for this tag right now; any pin is fine.
+            echo "OK"
+            return 0
+            ;;
+    esac
+
+    if [ "$digest" = "$index_digest" ]; then
+        echo "OK"
+        return 0
+    fi
+
+    if jq -e --arg d "$digest" '.manifests[]? | select(.digest == $d)' "$BODY_FILE" >/dev/null 2>&1; then
+        arch=$(jq -r --arg d "$digest" '.manifests[] | select(.digest == $d) | .platform.architecture // "unknown"' "$BODY_FILE" 2>/dev/null || echo "unknown")
+        echo "FAIL: ${source}: ${repository}:${tag}@${digest} is pinned to the ${arch}-only child manifest, not the multi-arch index. Re-pin to @${index_digest}."
+        return 0
+    fi
+
+    # Pinned digest matches neither the current index nor any current child --
+    # the tag has simply moved past this pin (normal, intentional version
+    # pinning). Not this check's concern.
+    echo "OK"
+}
+
+: > "$PINS_FILE"
+while IFS= read -r -d '' file; do
+    collect_pins "$file"
+done < <(find "$CHARTS_DIR" -name '*.yaml' -print0)
+
+sort -u -t '|' -k1,1 -k2,2 "$PINS_FILE" -o "$PINS_FILE"
+
+checked=0
+: > "$FAILURES_FILE"
+while IFS='|' read -r repository tag_digest source; do
+    if [ -z "$repository" ]; then
+        continue
+    fi
+    tag="${tag_digest%%@*}"
+    digest="${tag_digest#*@}"
+    checked=$((checked + 1))
+    result=$(check_pin "$repository" "$tag" "$digest" "$source" || true)
+    case "$result" in
+        FAIL:*)
+            echo "$result" >> "$FAILURES_FILE"
+            ;;
+        WARN:*)
+            echo "$result"
+            ;;
+    esac
+done < "$PINS_FILE"
+
+log_info "Checked $checked pinned image digest(s)."
+
+if [ -s "$FAILURES_FILE" ]; then
+    echo ""
+    log_error "$(wc -l < "$FAILURES_FILE" | tr -d ' ') mispinned digest(s) found:"
+    echo ""
+    while IFS= read -r line; do
+        echo "  - ${line#FAIL: }"
+    done < "$FAILURES_FILE"
+    exit 1
+fi
+
+log_success "All pinned digests are correct: index-pinned or genuinely single-arch."


### PR DESCRIPTION
## Summary

Following today's investigation (three mispinned digests forcing arm64 nodeSelectors, which directly caused two stuck-Pending incidents), adds a CI check so this bug class fails the build instead of silently landing.

- `hack/check-image-digests.sh` (bash, matching the repo's `hack/` script conventions -- no new language/dependency): scans every `helm-charts/**/*.yaml` for pinned `repository:tag@digest` references (both structured `{registry, repository, tag}` blocks and inline `image: repo:tag@digest` strings), queries each image's registry for the tag's current manifest, and fails if a pinned digest matches a single-arch child manifest instead of the multi-arch index.
- Wired into `make test` as `check-image-digests`. No new CI dependencies -- `yq` and `jq` are already available.
- Network/auth failures against a registry are warnings, not build failures, so a transient hiccup doesn't block unrelated PRs -- only a confirmed mispin does.
- Updated `documentation/gotcha.md` with the full write-up (recurrence, root cause, prevention).
- Fixed a stale runbook: `gitops-reconciliation.md` previously told a future agent to fix this exact symptom by pinning `argocd.repoServer` to `arm64` -- which is precisely what caused today's incidents. Now points to re-pinning the digest instead.
- Added guidance to `workloads.md` for the "insufficient memory on every node of one architecture" symptom, including the live eviction remediation used today.

## Test plan

- [x] `make test` passes, including the new check against the current (now-correct) repo state
- [x] Verified detection against the three previously-mispinned digests directly (correctly flagged, correct re-pin suggestion)
- [x] `shellcheck` clean
- [x] Manual `set -e`/`pipefail` audit -- fixed a real bug where bare `[ -z "$x" ] && continue` aborts the script under errexit whenever true is the common case, and a POSIX `read` gotcha where tab-as-IFS silently strips/shifts leading empty fields (switched the internal record delimiter to `|`)