### PR TITLE
refactor(monitoring): rework Blocky dashboard and document Grafana subPath gotcha

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1438,3 +1438,62 @@ off-cluster, so those queries time out without saying anything about Blocky
 health.
 
 ---
+
+## ArgoCD Reports Synced at the Right Revision While a subPath-Mounted ConfigMap Key Is Still Missing
+
+**Problem:** after merging a PR that added a new Grafana dashboard (a new
+key under `grafana.dashboards.default` in the `monitoring` chart), the
+`monitoring` Application showed `Synced`/`Healthy` at exactly the merge
+commit's revision within a few minutes, yet the live
+`monitoring-grafana-dashboards-default` ConfigMap was still missing the
+new dashboard's JSON key entirely -- not stale content, the key was
+absent.
+
+**Why it happens:** this is the same "sync revision lags the merge by
+tens of seconds to a couple of minutes" pattern already seen with
+`argocd-repo-server` rollouts elsewhere in this cluster, but here it is
+easy to miss because `status.sync.revision` matching the new commit
+looks like solid proof of a real sync -- it is not, on its own. A stale
+in-flight sync (started against an older revision) can still finish and
+report the newer revision string once the reconciler catches up to
+`HEAD` for status-reporting purposes, without that particular apply pass
+having actually re-rendered every resource against the new manifests.
+
+**Symptoms:**
+
+- `kubectl get application <name> -o jsonpath='{.status.sync.revision}'`
+  matches the exact merge commit, `status.sync.status` is `Synced`,
+  `status.health.status` is `Healthy`.
+- A specific resource (here, a ConfigMap key) that the new commit added
+  is nonetheless absent from the live object.
+- No error, no `OutOfSync` state, nothing to alert on -- looks fully
+  healthy from a status/health check alone.
+
+**Resolution:** don't trust `status.sync.revision` alone as proof a
+specific new resource/field landed -- diff the specific resource
+directly, or force a hard refresh and re-check:
+
+```shell
+kubectl annotate application <name> -n argocd \
+  argocd.argoproj.io/refresh=hard --overwrite
+```
+
+Poll until the `argocd.argoproj.io/refresh` annotation clears (ArgoCD
+removes it once the refresh completes), then re-check the resource. In
+this case the hard refresh immediately produced the missing ConfigMap
+key, and a fresh Grafana pod picked it up.
+
+**Related gotcha:** the Grafana `dashboards.default` mechanism mounts
+each dashboard JSON key as an individual `subPath` volume mount (one
+`volumeMounts` entry per dashboard file, not a whole-directory mount).
+Kubernetes does **not** live-update `subPath` mounts when the backing
+ConfigMap changes -- kubelet's ConfigMap-to-file sync relies on a
+symlink swap that `subPath` bypasses entirely. So even after the
+ConfigMap itself is correct, an already-running Grafana pod will keep
+serving the old file contents (or lack a key entirely) until the pod is
+recreated. Dashboards added via `gnetId` (downloaded by the chart's
+`download-dashboards` init container at pod start, not mounted from a
+ConfigMap) are unaffected by this specific quirk, but do depend on the
+init container running again, i.e. also a pod restart.
+
+---

--- a/helm-charts/monitoring/dashboards/blocky.yaml
+++ b/helm-charts/monitoring/dashboards/blocky.yaml
@@ -28,9 +28,7 @@ grafana:
             },
             "editable": true,
             "fiscalYearStartMonth": 0,
