### PR TITLE
feat(monitoring): add Grafana dashboard for resource requests vs usage

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -142,6 +142,7 @@ local _grafanaDashboards = [
   'dashboards/k3s-cluster-monitoring.yaml',
   'dashboards/onzack-cluster-monitoring.yaml',
   'dashboards/prometheus-stats.yaml',
+  'dashboards/resource-requests-vs-usage.yaml',
 ];
 
 local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };

--- a/helm-charts/monitoring/dashboards/resource-requests-vs-usage.yaml
+++ b/helm-charts/monitoring/dashboards/resource-requests-vs-usage.yaml
@@ -1,0 +1,606 @@
+grafana:
+  dashboards:
+    default:
+      resource-requests-vs-usage:
+        json: |
+          {
+            "annotations": {
+              "list": [
+                {
+                  "builtIn": 1,
+                  "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                  },
+                  "enable": true,
+                  "hide": true,
+                  "iconColor": "rgba(0, 211, 255, 1)",
+                  "name": "Annotations & Alerts",
+                  "type": "dashboard"
+                }
+              ]
+            },
+            "editable": true,
+            "fiscalYearStartMonth": 0,
+            "graphTooltip": 1,
+            "id": null,
+            "links": [],
+            "panels": [
+              {
+                "collapsed": false,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 0
+                },
+                "id": 1,
+                "panels": [],
+                "title": "Memory",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "KRR-style view: container memory request vs its own 6h average usage. Sort descending to find under-provisioned workloads (near/over 100%); sort ascending for downsize candidates.",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": true,
+                      "inspect": false
+                    },
+                    "mappings": []
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "% of request"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-background",
+                            "mode": "gradient"
+                          }
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "rgba(50, 172, 45, 0.9)",
+                                "value": null
+                              },
+                              {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 50
+                              },
+                              {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 100
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 1
+                },
+                "id": 2,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "% of request"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.2.0",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum by (namespace,container) (kube_pod_container_resource_requests{resource=\"memory\",container!=\"\",container!=\"POD\"}) / 1048576",
+                    "refId": "A",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum by (namespace,container) (avg_over_time(container_memory_working_set_bytes{container!=\"\",container!=\"POD\"}[6h])) / 1048576",
+                    "refId": "B",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "(sum by (namespace,container) (avg_over_time(container_memory_working_set_bytes{container!=\"\",container!=\"POD\"}[6h])) / on(namespace,container) group_left sum by (namespace,container) (kube_pod_container_resource_requests{resource=\"memory\",container!=\"\",container!=\"POD\"})) * 100",
+                    "refId": "C",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  }
+                ],
+                "title": "Memory: request vs 6h usage by container",
+                "transformations": [
+                  {
+                    "id": "merge",
+                    "options": {}
+                  },
+                  {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "__name__": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Value #A": "Request (MiB)",
+                        "Value #B": "Usage avg 6h (MiB)",
+                        "Value #C": "% of request"
+                      }
+                    }
+                  }
+                ],
+                "type": "table"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "showPoints": "never",
+                      "spanNulls": true
+                    },
+                    "unit": "bytes"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 10
+                },
+                "id": 3,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "lastNotNull",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi"
+                  }
+                },
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\",container!=\"\",container!=\"POD\"})",
+                    "refId": "A",
+                    "format": "time_series",
+                    "instant": false,
+                    "range": true,
+                    "legendFormat": "Requested"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum(container_memory_working_set_bytes{container!=\"\",container!=\"POD\"})",
+                    "refId": "B",
+                    "format": "time_series",
+                    "instant": false,
+                    "range": true,
+                    "legendFormat": "Used"
+                  }
+                ],
+                "title": "Cluster memory: requested vs used",
+                "type": "timeseries"
+              },
+              {
+                "collapsed": false,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 18
+                },
+                "id": 4,
+                "panels": [],
+                "title": "CPU",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Same as the memory table but for CPU cores. Note CPU request headroom is node-wide (bin-packing), unlike memory which is usually the tighter constraint on this cluster.",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": true,
+                      "inspect": false
+                    },
+                    "mappings": []
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "% of request"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-background",
+                            "mode": "gradient"
+                          }
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "rgba(50, 172, 45, 0.9)",
+                                "value": null
+                              },
+                              {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 50
+                              },
+                              {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 100
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 19
+                },
+                "id": 5,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "% of request"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.2.0",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum by (namespace,container) (kube_pod_container_resource_requests{resource=\"cpu\",container!=\"\",container!=\"POD\"})",
+                    "refId": "A",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum by (namespace,container) (avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\",container!=\"POD\"}[5m])[6h:5m]))",
+                    "refId": "B",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "(sum by (namespace,container) (avg_over_time(rate(container_cpu_usage_seconds_total{container!=\"\",container!=\"POD\"}[5m])[6h:5m])) / on(namespace,container) group_left sum by (namespace,container) (kube_pod_container_resource_requests{resource=\"cpu\",container!=\"\",container!=\"POD\"})) * 100",
+                    "refId": "C",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  }
+                ],
+                "title": "CPU: request vs 6h usage by container",
+                "transformations": [
+                  {
+                    "id": "merge",
+                    "options": {}
+                  },
+                  {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "__name__": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Value #A": "Request (cores)",
+                        "Value #B": "Usage avg 6h (cores)",
+                        "Value #C": "% of request"
+                      }
+                    }
+                  }
+                ],
+                "type": "table"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "showPoints": "never",
+                      "spanNulls": true
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 28
+                },
+                "id": 6,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "lastNotNull",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom"
+                  },
+                  "tooltip": {
+                    "mode": "multi"
+                  }
+                },
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\",container!=\"\",container!=\"POD\"})",
+                    "refId": "A",
+                    "format": "time_series",
+                    "instant": false,
+                    "range": true,
+                    "legendFormat": "Requested"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\",container!=\"POD\"}[5m]))",
+                    "refId": "B",
+                    "format": "time_series",
+                    "instant": false,
+                    "range": true,
+                    "legendFormat": "Used"
+                  }
+                ],
+                "title": "Cluster CPU: requested vs used",
+                "type": "timeseries"
+              },
+              {
+                "collapsed": false,
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 36
+                },
+                "id": 7,
+                "panels": [],
+                "title": "Ephemeral storage",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Container-level ephemeral-storage usage as a percentage of its configured limit. Rows with no per-container limit set fall back to a node-level percentage and are not a genuine per-container breach -- cross-check against the container's own resources before acting.",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "color-background",
+                        "mode": "gradient"
+                      },
+                      "filterable": true
+                    },
+                    "unit": "percent",
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(50, 172, 45, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(237, 129, 40, 0.89)",
+                          "value": 70
+                        },
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 37
+                },
+                "id": 8,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "Value"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.2.0",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "expr": "topk(20, ephemeral_storage_container_limit_percentage)",
+                    "refId": "A",
+                    "format": "table",
+                    "instant": true,
+                    "range": false
+                  }
+                ],
+                "title": "Ephemeral-storage: top 20 containers by limit percentage",
+                "type": "table"
+              }
+            ],
+            "refresh": "5m",
+            "schemaVersion": 39,
+            "tags": [
+              "kubernetes",
+              "krr",
+              "capacity"
+            ],
+            "templating": {
+              "list": []
+            },
+            "time": {
+              "from": "now-6h",
+              "to": "now"
+            },
+            "timepicker": {},
+            "timezone": "browser",
+            "title": "Resource Requests vs Usage",
+            "uid": "otaru-resource-requests-vs-usage",
+            "version": 1,
+            "weekStart": ""
+          }


