### PR TITLE
fix(monitoring): repair onzack cluster dashboard PromQL for live scrapes

### DIFF
--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -398,7 +398,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"})\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"}) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"worker\"}))",
+                    "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "{{pod}}",
@@ -469,7 +469,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)\n  *\n  sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n)",
+                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n  *\n  sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
                     "hide": false,
                     "instant": true,
                     "interval": "",
@@ -561,7 +561,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                    "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                     "interval": "",
                     "legendFormat": "{{node}}",
                     "refId": "A"
@@ -631,7 +631,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"})\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n)",
+                    "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "{{pod}}",
@@ -702,7 +702,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)\n  *\n  (\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n  )\n)",
+                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n  *\n  (\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  )\n)",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -794,7 +794,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                    "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                     "interval": "",
                     "legendFormat": "{{node}}",
                     "refId": "A"
@@ -857,7 +857,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -921,7 +921,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -1008,7 +1008,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                     "hide": false,
                     "interval": "",
                     "legendFormat": "{{node}} (read)",
@@ -1020,7 +1020,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node) * -1",
+                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node) * -1",
                     "hide": false,
                     "interval": "",
                     "legendFormat": "{{node}} (write)",
@@ -1084,7 +1084,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -1148,7 +1148,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -1241,7 +1241,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                     "interval": "",
                     "legendFormat": "{{node}} (receive)",
                     "refId": "A"
@@ -1252,7 +1252,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node) * -1",
+                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node) * -1",
                     "hide": false,
                     "interval": "",
                     "legendFormat": "{{node}} (transmit)",
@@ -1347,7 +1347,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1411,7 +1411,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1475,7 +1475,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor",
+                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1540,7 +1540,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1605,7 +1605,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n-\navg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)",
+                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1674,7 +1674,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1744,7 +1744,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"})\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"}) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"worker\"}))",
+                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1814,7 +1814,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -1881,7 +1881,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -1952,7 +1952,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2022,7 +2022,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"})\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n)",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2092,7 +2092,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -2159,7 +2159,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2224,7 +2224,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2289,7 +2289,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2354,7 +2354,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) > 0",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2418,7 +2418,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2484,7 +2484,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2546,7 +2546,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2612,7 +2612,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) > 0",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2677,7 +2677,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2741,7 +2741,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2806,7 +2806,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2870,7 +2870,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2934,7 +2934,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3000,7 +3000,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3062,7 +3062,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3127,7 +3127,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) > 0",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3192,7 +3192,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3256,7 +3256,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3321,7 +3321,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3385,7 +3385,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3451,7 +3451,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3513,7 +3513,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3578,7 +3578,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3864,7 +3864,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3878,7 +3878,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3892,7 +3892,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3906,7 +3906,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3920,7 +3920,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "avg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "avg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3934,7 +3934,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)\n*\navg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\navg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3948,7 +3948,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -3962,7 +3962,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4287,7 +4287,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4301,7 +4301,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4315,7 +4315,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4329,7 +4329,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4343,7 +4343,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "avg(sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))) by (node)\n-\navg(sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))) by (node)",
+                        "expr": "avg(sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))) by (node)\n-\navg(sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4357,7 +4357,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) by (node)\n*\navg(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"worker\"})) by (node)\n-\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"worker\"})) by (node)\n) by (node)",
+                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\navg(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n-\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4371,7 +4371,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4385,7 +4385,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -4496,7 +4496,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (namespace)\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\",pod!=\"\"}[5m]) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (namespace) > 0",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (namespace)\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\",pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) by (namespace) > 0",
                         "interval": "",
                         "legendFormat": "{{namespace}}",
                         "refId": "A"
@@ -4589,7 +4589,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"}) by (namespace)\n-\nsum(container_memory_working_set_bytes{container=\"\",pod!=\"\"}* on(node) group_left() kube_node_role{role=\"$noderole\"}) by (namespace) > 0",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (namespace)\n-\nsum(container_memory_working_set_bytes{container=\"\",pod!=\"\"} * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) by (namespace) > 0",
                         "interval": "",
                         "legendFormat": "{{namespace}}",
                         "refId": "A"
@@ -4676,7 +4676,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4772,7 +4772,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -4783,7 +4783,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -4795,7 +4795,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -4881,7 +4881,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)",
+                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
                         "interval": "",
                         "legendFormat": "allocatable (netto)",
                         "refId": "A"
@@ -4892,7 +4892,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (requested)",
@@ -4904,7 +4904,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (requested)",
@@ -4974,7 +4974,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -5070,7 +5070,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -5081,7 +5081,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -5093,7 +5093,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -5179,7 +5179,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)",
+                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "allocatable (netto)",
@@ -5191,7 +5191,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (requested)",
@@ -5203,7 +5203,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (requested)",
@@ -5273,7 +5273,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"})\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"worker\"}) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"worker\"}))",
+                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -5369,7 +5369,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -5380,7 +5380,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -5392,7 +5392,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -5478,7 +5478,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)",
+                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
                         "interval": "",
                         "legendFormat": "allocatable (netto)",
                         "refId": "A"
