### PR TITLE
fix(blocky): stop ambient DNS capture from stealing gateway DNS

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -105,7 +105,9 @@ Traffic entering the cluster follows this path:
 4. the destination node `ztunnel` forwards traffic to the target pod
 
 This applies to TCP and HTTP traffic. UDP listeners can stay on Envoy Gateway,
-but they do not gain Istio mTLS.
+but they do not gain Istio mTLS. The Envoy proxy pods also set
+`ambient.istio.io/dns-capture=false` so ambient DNS capture does not
+intercept Envoy's outbound connections to Blocky on port 53.
 
 ### North-South Path
 

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1390,3 +1390,45 @@ check the release changelog for `#28440`/`#28421` to confirm the fix
 landed before assuming it's resolved.
 
 [argocd-28440]: https://github.com/argoproj/argo-cd/pull/28440
+
+## Ambient DNS Capture Steals Envoy Gateway North-South DNS to Blocky
+
+**Problem:** Blocky pods are healthy and block ads when queried on the pod IP
+from a hostNetwork probe, but digs to the gateway VIP `192.168.10.51:53`
+return real A records for denylisted domains (for example `doubleclick.net`)
+and Blocky's `blocky_query_total` barely moves. Grafana shows almost no
+requests even though clients appear to use the VIP.
+
+**Why it happens:** the `gateway` namespace is ambient-enrolled so Envoy can
+use the mesh path to TCP/HTTP backends. Ambient DNS capture (default from
+Istio 1.25) intercepts **outbound** connections from those Envoy pods to
+destination port 53. Envoy's UDPRoute/TCPRoute still thinks it is proxying
+to `blocky-dns` endpoints, but ztunnel answers the query via the cluster DNS
+path instead of delivering the packet to Blocky. Access logs can show
+`upstream_host` set to a Blocky pod IP with a ~155-byte unblocked answer,
+which is misleading.
+
+**Fingerprint:**
+
+| Path | `doubleclick.net` | `unifi` |
+| ---- | ----------------- | ------ |
+| Blocky pod IP (hostNetwork dig) | `0.0.0.0` | `192.168.10.1` TTL 3600, one answer |
+| VIP while capture is on | real Google IPs | often TTL 5 / two answers / wrong source |
+| VIP after capture is off | `0.0.0.0` | `192.168.10.1` TTL 3600, one answer |
+
+**Resolution:** set `ambient.istio.io/dns-capture: "false"` on the Envoy
+proxy pod template (`EnvoyProxy` → `envoyDeployment.pod.annotations`). Also
+keep the `blocky-dns` Service off the shared waypoint
+(`istio.io/use-waypoint: none`) so plain DNS stays L4 to Blocky endpoints;
+the HTTP `blocky` Service can remain waypoint-bound for DoH/metrics AuthZ.
+
+**Verify after change:**
+
+```shell
+dig @192.168.10.51 doubleclick.net +short   # expect 0.0.0.0
+dig @192.168.10.51 unifi +short             # expect 192.168.10.1
+```
+
+Do not dig Blocky pod IPs from a LAN laptop: `10.42.0.0/16` is not routed
+off-cluster, so those queries time out without saying anything about Blocky
+health.

--- a/helm-charts/blocky/templates/service.yaml
+++ b/helm-charts/blocky/templates/service.yaml
@@ -18,6 +18,11 @@ kind: Service
 metadata:
   name: {{ .Values.name }}-dns
   namespace: {{ .Values.namespace }}
+  labels:
+    # Plain DNS is L4 UDP/TCP, not HTTP. Keep this Service off the shared
+    # waypoint so Envoy's DNS routes hit Blocky endpoints directly instead of
+    # the L7 waypoint path used by the HTTP DoH/metrics Service.
+    istio.io/use-waypoint: none
 spec:
   selector:
     app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/envoy-gateway/README.md
+++ b/helm-charts/envoy-gateway/README.md
@@ -15,6 +15,10 @@ workload and use the mesh path to ambient backends.
 UDP listeners can remain on the same Envoy Gateway, but they still do not gain
 Istio mTLS. This chart change is about the TCP and HTTP ingress path.
 
+The generated Envoy proxy pods set `ambient.istio.io/dns-capture=false`. Without
+that, ambient DNS capture steals Envoy's outbound connections to backend port
+53 and answers via cluster DNS, so Blocky never sees north-south DNS traffic.
+
 The shared ambient waypoint still lives in `istio-waypoints` for east-west L7
 handling. The ingress proxy is ambient-enrolled, but it is not enrolled to use
 that shared waypoint itself.

--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -13,6 +13,12 @@ spec:
           resources:
 {{ toYaml .Values.envoyProxy.resources | indent 12 }}
         pod:
+          # Ambient DNS capture intercepts outbound UDP/TCP 53 from the proxy
+          # and answers via cluster DNS, so Envoy's DNS UDPRoute/TCPRoute never
+          # reaches blocky. Opt the proxy pods out so north-south DNS on :53 is
+          # plain-proxied to blocky-dns.
+          annotations:
+            ambient.istio.io/dns-capture: "false"
           affinity:
 {{ toYaml .Values.envoyProxy.affinity | indent 12 }}
         # Envoy Gateway v1.8 has no first-class field for the


### PR DESCRIPTION
## Summary

- Disable ambient DNS capture on Envoy Gateway proxy pods so north-south DNS on `192.168.10.51:53` is plain-proxied to Blocky instead of answered by ztunnel/cluster DNS.
- Label `blocky-dns` with `istio.io/use-waypoint: none` so plain DNS stays L4 to Blocky endpoints (HTTP DoH/metrics Service remains waypoint-bound).
- Document the failure mode in `documentation/gotcha.md` and connectivity notes.

## Root cause

Gateway pods are ambient-enrolled. Ambient DNS capture intercepts Envoy outbound connections to destination port 53. Envoy access logs still showed Blocky pod IPs as `upstream_host`, but answers were unblocked cluster-DNS style and Blocky metrics did not move.

Live verification after `ambient.istio.io/dns-capture=false` on the Envoy pod template:

- `dig @192.168.10.51 doubleclick.net` → `0.0.0.0`
- `dig @192.168.10.51 unifi` → `192.168.10.1` TTL 3600
- Blocky metrics incremented from the gateway pod IP

## Test plan

- [x] `make test`
- [x] Live VIP dig before/after dns-capture annotation
- [ ] After merge/Argo sync: re-check VIP digs and Grafana Blocky dashboard query rate