### PR TITLE
fix(argocd): reduce repo-server CPU hotfix, pod stuck Pending

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -160,9 +160,16 @@ argo-cd:
     # requests (2115m free of 4000m) and already hosts this pod, so applying
     # the 1678m recommendation now: RollingUpdate surge peaks at ~3563m/4000m
     # (89%) on nuc-00, well within capacity.
+    # KRR 2026-07-18 hotfix: the 1678m request above stopped fitting anywhere
+    # within a couple of hours -- nuc-00's free CPU had dropped to ~363m by
+    # the time the rollout retried (other workloads' requests grew after
+    # this pass), leaving the new pod Pending on all 5 nodes for 80+ minutes
+    # (FailedScheduling: insufficient cpu). Reduced to 700m, which fits with
+    # margin on raspberrypi-00/01/03 (~800-965m free each) -- still a large
+    # improvement over the original 250m, just not the full KRR peak.
     resources:
       requests:
-        cpu: 1678m
+        cpu: 700m
         memory: 512Mi
         ephemeral-storage: 512Mi
       limits:


### PR DESCRIPTION
## Summary

- The `argocd-repo-server` CPU request upsize applied earlier today in #2848 (250m -> 1678m, per KRR's recommendation) stopped fitting on any node within a couple of hours: other workloads' CPU requests grew, and by the time the rollout retried, no node had 1678m free. The new pod has been stuck `Pending` (`FailedScheduling: insufficient cpu`) for 80+ minutes; the old replica is still `Running`, so the service itself was never down.
- Reduces the request to `700m`, which fits with margin on three nodes (raspberrypi-00/01/03, each with ~800-965m free CPU currently) -- still a large improvement over the original 250m, just not the full KRR peak this cluster can't currently support.

Same pattern as the same-day `changedetection-browser` hotfix (#2849).

## Test plan

- [x] `make test` passes
- [ ] Post-merge: confirm the repo-server rollout completes and the pod goes `Running`/`Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JboiWiH98ZjpRz5kYoreUY