-            "gnetId": 13768,
-            "graphTooltip": 0,
-            "id": 2,
+            "graphTooltip": 1,
             "links": [
               {
                 "icon": "external link",
@@ -44,605 +42,63 @@ grafana:
             "liveNow": false,
             "panels": [
               {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "current service state",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [
-                      {
-                        "options": {
-                          "0": {
-                            "text": "down"
-                          },
-                          "1": {
-                            "text": "up"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "#d44a3a",
-                          "value": null
-                        },
-                        {
-                          "color": "rgba(237, 129, 40, 0.89)",
-                          "value": 1
-                        },
-                        {
-                          "color": "#299c46",
-                          "value": 1
-                        }
-                      ]
-                    },
-                    "unit": "none"
-                  },
-                  "overrides": []
-                },
-                "id": 26,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "none",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": false,
-                    "expr": "count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "State",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Is blocking enabled?",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [
-                      {
-                        "options": {
-                          "0": {
-                            "text": "off"
-                          },
-                          "1": {
-                            "text": "on"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "#d44a3a",
-                          "value": null
-                        },
-                        {
-                          "color": "rgba(237, 129, 40, 0.89)",
-                          "value": 1
-                        },
-                        {
-                          "color": "#299c46",
-                          "value": 1
-                        }
-                      ]
-                    },
-                    "unit": "none"
-                  },
-                  "overrides": []
-                },
+                "collapsed": false,
                 "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 6,
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
                   "y": 0
                 },
-                "id": 43,
-                "maxDataPoints": 100,
+                "id": 1,
+                "panels": [],
+                "title": "Overview",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Blocky pods reporting metrics",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 1
+                        },
+                        {
+                          "color": "green",
+                          "value": 2
+                        }
+                      ]
+                    },
+                    "unit": "none"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 0,
+                  "y": 1
+                },
+                "id": 2,
                 "options": {
                   "colorMode": "value",
                   "graphMode": "none",
                   "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "value",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": false,
-                    "expr": "blocky_blocking_enabled",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Blocking",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Blocky [version](https://github.com/0xERR0R/blocky) number",                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 0,
-                  "y": 3
-                },
-                "id": 55,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "center",
                   "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "/^version$/",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "repeatDirection": "v",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": false,
-                    "expr": "blocky_build_info ",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Version",
-                "transformations": [
-                  {
-                    "id": "labelsToFields",
-                    "options": {}
-                  },
-                  {
-                    "id": "merge",
-                    "options": {}
-                  }
-                ],
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Average query response time for all query types",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 0.08
-                        }
-                      ]
-                    },
-                    "unit": "s"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 6,
-                  "y": 3
-                },
-                "id": 24,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_request_duration_seconds_sum[$__range])) / sum(increase(blocky_request_duration_seconds_count[$__range]))",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Avg response time",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Number of denylist entries",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "none"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 12,
-                  "y": 5
-                },
-                "id": 30,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(blocky_denylist_cache_entries) / count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Denylist entries total",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Time since last list refresh",
-                "fieldConfig": {
-                  "defaults": {
-                    "decimals": 0,
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "s"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 18,
-                  "y": 5
-                },
-                "id": 57,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": false,
-                    "expr": "sum(time() -blocky_last_list_group_refresh_timestamp_seconds)/ count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Last list refresh",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Number of all queries. Shows the last value",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "none"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 0,
-                  "y": 6
-                },
-                "hideTimeOverride": true,
-                "id": 4,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "ceil(sum(increase(blocky_query_total[$__range]))) ",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Query Count Total",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "default": true,
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Percentage of blocked queries",
-                "fieldConfig": {
-                  "defaults": {
-                    "decimals": 2,
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "max": 1,
-                    "min": 0,
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    },
-                    "unit": "percentunit"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 6,
-                  "y": 6
-                },
-                "id": 34,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
                   "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
@@ -663,573 +119,14 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_response_total{response_type=\"BLOCKED\"}[$__range])) / sum(increase(blocky_query_total[$__range])) ",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
+                    "expr": "count(blocky_blocking_enabled{job=~\"$job\"})",
                     "legendFormat": "",
-                    "refId": "A"
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
                   }
                 ],
