### PR TITLE
docs: fix Blocky ambient DNS gotcha formatting

### DIFF
--- a/documentation/connectivity.md
+++ b/documentation/connectivity.md
@@ -105,9 +105,11 @@ Traffic entering the cluster follows this path:
 4. the destination node `ztunnel` forwards traffic to the target pod
 
 This applies to TCP and HTTP traffic. UDP listeners can stay on Envoy Gateway,
-but they do not gain Istio mTLS. The Envoy proxy pods also set
-`ambient.istio.io/dns-capture=false` so ambient DNS capture does not
-intercept Envoy's outbound connections to Blocky on port 53.
+but they do not gain Istio mTLS.
+
+The Envoy proxy pods also set `ambient.istio.io/dns-capture=false` so ambient
+DNS capture does not intercept Envoy's outbound connections to Blocky on
+port 53.
 
 ### North-South Path
 

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1412,11 +1412,11 @@ which is misleading.
 
 ### Symptoms: VIP Answers Without Hitting Blocky
 
-| Path | `doubleclick.net` | `unifi` |
-| ---- | ----------------- | ------ |
-| Blocky pod IP (hostNetwork dig) | `0.0.0.0` | `192.168.10.1` (TTL 3600, one answer) |
-| VIP while capture is on | real Google IPs | often TTL 5, two answers, or wrong source |
-| VIP after capture is off | `0.0.0.0` | `192.168.10.1` (TTL 3600, one answer) |
+| Path                            | `doubleclick.net` | `unifi`                                   |
+| ------------------------------- | ----------------- | ----------------------------------------- |
+| Blocky pod IP (hostNetwork dig) | `0.0.0.0`         | `192.168.10.1` (TTL 3600, one answer)     |
+| VIP while capture is on         | real Google IPs   | often TTL 5, two answers, or wrong source |
+| VIP after capture is off        | `0.0.0.0`         | `192.168.10.1` (TTL 3600, one answer)     |
 
 ### Resolution: Disable DNS Capture on Envoy Proxy Pods
 

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1391,6 +1391,8 @@ landed before assuming it's resolved.
 
 [argocd-28440]: https://github.com/argoproj/argo-cd/pull/28440
 
+---
+
 ## Ambient DNS Capture Steals Envoy Gateway North-South DNS to Blocky
 
 **Problem:** Blocky pods are healthy and block ads when queried on the pod IP
@@ -1408,21 +1410,23 @@ path instead of delivering the packet to Blocky. Access logs can show
 `upstream_host` set to a Blocky pod IP with a ~155-byte unblocked answer,
 which is misleading.
 
-**Fingerprint:**
+### Symptoms: VIP Answers Without Hitting Blocky
 
 | Path | `doubleclick.net` | `unifi` |
 | ---- | ----------------- | ------ |
-| Blocky pod IP (hostNetwork dig) | `0.0.0.0` | `192.168.10.1` TTL 3600, one answer |
-| VIP while capture is on | real Google IPs | often TTL 5 / two answers / wrong source |
-| VIP after capture is off | `0.0.0.0` | `192.168.10.1` TTL 3600, one answer |
+| Blocky pod IP (hostNetwork dig) | `0.0.0.0` | `192.168.10.1` (TTL 3600, one answer) |
+| VIP while capture is on | real Google IPs | often TTL 5, two answers, or wrong source |
+| VIP after capture is off | `0.0.0.0` | `192.168.10.1` (TTL 3600, one answer) |
 
-**Resolution:** set `ambient.istio.io/dns-capture: "false"` on the Envoy
-proxy pod template (`EnvoyProxy` → `envoyDeployment.pod.annotations`). Also
-keep the `blocky-dns` Service off the shared waypoint
-(`istio.io/use-waypoint: none`) so plain DNS stays L4 to Blocky endpoints;
-the HTTP `blocky` Service can remain waypoint-bound for DoH/metrics AuthZ.
+### Resolution: Disable DNS Capture on Envoy Proxy Pods
 
-**Verify after change:**
+Set `ambient.istio.io/dns-capture: "false"` on the Envoy proxy pod template
+(`EnvoyProxy` → `envoyDeployment.pod.annotations`). Also keep the
+`blocky-dns` Service off the shared waypoint (`istio.io/use-waypoint: none`)
+so plain DNS stays L4 to Blocky endpoints. The HTTP `blocky` Service can
+remain waypoint-bound for DoH/metrics AuthZ.
+
+Verify after change:
 
 ```shell
 dig @192.168.10.51 doubleclick.net +short   # expect 0.0.0.0
@@ -1432,3 +1436,5 @@ dig @192.168.10.51 unifi +short             # expect 192.168.10.1
 Do not dig Blocky pod IPs from a LAN laptop: `10.42.0.0/16` is not routed
 off-cluster, so those queries time out without saying anything about Blocky
 health.
+
+---

--- a/helm-charts/envoy-gateway/README.md
+++ b/helm-charts/envoy-gateway/README.md
@@ -15,9 +15,10 @@ workload and use the mesh path to ambient backends.
 UDP listeners can remain on the same Envoy Gateway, but they still do not gain
 Istio mTLS. This chart change is about the TCP and HTTP ingress path.
 
-The generated Envoy proxy pods set `ambient.istio.io/dns-capture=false`. Without
-that, ambient DNS capture steals Envoy's outbound connections to backend port
-53 and answers via cluster DNS, so Blocky never sees north-south DNS traffic.
+The generated Envoy proxy pods set `ambient.istio.io/dns-capture=false`.
+Without that annotation, ambient DNS capture steals Envoy's outbound
+connections to backend port 53 and answers via cluster DNS, so Blocky never
+sees north-south DNS traffic.
 
 The shared ambient waypoint still lives in `istio-waypoints` for east-west L7
 handling. The ingress proxy is ambient-enrolled, but it is not enrolled to use


### PR DESCRIPTION
## Summary

- Restructure the ambient DNS capture gotcha with `### Symptoms` / `### Resolution` and `---` separators so it matches the rest of `documentation/gotcha.md`.
- Minor connectivity + envoy-gateway README wording/EOF cleanups.

## Test plan

- [x] `make test` (markdownlint clean)