@@ -5489,7 +5489,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -5501,7 +5501,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -5513,7 +5513,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -5583,7 +5583,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() kube_node_role{role=\"$noderole\"})\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n)",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -5679,7 +5679,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n)",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -5690,7 +5690,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -5702,7 +5702,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -5788,7 +5788,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)",
+                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "allocatable (netto)",
@@ -5800,7 +5800,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -5812,7 +5812,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (node)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (node)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -5824,7 +5824,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -5894,7 +5894,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -5990,7 +5990,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -6001,7 +6001,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -6013,7 +6013,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -6099,7 +6099,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "requested",
                         "refId": "A"
@@ -6110,7 +6110,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -6122,7 +6122,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -6134,7 +6134,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -6204,7 +6204,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -6300,7 +6300,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -6311,7 +6311,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -6323,7 +6323,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -6409,7 +6409,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "requested",
                         "refId": "A"
@@ -6420,7 +6420,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -6432,7 +6432,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -6444,7 +6444,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -6510,7 +6510,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"}))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -6602,7 +6602,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": " apps (wasted)",
@@ -6614,7 +6614,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (wasted)",
@@ -6700,7 +6700,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (wasted)",
@@ -6712,7 +6712,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (wasted)",
@@ -6724,7 +6724,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -6736,7 +6736,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -6748,7 +6748,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "apps (requested)",
                         "refId": "C"
@@ -6759,7 +6759,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (requested)",
@@ -6826,7 +6826,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -6918,7 +6918,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": " apps (wasted)",
@@ -6930,7 +6930,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n)",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (wasted)",
@@ -7016,7 +7016,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (wasted)",
@@ -7028,7 +7028,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (wasted)",
@@ -7040,7 +7040,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -7052,7 +7052,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -7064,7 +7064,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "apps (requested)",
                         "refId": "C"
@@ -7075,7 +7075,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (requested)",
@@ -7141,7 +7141,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -7233,7 +7233,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total",
@@ -7245,7 +7245,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "(100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -7257,7 +7257,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -7343,7 +7343,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -7354,7 +7354,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -7366,7 +7366,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -7432,7 +7432,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) kube_node_role{role=\"$noderole\"}) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() kube_node_role{role=\"$noderole\"}) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -7524,7 +7524,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total",
@@ -7536,7 +7536,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -7548,7 +7548,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -7634,7 +7634,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps",
@@ -7646,7 +7646,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s",
@@ -7658,7 +7658,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "A"
@@ -7727,7 +7727,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -7823,7 +7823,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -7835,7 +7835,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "(100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))) or on() vector(0)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -7847,7 +7847,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\",}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\",}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -7933,7 +7933,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -7945,7 +7945,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (limits)",
@@ -7957,7 +7957,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -7969,7 +7969,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (limits)",
@@ -7981,7 +7981,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -7993,7 +7993,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total (limits)",
                         "refId": "A"