-                "title": "Queries blocked",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Number of entries in the cache. Shows the last value",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 12,
-                  "y": 8
-                },
-                "id": 45,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "last"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(blocky_cache_entries)/ count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Cache entries count",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Cache Hit/Miss ratio. 100 % means, all queries could be answered from the cache, 0% - all queries must be resolved via external DNS",
-                "fieldConfig": {
-                  "defaults": {
-                    "color": {
-                      "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "max": 1,
-                    "min": 0,
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "percentunit"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 18,
-                  "y": 8
-                },
-                "id": 47,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "mean"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_cache_hits_total[$__range])) / (sum(increase(blocky_cache_hits_total[$__range])) + sum(increase(blocky_cache_misses_total[$__range])))",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Cache Hit/Miss ratio",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Amount of performed DNS queries to prefetch cached queries",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 0,
-                  "y": 9
-                },
-                "id": 53,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "ceil(sum(increase(blocky_prefetches_total[$__range])))",
-                    "format": "table",
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Prefetch count",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Amount of unique domains in the prefetched cache",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 6,
-                  "y": 9
-                },
-                "id": 49,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(blocky_prefetch_domain_name_cache_entries)/ count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Prefetch domain count",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Amount of prefetch queries per minute",
-                "fieldConfig": {
-                  "defaults": {
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    }
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 12,
-                  "y": 11
-                },
-                "id": 51,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(rate(blocky_prefetches_total[5m])) * 60",
-                    "format": "table",
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Prefetch rate per min",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "How many of cached entries were prefetched automatically",
-                "fieldConfig": {
-                  "defaults": {
-                    "color": {
-                      "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "max": 1,
-                    "min": 0,
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "percentunit"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 18,
-                  "y": 11
-                },
-                "id": 58,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "mean"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_prefetch_hits_total[$__range])) / (sum(increase(blocky_cache_hits_total[$__range])))",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Prefetch Hit ratio",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "description": "Number of occured errors",
-                "fieldConfig": {
-                  "defaults": {
-                    "decimals": 0,
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "#299c46",
-                          "value": null
-                        },
-                        {
-                          "color": "rgba(237, 129, 40, 0.89)",
-                          "value": 1
-                        },
-                        {
-                          "color": "#d44a3a"
-                        }
-                      ]
-                    },
-                    "unit": "short"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 0,
-                  "y": 12
-                },
-                "id": 36,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_error_total[$__range]))",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Error count",
-                "transparent": true,
-                "type": "stat"
-              },
-              {
-                "datasource": {
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "fieldConfig": {
-                  "defaults": {
-                    "decimals": 2,
-                    "mappings": [
-                      {
-                        "options": {
-                          "match": "null",
-                          "result": {
-                            "text": "N/A"
-                          }
-                        },
-                        "type": "special"
-                      }
-                    ],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        }
-                      ]
-                    },
-                    "unit": "bytes"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 6,
-                  "y": 12
-                },
-                "id": 28,
-                "maxDataPoints": 100,
-                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "horizontal",
-                  "percentChangeColorMode": "standard",
-                  "reduceOptions": {
-                    "calcs": [
-                      "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "showPercentChange": false,
-                  "textMode": "auto",
-                  "wideLayout": true
-                },
-                "pluginVersion": "11.2.1",
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": true,
-                    "expr": "sum(go_memstats_sys_bytes{job=~\"$job\",namespace=\"blocky\"})/count(blocky_blocking_enabled{job=~\"$job\"})",
-                    "format": "table",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Memory allocated",
+                "title": "Replicas",
                 "transparent": true,
                 "type": "stat"
               },
@@ -1238,19 +135,1080 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "1 only if all replicas have blocking enabled",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "0": {
+                            "text": "off",
+                            "color": "red"
+                          },
+                          "1": {
+                            "text": "on",
+                            "color": "green"
+                          }
+                        }
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "green",
+                          "value": 1
+                        }
+                      ]
+                    },
+                    "unit": "none"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 6,
+                  "y": 1
+                },
+                "id": 3,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "min(blocky_blocking_enabled{job=~\"$job\"})",
+                    "legendFormat": "",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Blocking",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Blocky build version",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "none"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 12,
+                  "y": 1
+                },
+                "id": 4,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "name",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "max by (version) (blocky_build_info{job=~\"$job\"})",
+                    "legendFormat": "{{version}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Version",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Sum of process RSS across Blocky pods (limit 512Mi each)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "bytes",
+                    "decimals": 1
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 18,
+                  "y": 1
+                },
+                "id": 5,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(process_resident_memory_bytes{job=~\"$job\",namespace=\"blocky\"})",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Memory (RSS)",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 4
+                },
+                "id": 6,
+                "panels": [],
+                "title": "Traffic (dashboard range)",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Total DNS queries in the selected time range",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 0
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 0,
+                  "y": 5
+                },
+                "id": 7,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "ceil(sum(increase(blocky_query_total{job=~\"$job\"}[$__range])))",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Queries",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Share of queries answered as BLOCKED",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.05
+                        },
+                        {
+                          "color": "orange",
+                          "value": 0.2
+                        }
+                      ]
+                    },
+                    "unit": "percentunit",
+                    "decimals": 2
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 6,
+                  "y": 5
+                },
+                "id": 8,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_response_total{job=~\"$job\",response_type=\"BLOCKED\"}[$__range])) / clamp_min(sum(increase(blocky_query_total{job=~\"$job\"}[$__range])), 1)",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Blocked",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Resolver cache hits / (hits + misses)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 0.5
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.8
+                        }
+                      ]
+                    },
+                    "unit": "percentunit",
+                    "decimals": 2
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 12,
+                  "y": 5
+                },
+                "id": 9,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_cache_hits_total{job=~\"$job\"}[$__range])) / clamp_min(sum(increase(blocky_cache_hits_total{job=~\"$job\"}[$__range])) + sum(increase(blocky_cache_misses_total{job=~\"$job\"}[$__range])), 1)",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Cache hit ratio",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Mean request duration across all response types",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 0.05
+                        },
+                        {
+                          "color": "red",
+                          "value": 0.2
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 3
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 18,
+                  "y": 5
+                },
+                "id": 10,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_request_duration_seconds_sum{job=~\"$job\"}[$__range])) / clamp_min(sum(increase(blocky_request_duration_seconds_count{job=~\"$job\"}[$__range])), 1)",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Avg latency",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 8
+                },
+                "id": 11,
+                "panels": [],
+                "title": "Denylists & reliability",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Denylist entries per replica (averaged)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 0
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 0,
+                  "y": 9
+                },
+                "id": 12,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(blocky_denylist_cache_entries{job=~\"$job\"}) / clamp_min(count(blocky_blocking_enabled{job=~\"$job\"}), 1)",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Denylist entries",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Age of oldest denylist group refresh across replicas",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 86400
+                        },
+                        {
+                          "color": "red",
+                          "value": 172800
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 0
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 6,
+                  "y": 9
+                },
+                "id": 13,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(time() - blocky_last_list_group_refresh_timestamp_seconds{job=~\"$job\"})",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "List age",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Denylist/source download failures in range (was missing from old dashboard)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 1
+                        },
+                        {
+                          "color": "red",
+                          "value": 10
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 0
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 12,
+                  "y": 9
+                },
+                "id": 14,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_failed_downloads_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Failed downloads",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Blocky error counter increase in range",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 1
+                        },
+                        {
+                          "color": "red",
+                          "value": 5
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 0
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 3,
+                  "w": 6,
+                  "x": 18,
+                  "y": 9
+                },
+                "id": 15,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_error_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Errors",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 12
+                },
+                "id": 16,
+                "panels": [],
+                "title": "Rates",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "DNS queries per minute",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
                       "mode": "palette-classic"
                     },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
                       "axisCenteredZero": false,
                       "axisColorMode": "text",