### PR DESCRIPTION
## Summary

- Adds a new Grafana dashboard (`Resource Requests vs Usage`) showing, per container, the configured CPU/memory request against its own 6h average usage, plus a percentage-of-request column so under- and over-provisioned workloads are visible at a glance.
- Adds cluster-wide requested-vs-used timeseries panels for both CPU and memory.
- Adds a table of the top containers by ephemeral-storage limit percentage (metric not covered by KRR).
- Wires the new dashboard values file into the `monitoring` Application's `helm.valueFiles` list in `argocd/manifest.jsonnet`, following the existing pattern for the other dashboard files.

This gives standing visibility into the same signal the `/right-sizing` skill's KRR run looks at, rather than only seeing it when a right-sizing pass happens to run.

## Test plan

- [x] `make test` passes (Helm chart validation, YAML/EditorConfig checks, ArgoCD manifest rendering, image digest check)
- [x] `helm template` with all dashboard value files confirms the new dashboard renders into the Grafana sidecar ConfigMap and mounts at the expected path
- [x] All PromQL expressions in the dashboard verified directly against the live Prometheus instance before being embedded (request/usage/ratio queries for both CPU and memory return sensible per-namespace/container data)
- [ ] Post-merge: confirm the dashboard appears in Grafana and renders real data (will verify after ArgoCD sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JboiWiH98ZjpRz5kYoreUY