### PR TITLE
fix(monitoring): remove non-functional Blocky blocking buttons

### DIFF
--- a/helm-charts/monitoring/dashboards/blocky.yaml
+++ b/helm-charts/monitoring/dashboards/blocky.yaml
@@ -213,45 +213,10 @@ grafana:
               },
               {
                 "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Enable Ad disable blocking",
-                "gridPos": {
-                  "h": 5,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-                },
-                "id": 42,
-                "options": {
-                  "code": {
-                    "language": "plaintext",
-                    "showLineNumbers": false,
-                    "showMiniMap": false
-                  },
-                  "content": "<style>\n\n.blocky_btn {\n    border: none;\n  cursor: pointer; \n    padding: 12px;\n  font-size: 16px;\n  min-width: 100px\n}\n\n.blocky_greenbtn { \n  background-color: #4CAF50;\n  color: white;\n}\n\n.blocky_redbtn { \n  background-color: #AF504C;\n  color: white;\n}\n\n\n.blocky_alert {\n  font-size: 14px\n}\n</style>\n<div class=\"blocky_alert blocky_alert-warning fade in\">\n  <a href=\"#\" class=\"close\" data-dismiss=\"blocky_alert\" aria-label=\"close\" style=\"text-decoration:none\">&times;</a>Done!\n</div>\n<div>\n   <button class=\"blocky_btn blocky_greenbtn\" onclick=\"blocky_status_enable()\">On</button>\n   <button class=\"blocky_btn blocky_redbtn\" onclick=\"blocky_status_disable5m()\">Off 5m</button>\n   <button class=\"blocky_btn blocky_redbtn\" onclick=\"blocky_status_disable30m()\">Off 30m</button>\n<div>\n\n\n<script type=\"text/javascript\">\n\nfunction blocky_status_disable() {\n  blocky_status_switch(false, 0)\n}\n\nfunction blocky_status_disable5m() {\n  blocky_status_switch(false, 5*60)\n}\n\nfunction blocky_status_disable30m() {\n  blocky_status_switch(false, 30*60)\n}\n\nfunction blocky_status_enable() {\n  blocky_status_switch(true, 0)\n}\n\nfunction blocky_status_switch(enable, duration) {\n  var url = '$blocky_url';\n  op = enable ? 'enable' : 'disable?duration='+duration+\"s\"\n  \n  $.get(url + '/api/blocking/'+op, function(data) {\n    showAlert()\n  })\n}\n\nvar showAlert = function() {\n\t// first show the alert\n  $('.blocky_alert').show().fadeTo(500, 1);\n  \n  // Now set a timeout to hide it\n  window.setTimeout(function() {\n    $(\".blocky_alert\").fadeTo(500, 0).slideUp(500, function() {\n      $(this).hide();\n    });\n  }, 3000);\n}\n\n// start with the alert hidden\n$('.blocky_alert').hide();\n\n</script>",
-                  "mode": "html"
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "refId": "A"
-                  }
-                ],
-                "title": "Blocking status",
-                "transparent": true,
-                "type": "text"
-              },
-              {
-                "datasource": {
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "Blocky [version](https://github.com/0xERR0R/blocky) number",
-                "fieldConfig": {
+                "description": "Blocky [version](https://github.com/0xERR0R/blocky) number",                "fieldConfig": {
                   "defaults": {
                     "mappings": [],
                     "thresholds": {
@@ -2040,14 +2005,6 @@ grafana:
             "templating": {
               "list": [
                 {
-                  "hide": 2,
-                  "label": "blocky API URL",
-                  "name": "blocky_url",
-                  "query": "blocky.blocky.svc.cluster.local",
-                  "skipUrlSync": false,
-                  "type": "constant"
-                },
-                {
                   "current": {
                     "selected": false,
                     "text": "All",
@@ -2098,6 +2055,6 @@ grafana:
             "timezone": "",
             "title": "blocky",
             "uid": "JvOqE4gRk",
-            "version": 7,
+            "version": 8,
             "weekStart": ""
           }


### PR DESCRIPTION
## Summary

- Remove the Grafana **Blocking status** HTML panel (On / Off 5m / Off 30m).
- Remove unused `blocky_url` dashboard variable.

Those buttons ran browser-side jQuery against `blocky.blocky.svc.cluster.local` and the blocking REST API is not exposed on the ingress, so they never worked here. Keep the Prometheus **Blocking** stat panel for status.

## Test plan

- [x] `make test`
- [ ] After Argo sync + Grafana remount/restart, dashboard no longer shows the button panel