-                      "axisLabel": "avg requests / min",
+                      "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
-                      "barWidthFactor": 0.6,
+                      "drawStyle": "line",
+                      "fillOpacity": 20,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 7,
+                  "w": 12,
+                  "x": 0,
+                  "y": 13
+                },
+                "id": 17,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(blocky_query_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "queries/min",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Query rate",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Responses/min stacked by response_type",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 40,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 7,
+                  "w": 12,
+                  "x": 12,
+                  "y": 13
+                },
+                "id": 18,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (response_type) (rate(blocky_response_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "{{response_type}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Responses by type",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Mean latency per response_type (RESOLVED ≈ upstream DoH)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 3,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
                       "drawStyle": "line",
                       "fillOpacity": 10,
                       "gradientMode": "none",
@@ -1260,14 +1218,14 @@ grafana:
                         "viz": false
                       },
                       "insertNulls": false,
-                      "lineInterpolation": "linear",
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
                       "showPoints": "never",
-                      "spanNulls": true,
+                      "spanNulls": false,
                       "stacking": {
                         "group": "A",
                         "mode": "none"
@@ -1275,62 +1233,47 @@ grafana:
                       "thresholdsStyle": {
                         "mode": "off"
                       }
-                    },
-                    "links": [],
-                    "mappings": [],
-                    "thresholds": {
-                      "mode": "absolute",
-                      "steps": [
-                        {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
-                        }
-                      ]
-                    },
-                    "unit": "short"
+                    }
                   },
                   "overrides": []
                 },
                 "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 15
+                  "y": 20
                 },
-                "id": 10,
+                "id": 19,
                 "options": {
                   "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
                     "placement": "bottom",
-                    "showLegend": false
+                    "showLegend": true
                   },
                   "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
+                    "mode": "multi",
+                    "sort": "desc"
                   }
                 },
-                "pluginVersion": "8.3.3",
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": true,
-                    "expr": "sum(rate(blocky_query_total[5m])) * 60",
-                    "format": "time_series",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": " ",
+                    "editorMode": "code",
+                    "expr": "sum by (response_type) (rate(blocky_request_duration_seconds_sum{job=~\"$job\"}[5m])) / clamp_min(sum by (response_type) (rate(blocky_request_duration_seconds_count{job=~\"$job\"}[5m])), 1e-9)",
+                    "legendFormat": "{{response_type}}",
+                    "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "Request rate",
+                "title": "Latency by response type",
                 "transparent": true,
                 "type": "timeseries"
               },
