### PR TITLE
perf: right-size CPU/memory to KRR 2026-07-18 recommendations

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -152,15 +152,17 @@ argo-cd:
     # KRR 2026-07-12: 14d peak 380Mi against a 768Mi request/limit (WARNING,
     # ~2x headroom). Downsized to 512Mi, keeping ~35% margin over peak given
     # the cold-cache render spikes noted on reposerver.parallelism.limit
-    # above. CPU is a separate, deferred item: KRR wants ~1.7 cores against
-    # the current 250m (CRITICAL), but the nodes this pod can land on are
-    # already at 63-69% CPU requests, and a jump this size risks
-    # near-saturating whichever one it schedules on. CPU throttling
-    # degrades gracefully (unlike an OOM), so leaving this deferred is a
-    # smaller risk than following KRR blindly on a memory-tight cluster.
+    # above. CPU was deferred at the time: KRR wanted ~1.7 cores against the
+    # current 250m (CRITICAL), but this pod was still forced onto arm64 by a
+    # mispinned digest, and all 4 arm64 nodes sat at 63-69% CPU requests.
+    # KRR 2026-07-18: PR #2842 removed the arm64 nodeSelector (mispinned
+    # digest fixed). nuc-00 (amd64, now a valid target) sits at 47% CPU
+    # requests (2115m free of 4000m) and already hosts this pod, so applying
+    # the 1678m recommendation now: RollingUpdate surge peaks at ~3563m/4000m
+    # (89%) on nuc-00, well within capacity.
     resources:
       requests:
-        cpu: 250m
+        cpu: 1678m
         memory: 512Mi
         ephemeral-storage: 512Mi
       limits:

--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -83,8 +83,13 @@ browser:
   resources:
     # KRR 2026-07-05: Playwright browser peaked at ~1.08Gi during Amazon watch fetches; 1Gi left ~6Mi headroom.
     # KRR 2026-07-09: 14-day peak grew to ~1.28Gi, exceeding the 1152Mi limit set above. Bumped to 1408Mi for headroom.
+    # KRR 2026-07-18: CPU CRITICAL, 14d peak needs ~1189m against the 50m
+    # request (memory unaffected, still GOOD at 1408Mi). Deployment uses
+    # Recreate; raspberrypi-03 (its current node, 62% CPU requests) frees
+    # the old 50m before scheduling the new pod, and rpi-02 has 1395m free
+    # as a fallback if the scheduler places it elsewhere.
     requests:
-      cpu: 50m
+      cpu: 1189m
       memory: 1408Mi
       ephemeral-storage: 1Gi
     limits:

--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -2,12 +2,18 @@ descheduler:
   kind: Deployment
   resources:
     # KRR 2026-07-05: live peak ~100Mi working set; 256Mi request was never approached.
+    # KRR 2026-07-18: 14d peak ~10m CPU / ~100Mi memory (both GOOD, safe
+    # downsize). KRR also flags the 500m CPU limit as unnecessary, but it is
+    # inherited from the vendored chart's own default (this file never sets
+    # it) and a plain values.yaml `null` does not remove a subchart-default
+    # key on merge (confirmed via `helm template`) -- left as is rather than
+    # fighting the chart with a hackier override.
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 10m
+      memory: 100Mi
       ephemeral-storage: 64Mi
     limits:
-      memory: 128Mi
+      memory: 100Mi
       ephemeral-storage: 64Mi
   deschedulerPolicy:
     profiles:

--- a/helm-charts/keda/values.yaml
+++ b/helm-charts/keda/values.yaml
@@ -8,29 +8,35 @@ _shared:
 
 keda:
   resources:
+    # KRR 2026-07-18: 14d peaks all GOOD-rated -- downsize CPU requests and
+    # correct memory requests to the observed peak. KRR also flags the
+    # 1-core CPU limit on each as unnecessary, but it is inherited from the
+    # vendored chart's own defaults (this file never sets limits.cpu) and a
+    # plain values.yaml `null` does not remove a subchart-default key on
+    # merge (confirmed via `helm template`) -- left as is.
     operator:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 10m
+        memory: 150Mi
         ephemeral-storage: 64Mi
       limits:
-        memory: 128Mi
+        memory: 150Mi
         ephemeral-storage: 64Mi
     metricServer:
       requests:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 17m
+        memory: 140Mi
         ephemeral-storage: 64Mi
       limits:
-        memory: 128Mi
+        memory: 140Mi
         ephemeral-storage: 64Mi
     webhooks:
       requests:
-        cpu: 50m
-        memory: 64Mi
+        cpu: 10m
+        memory: 100Mi
         ephemeral-storage: 64Mi
       limits:
-        memory: 64Mi
+        memory: 100Mi
         ephemeral-storage: 64Mi
   operator:
     affinity:

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -11,13 +11,18 @@ kubernetes-mcp-server:
   service:
     port: 8080
   fullnameOverride: kubernetes-mcp-server
+  # KRR 2026-07-18: 14d peak ~10m CPU / ~100Mi memory (both GOOD, safe
+  # downsize). KRR also flags the 100m CPU limit as unnecessary, but it is
+  # inherited from the vendored chart's own default (this file never sets
+  # it) and a plain values.yaml `null` does not remove a subchart-default
+  # key on merge (confirmed via `helm template`) -- left as is.
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 10m
+      memory: 100Mi
       ephemeral-storage: 64Mi
     limits:
-      memory: 128Mi
+      memory: 100Mi
       ephemeral-storage: 64Mi
   affinity:
     podAntiAffinity:

--- a/helm-charts/kyverno/values.yaml
+++ b/helm-charts/kyverno/values.yaml
@@ -18,4 +18,16 @@ kyverno:
   cleanupController:
     resources: *resources
   reportsController:
-    resources: *resources
+    # KRR 2026-07-18: CPU WARNING, 14d peak needs ~335m against the shared
+    # 50m request (memory unaffected, still GOOD at 128Mi). Split out from
+    # the shared &resources anchor so the other three controllers keep
+    # their existing 50m request. raspberrypi-00 (its current node, 77%
+    # CPU requests, 895m free) has room for the RollingUpdate surge.
+    resources:
+      requests:
+        cpu: 335m
+        memory: 128Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 128Mi
+        ephemeral-storage: 64Mi

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -125,8 +125,13 @@ probes:
 
 resources:
   # KRR 2026-07-05: live peak ~763Mi working set; 1Gi request reserved ~1.3x actual usage.
+  # KRR 2026-07-18: CPU CRITICAL, 14d peak needs ~1150m against the 320m
+  # request. Deferred previously while this pod was forced onto arm64 by a
+  # mispinned digest; PR #2842 removed that nodeSelector. Deployment uses
+  # Recreate, so raspberrypi-03 (its current node, 62% CPU requests) frees
+  # the old 320m before scheduling the new pod — 1150m fits comfortably.
   requests:
-    cpu: 320m
+    cpu: 1150m
     memory: 768Mi
     ephemeralStorage: 1Gi
   limits:

--- a/helm-charts/umami/values.yaml
+++ b/helm-charts/umami/values.yaml
@@ -28,12 +28,16 @@ deployment:
   replicas: 1
   resources:
     # KRR 2026-07-05: live peak ~340Mi working set; 256Mi request left ~84Mi headroom.
+    # KRR 2026-07-18: CPU WARNING, 14d peak needs ~359m against the 50m
+    # request; memory peak dropped to ~313Mi (GOOD), so downsized to match.
+    # raspberrypi-01 (its current node, 81% CPU requests, 725m free) has
+    # room for the RollingUpdate surge.
     requests:
-      cpu: 50m
-      memory: 384Mi
+      cpu: 359m
+      memory: 320Mi
       ephemeral-storage: 256Mi
     limits:
-      memory: 384Mi
+      memory: 320Mi
       ephemeral-storage: 256Mi
 
 routes:


### PR DESCRIPTION
## Summary

KRR right-sizing pass. All changes are resource requests/limits only,
each with an inline `# KRR 2026-07-18:` comment and confirmed node
CPU/memory headroom before any upsize (this is a memory-tight cluster).

- **argocd-repo-server**: CPU 250m -> 1678m. Previously deferred because
  the pod was arm64-pinned by a mispinned digest (fixed in #2842); now
  unpinned, nuc-00 has enough CPU headroom for the RollingUpdate surge.
- **openclaw**: CPU 320m -> 1150m, same deferred-then-unblocked reasoning.
- **changedetection-browser**: CPU 50m -> 1189m (memory unchanged, GOOD).
- **umami**: CPU 50m -> 359m, memory corrected down to 320Mi.
- **kyverno reports-controller**: CPU 50m -> 335m (split from the shared
  resources anchor so the other three controllers are untouched).
- **descheduler, keda (operator/metrics-apiserver/webhooks),
  kubernetes-mcp-server**: downsize CPU/memory requests to KRR's
  GOOD-rated 14-day peaks, freeing cluster capacity.

Skipped (guarded / out of scope, see inline history and journal):
`changedetection` main app memory, `argocd-application-controller`
memory, `jellyfin` (no chart in this repo), `longhorn-csi-plugin`,
and five `longhorn-system` components with no resources hook in the
vendored chart. `monitoring-prometheus-server` memory upsize (WARNING,
3264Mi -> 3675Mi) deferred: the only node with meaningful free memory
is already claimed by the argocd-repo-server CPU upsize this pass, and
no node reliably fits both.

Also fixes an unrelated existing CPU-limit inheritance: KRR flags
several existing CPU limits (descheduler, keda x3, kubernetes-mcp-server)
as unnecessary, but each is inherited from a vendored chart's own
default and a plain `values.yaml` null does not remove a subchart
default on merge (confirmed via `helm template`) -- left as is.

Ephemeral-storage (Part 2): no genuine breaches. The `> 70%` hits are
all the same node-level fallback percentage (no container-level limit
set) on `longhorn-system` pods already known to lack a resources hook.

## Test plan

- [x] `helm template` on every touched chart renders without error
- [x] `make test` passes (Helm validation, YAML/Markdown lint,
      Terraform/Terragrunt lint, digest-pin check, zizmor)
- [ ] Argo CD syncs touched apps to the new revision
- [ ] Pod `resources` reflect new values, no new OOMKilled/CrashLoopBackOff