### PR TITLE
fix(monitoring): set Grafana Prometheus scrape interval to 1m

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -236,12 +236,21 @@ grafana:
     datasources.yaml:
       apiVersion: 1
       datasources:
+        # uid matches hardcoded dashboard targets (PBFA97CFB590B2093).
+        # timeInterval must match Prometheus scrape_interval (1m). Without it Grafana
+        # assumes 15s and $__rate_interval collapses to ~1m, so rate()/increase() get
+        # <2 samples and Activity/heatmap panels show "No data".
         - name: Prometheus
           type: prometheus
+          uid: PBFA97CFB590B2093
           url: http://monitoring-prometheus-server.monitoring.svc.cluster.local
           isDefault: true
+          jsonData:
+            timeInterval: 1m
+            httpMethod: POST
         - name: Loki
           type: loki
+          uid: P8E80F9AEF21F6940
           url: http://monitoring-loki.monitoring.svc.cluster.local:3100
   dashboardProviders:
     dashboardproviders.yaml:


### PR DESCRIPTION
## Summary
- Blocky Activity / heatmap panels show **No data** after switching to `\$__rate_interval`.
- Root cause: Prometheus scrapes Blocky every **1m**, but the Grafana Prometheus datasource had no `timeInterval`, so Grafana assumed **15s** and computed `\$__rate_interval ≈ 1m`.
- `rate()` / `increase()` need ≥2 samples → empty series → No data.
- Health tiles and Breakdown pies (using `\$__range` / instant gauges) were fine.

## Fix
- Set Prometheus datasource `jsonData.timeInterval: 1m` (matches scrape_interval).
- Pin datasource UIDs to the values already used in dashboard JSON.

## Test plan
- [x] `make test`
- [ ] After deploy: Blocky Activity query rate / failures / heatmap show series again
- [ ] Grafana datasource shows Min interval 1m