@@ -1339,21 +1282,33 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Resolver cache activity",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
                       "mode": "palette-classic"
                     },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
                       "axisCenteredZero": false,
                       "axisColorMode": "text",
-                      "axisLabel": "avg requests / min",
+                      "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
-                      "barWidthFactor": 0.6,
-                      "drawStyle": "bars",
-                      "fillOpacity": 100,
+                      "drawStyle": "line",
+                      "fillOpacity": 15,
                       "gradientMode": "none",
                       "hideFrom": {
                         "legend": false,
@@ -1361,14 +1316,14 @@ grafana:
                         "viz": false
                       },
                       "insertNulls": false,
-                      "lineInterpolation": "linear",
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
                       "showPoints": "never",
-                      "spanNulls": true,
+                      "spanNulls": false,
                       "stacking": {
                         "group": "A",
                         "mode": "none"
@@ -1376,8 +1331,72 @@ grafana:
                       "thresholdsStyle": {
                         "mode": "off"
                       }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 7,
+                  "w": 12,
+                  "x": 12,
+                  "y": 20
+                },
+                "id": 20,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
                     },
-                    "links": [],
+                    "editorMode": "code",
+                    "expr": "sum(rate(blocky_cache_hits_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "hits/min",
+                    "range": true,
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(blocky_cache_misses_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "misses/min",
+                    "range": true,
+                    "refId": "B"
+                  }
+                ],
+                "title": "Cache hits vs misses",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Queries/min by client IP (as seen by Blocky)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
                     "mappings": [],
                     "thresholds": {
                       "mode": "absolute",
@@ -1385,70 +1404,215 @@ grafana:
                         {
                           "color": "green",
                           "value": null
-                        },
-                        {
-                          "color": "red",
-                          "value": 80
                         }
                       ]
                     },
-                    "unit": "short"
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 10,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
                   },
                   "overrides": []
                 },
                 "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 22
+                  "y": 27
                 },
-                "id": 52,
+                "id": 21,
                 "options": {
                   "legend": {
-                    "calcs": [],
-                    "displayMode": "list",
+                    "calcs": [
+                      "mean",
+                      "max",
+                      "sum"
+                    ],
+                    "displayMode": "table",
                     "placement": "bottom",
                     "showLegend": true
                   },
                   "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
+                    "mode": "multi",
+                    "sort": "desc"
                   }
                 },