@@ -8062,7 +8062,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() kube_node_role{role=\"$noderole\"})\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left(role) kube_node_role{role=\"$noderole\"})",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "instant": true,
                         "interval": "",
@@ -8158,7 +8158,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -8170,7 +8170,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -8182,7 +8182,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -8268,7 +8268,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (used)",
@@ -8280,7 +8280,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "apps (limits)",
@@ -8292,7 +8292,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (used)",
@@ -8304,7 +8304,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "k8s (limits)",
@@ -8316,7 +8316,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "total (used)",
@@ -8328,7 +8328,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() topk(1,kube_node_role{role=\"$noderole\"}) by (node))",
+                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
                         "interval": "",
                         "legendFormat": "total (limits)",
                         "refId": "A"
@@ -8442,7 +8442,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -8544,7 +8544,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) ((node_uname_info))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -8657,7 +8657,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -8752,7 +8752,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node ))) by (node)\n*\n(\n sum(node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node ))) by (node)\n -\n sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node ))) by (node)\n)",
+                        "expr": "100\n/\nsum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n*\n(\n sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n -\n sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -8948,7 +8948,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -8962,7 +8962,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -8976,7 +8976,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -8990,7 +8990,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -9004,7 +9004,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -9018,7 +9018,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -9133,7 +9133,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (mountpoint,node)\n-\nmax((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (mountpoint,node)",
+                        "expr": "max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n-\nmax((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}} {{mountpoint}}",
@@ -9235,7 +9235,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nmax((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (mountpoint,node)\n*\n(\n  max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (mountpoint,node)\n  -\n  max((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (mountpoint,node)\n)",
+                        "expr": "100\n/\nmax((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n*\n(\n  max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n  -\n  max((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}} {{mountpoint}}",
@@ -9338,7 +9338,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode=\"iowait\"}[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) ((node_uname_info))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode=\"iowait\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -9432,7 +9432,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -9527,7 +9527,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -9621,7 +9621,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -9716,7 +9716,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -9810,7 +9810,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -9904,7 +9904,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (label_replace(topk(1,node_uname_info) by (instance), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "{{node}}",
@@ -10093,7 +10093,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10107,7 +10107,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10121,7 +10121,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10135,7 +10135,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10149,7 +10149,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10163,7 +10163,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) kube_node_role{role=\"$noderole\"})) by (node)",
+                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "format": "table",
                         "hide": false,
                         "instant": true,
@@ -10276,7 +10276,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10370,7 +10370,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10464,7 +10464,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10558,7 +10558,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10652,7 +10652,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10746,7 +10746,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) (label_replace((node_uname_info), \"node\", \"$1\", \"nodename\", \"(.*)\") * on(node) group_left(role) topk(1,kube_node_role{role=\"$noderole\"}) by (node))) by (node)",
+                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10786,9 +10786,9 @@ grafana:
                 },
                 {
                   "current": {
-                    "selected": false,
-                    "text": "worker",
-                    "value": "worker"
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
                   },
                   "datasource": {
                     "type": "prometheus",
@@ -10796,7 +10796,7 @@ grafana:
                   },
                   "definition": "label_values(kube_node_role,role)",
                   "hide": 0,
-                  "includeAll": false,
+                  "includeAll": true,
                   "label": "Node Role",
                   "multi": false,
                   "name": "noderole",
@@ -10809,7 +10809,8 @@ grafana:
                   "regex": "",
                   "skipUrlSync": false,
                   "sort": 0,
-                  "type": "query"
+                  "type": "query",
+                  "allValue": ".*"
                 },
                 {
                   "current": {
@@ -10859,6 +10860,6 @@ grafana:
             "timezone": "",
             "title": "Cluster Monitoring",
             "uid": "ozk-std-clstr-mon-norec",
-            "version": 16,
+            "version": 19,
             "weekStart": ""
           }


### PR DESCRIPTION
## Summary

In-place PromQL/label fixes for **onzack-cluster-monitoring** only (no layout refactor).

Pre-fix live audit: **159/164** unique expressions empty. Post-fix: **0/150** broken.

### Root causes
| Issue | Fix |
|-------|-----|
| `$noderole` default `worker` (cluster has control-plane/etcd only; workers unlabelled) | Join via `group by (node) (kube_node_info)`; noderole All/`.*` |
| `job="node-exporter"` | `job=~"kubernetes-service-endpoints\|node-exporter"` |
| cAdvisor series lack `node` label | Join container metrics on `instance` via `label_replace` of node name |
| `cattle-.*openshift-.*` missing `\|` | `cattle-.*\|openshift-.*` |
| System pods often have **no CPU limits** | `(expr) or on() vector(0)` for k8s CPU-limit panels |

## Test plan
- [x] Live Prometheus audit: 0 broken unique exprs
- [x] `make test`
- [ ] After merge: hard-refresh monitoring + restart Grafana if subPath stale