-                "pluginVersion": "8.3.3",
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": true,
-                    "expr": "sum by (client) (rate(blocky_query_total[5m])) * 60",
-                    "format": "time_series",
-                    "instant": false,
-                    "interval": "",
-                    "legendFormat": " {{client}}",
+                    "editorMode": "code",
+                    "expr": "sum by (client) (rate(blocky_query_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "{{client}}",
+                    "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "Request rate per client",
+                "title": "Query rate by client",
                 "transparent": true,
                 "type": "timeseries"
               },
               {
-                "cards": {},
-                "color": {
-                  "cardColor": "#FADE2A",
-                  "colorScale": "sqrt",
-                  "colorScheme": "interpolateYlOrBr",
-                  "exponent": 0.5,
-                  "mode": "opacity"
-                },
-                "dataFormat": "tsbuckets",
                 "datasource": {
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Error and denylist download failure rates",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 3,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 15,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 7,
+                  "w": 12,
+                  "x": 12,
+                  "y": 27
+                },
+                "id": 22,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(blocky_error_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "errors/min",
+                    "range": true,
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(blocky_failed_downloads_total{job=~\"$job\"}[5m])) * 60",
+                    "legendFormat": "failed downloads/min",
+                    "range": true,
+                    "refId": "B"
+                  }
+                ],
+                "title": "Failures",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 34
+                },
+                "id": 23,
+                "panels": [],
+                "title": "Upstream latency distribution",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Histogram of upstream resolve latency (response_type=RESOLVED)",
                 "fieldConfig": {
                   "defaults": {
                     "custom": {
@@ -1465,37 +1629,29 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 9,
+                  "h": 8,
                   "w": 24,
                   "x": 0,
-                  "y": 29
+                  "y": 35
                 },
-                "heatmap": {},
-                "hideZeroBuckets": false,
-                "highlightCards": true,
-                "id": 22,
-                "legend": {
-                  "show": true
-                },
+                "id": 24,
                 "options": {
                   "calculate": false,
-                  "calculation": {},
-                  "cellGap": 2,
-                  "cellValues": {},
+                  "cellGap": 1,
                   "color": {
                     "exponent": 0.5,
-                    "fill": "#FADE2A",
-                    "mode": "opacity",
+                    "fill": "dark-orange",
+                    "mode": "scheme",
                     "reverse": false,
                     "scale": "exponential",
                     "scheme": "Oranges",
-                    "steps": 128
+                    "steps": 64
                   },
                   "exemplars": {
                     "color": "rgba(255,0,255,0.7)"
                   },
                   "filterValues": {
-                    "le": 1e-9
+                    "le": 1e-09
                   },
                   "legend": {
                     "show": true
@@ -1503,7 +1659,6 @@ grafana:
                   "rowsFrame": {
                     "layout": "auto"
                   },
-                  "showValue": "never",
                   "tooltip": {
                     "mode": "single",
                     "showColorScale": false,
@@ -1516,57 +1671,48 @@ grafana:
                   }
                 },
                 "pluginVersion": "11.2.1",
-                "reverseYBuckets": false,
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": true,
-                    "expr": "sum(increase(blocky_request_duration_seconds_bucket{response_type=\"RESOLVED\"}[$__range])) by (le)",
+                    "editorMode": "code",
+                    "expr": "sum(increase(blocky_request_duration_seconds_bucket{job=~\"$job\",response_type=\"RESOLVED\"}[$__rate_interval])) by (le)",
                     "format": "heatmap",
-                    "instant": false,
-                    "interval": "",
                     "legendFormat": "{{le}}",
+                    "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "request duration (upstream)",
-                "tooltip": {
-                  "show": true,
-                  "showHistogram": false
-                },
+                "title": "RESOLVED duration heatmap",
                 "transparent": true,
-                "type": "heatmap",
-                "xAxis": {
-                  "show": true
+                "type": "heatmap"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 43
                 },
-                "yAxis": {
-                  "format": "ms",
-                  "logBase": 1,
-                  "show": true
-                },
-                "yBucketBound": "auto"
+                "id": 25,
+                "panels": [],
+                "title": "Breakdown (dashboard range)",
+                "type": "row"
               },
               {
                 "datasource": {
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Query RR types in range",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
                       "mode": "palette-classic"
                     },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
-                    },
-                    "decimals": 0,
                     "mappings": [],
                     "unit": "short"
                   },
@@ -1574,15 +1720,17 @@ grafana:
                 },
                 "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
-                  "y": 38
+                  "y": 44
                 },
-                "id": 2,
-                "maxDataPoints": 3,
+                "id": 26,
                 "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
                   "legend": {
-                    "calcs": [],
                     "displayMode": "table",
                     "placement": "right",
                     "showLegend": true,
@@ -1594,7 +1742,7 @@ grafana:
                   "pieType": "donut",
                   "reduceOptions": {
                     "calcs": [
-                      "sum"
+                      "lastNotNull"
                     ],
                     "fields": "",
                     "values": false
@@ -1604,23 +1752,22 @@ grafana:
                     "sort": "none"
                   }
                 },
-                "pluginVersion": "6.6.2",
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": false,
-                    "expr": " sort_desc(sum by (type) (ceil(increase(blocky_query_total[$__range]))))",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{ type }}",
-                    "refId": "A"
+                    "editorMode": "code",
+                    "expr": "sum by (type) (increase(blocky_query_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "{{type}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
                   }
                 ],
-                "title": "Query by type",
+                "title": "Query type",
                 "transparent": true,
                 "type": "piechart"
               },
@@ -1629,19 +1776,219 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
                       "mode": "palette-classic"
                     },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
+                    "mappings": [],
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 44
+                },
+                "id": 27,
+                "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
+                  "legend": {
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "values": [
+                      "value",
+                      "percent"
+                    ]
+                  },
+                  "pieType": "donut",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
                     },
-                    "decimals": 0,
+                    "editorMode": "code",
+                    "expr": "sum by (response_type) (increase(blocky_response_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "{{response_type}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Response type",
+                "transparent": true,
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 44
+                },
+                "id": 28,
+                "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
+                  "legend": {
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "values": [
+                      "value",
+                      "percent"
+                    ]
+                  },
+                  "pieType": "donut",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (response_code) (increase(blocky_response_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "{{response_code}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Response code",
+                "transparent": true,
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Includes upstream DoH endpoints and block groups",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 52
+                },
+                "id": 29,
+                "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
+                  "legend": {
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "values": [
+                      "value",
+                      "percent"
+                    ]
+                  },
+                  "pieType": "donut",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (reason) (increase(blocky_response_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "{{reason}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Response reason",
+                "transparent": true,
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
                     "mappings": [],
                     "unit": "short"
                   },
@@ -1651,13 +1998,15 @@ grafana:
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 38
+                  "y": 52
                 },
-                "id": 8,
-                "maxDataPoints": 3,
+                "id": 30,
                 "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
                   "legend": {
-                    "calcs": [],
                     "displayMode": "table",
                     "placement": "right",
                     "showLegend": true,
@@ -1679,66 +2028,60 @@ grafana:
                     "sort": "none"
                   }
                 },
-                "pluginVersion": "6.6.2",
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": false,
-                    "expr": "sort_desc(sum by (client) (ceil(increase(blocky_query_total[$__range]))))",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{ client }}",
-                    "refId": "A"
+                    "editorMode": "code",
+                    "expr": "sum by (client) (increase(blocky_query_total{job=~\"$job\"}[$__range]))",
+                    "legendFormat": "{{client}}",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
                   }
                 ],
-                "title": "Query per Client",
+                "title": "Client",
                 "transparent": true,
                 "type": "piechart"
               },
               {
                 "datasource": {
-                  "default": true,
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Entries per denylist group (per-replica average)",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
                       "mode": "palette-classic"
                     },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
-                    },
-                    "decimals": 0,
                     "mappings": [],
                     "unit": "short"
                   },
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 8,
-                  "w": 12,
+                  "h": 7,
+                  "w": 8,
                   "x": 0,
-                  "y": 46
+                  "y": 60
                 },
-                "id": 32,
-                "maxDataPoints": 3,
+                "id": 31,
                 "options": {
+                  "displayLabels": [
+                    "name",
+                    "percent"
+                  ],
                   "legend": {
-                    "calcs": [],
                     "displayMode": "table",
                     "placement": "right",
                     "showLegend": true,
                     "values": [
-                      "value"
+                      "value",
+                      "percent"
                     ]
                   },
                   "pieType": "donut",
@@ -1754,7 +2097,7 @@ grafana:
                     "sort": "none"
                   }
                 },
-                "pluginVersion": "6.6.2",
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
@@ -1762,13 +2105,11 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "exemplar": false,
-                    "expr": "topk(1, blocky_denylist_cache_entries) by (group)",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
+                    "expr": "avg by (group) (blocky_denylist_cache_entries{job=~\"$job\"})",
                     "legendFormat": "{{group}}",
-                    "refId": "A"
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
                   }
                 ],
                 "title": "Denylist by group",
@@ -1780,44 +2121,40 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Resolver cache entries per replica",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
-                      "mode": "palette-classic"
+                      "mode": "thresholds"
                     },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
-                    },
-                    "decimals": 0,
                     "mappings": [],
-                    "unit": "short"
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 0
                   },
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 46
+                  "h": 7,
+                  "w": 8,
+                  "x": 8,
+                  "y": 60
                 },
-                "id": 14,
-                "maxDataPoints": 3,
+                "id": 32,
                 "options": {
-                  "legend": {
-                    "calcs": [],
-                    "displayMode": "table",
-                    "placement": "right",
-                    "showLegend": true,
-                    "values": [
-                      "value",
-                      "percent"
-                    ]
-                  },
-                  "pieType": "donut",
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -1825,148 +2162,67 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
-                  }
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": false,
-                    "expr": " sort_desc(sum by (reason) (ceil(increase(blocky_response_total[$__range]))))",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{reason}}",
+                    "editorMode": "code",
+                    "expr": "sum(blocky_cache_entries{job=~\"$job\"}) / clamp_min(count(blocky_blocking_enabled{job=~\"$job\"}), 1)",
+                    "legendFormat": "",
+                    "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "Response Reasons",
+                "title": "Cache entries",
                 "transparent": true,
-                "type": "piechart"
+                "type": "stat"
               },
               {
                 "datasource": {
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
+                "description": "Total process CPU cores used by Blocky pods",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
-                      "mode": "palette-classic"
+                      "mode": "thresholds"
                     },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
-                    },
-                    "decimals": 0,
                     "mappings": [],
-                    "unit": "short"
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "percentunit",
+                    "decimals": 2
                   },
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 54
+                  "h": 7,
+                  "w": 8,
+                  "x": 16,
+                  "y": 60
                 },
-                "id": 38,
-                "interval": "",
-                "maxDataPoints": 3,
+                "id": 33,
                 "options": {
-                  "legend": {
-                    "calcs": [],
-                    "displayMode": "table",
-                    "placement": "right",
-                    "showLegend": true,
-                    "values": [
-                      "value",
-                      "percent"
-                    ]
-                  },
-                  "pieType": "donut",
-                  "reduceOptions": {
-                    "calcs": [
-                      "sum"
-                    ],
-                    "fields": "",
-                    "values": false
-                  },
-                  "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
-                  }
-                },
-                "targets": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "PBFA97CFB590B2093"
-                    },
-                    "exemplar": false,
-                    "expr": " sort_desc(sum by (response_type) (ceil(increase(blocky_response_total[$__range]))))",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{response_type}}",
-                    "refId": "A"
-                  }
-                ],
-                "title": "Response Type",
-                "transparent": true,
-                "type": "piechart"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "PBFA97CFB590B2093"
-                },
-                "fieldConfig": {
-                  "defaults": {
-                    "color": {
-                      "mode": "palette-classic"
-                    },
-                    "custom": {
-                      "hideFrom": {
-                        "legend": false,
-                        "tooltip": false,
-                        "viz": false
-                      }
-                    },
-                    "decimals": 0,
-                    "mappings": [],
-                    "unit": "short"
-                  },
-                  "overrides": []
-                },
-                "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 54
-                },
-                "id": 12,
-                "maxDataPoints": 3,
-                "options": {
-                  "legend": {
-                    "calcs": [],
-                    "displayMode": "table",
-                    "placement": "right",
-                    "showLegend": true,
-                    "values": [
-                      "value",
-                      "percent"
-                    ]
-                  },
-                  "pieType": "donut",
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -1974,34 +2230,36 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
-                  }
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
+                "pluginVersion": "11.2.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "PBFA97CFB590B2093"
                     },
-                    "exemplar": false,
-                    "expr": " sort_desc(sum by (response_code) (ceil(increase(blocky_response_total[$__range]))))",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{response_code}}",
+                    "editorMode": "code",
+                    "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\",namespace=\"blocky\"}[5m]))",
+                    "legendFormat": "",
+                    "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "Response status",
+                "title": "CPU",
                 "transparent": true,
-                "type": "piechart"
+                "type": "stat"
               }
             ],
-            "refresh": false,
+            "refresh": "auto",
             "schemaVersion": 39,
-            "tags": [],
+            "tags": [
+              "dns",
+              "blocky",
+              "otaru"
+            ],
             "templating": {
               "list": [
                 {
@@ -2052,9 +2310,9 @@ grafana:
                 "1d"
               ]
             },
-            "timezone": "",
+            "timezone": "browser",
             "title": "blocky",
             "uid": "JvOqE4gRk",
-            "version": 8,
+            "version": 11,
             "weekStart": ""
           }


### PR DESCRIPTION
## Summary

- Refactor the Blocky Grafana dashboard (v11): meaningful sections, auto refresh, and metrics that actually move on this cluster.
- Drop zero-value prefetch panels; add `blocky_failed_downloads_total`, response-type rates, latency by type, failures rate, process RSS/CPU.
- Document Argo CD “Synced at right revision but ConfigMap key still missing” and Grafana `subPath` mount not live-updating (from stash `4ec677c4` / `stash@{0}`), appended after the Blocky ambient DNS gotcha.

## Dashboard changes

| Change | Detail |
|--------|--------|
| Layout | Overview → traffic → denylists/reliability → rates → heatmap → breakdowns |
| Added | Failed downloads, failures series, responses/latency by type, cache hit/miss rates, RSS, CPU |
| Removed | Prefetch stats (all zeros with prefetch disabled) |
| Ops | `refresh: auto`, consistent `job=~"$job"` filters |

## Gotcha

After dashboard ConfigMap changes: verify the live ConfigMap key (not only Application revision), hard-refresh Argo CD if needed, and restart Grafana so `subPath` mounts pick up new JSON.

## Test plan

- [x] `make test`
- [ ] After merge: confirm `monitoring-grafana-dashboards-default` has updated `blocky` key
- [ ] Restart Grafana pods if needed so subPath mounts reload
- [ ] Open Blocky dashboard: stats populate, auto refresh on, no empty prefetch row
- [ ] Failed downloads / list age / blocked ratio look sane vs Prometheus