### PR TITLE
chore(monitoring): Onzack Cluster Monitoring 17404 rev 11

### DIFF
--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -4,12 +4,67 @@ grafana:
       onzack-cluster-monitoring:
         json: |
           {
+            "__inputs": [
+              {
+                "name": "DS_PROMETHEUS",
+                "label": "prometheus",
+                "description": "",
+                "type": "datasource",
+                "pluginId": "prometheus",
+                "pluginName": "Prometheus"
+              }
+            ],
+            "__elements": {},
+            "__requires": [
+              {
+                "type": "panel",
+                "id": "gauge",
+                "name": "Gauge",
+                "version": ""
+              },
+              {
+                "type": "grafana",
+                "id": "grafana",
+                "name": "Grafana",
+                "version": "13.0.1"
+              },
+              {
+                "type": "datasource",
+                "id": "prometheus",
+                "name": "Prometheus",
+                "version": "1.0.0"
+              },
+              {
+                "type": "panel",
+                "id": "stat",
+                "name": "Stat",
+                "version": ""
+              },
+              {
+                "type": "panel",
+                "id": "table",
+                "name": "Table",
+                "version": ""
+              },
+              {
+                "type": "panel",
+                "id": "text",
+                "name": "Text",
+                "version": ""
+              },
+              {
+                "type": "panel",
+                "id": "timeseries",
+                "name": "Time series",
+                "version": ""
+              }
+            ],
             "annotations": {
               "list": [
                 {
                   "builtIn": 1,
                   "datasource": {
-                    "type": "datasource",
+                    "type": "grafana",
                     "uid": "grafana"
                   },
                   "enable": true,
@@ -26,28 +81,47 @@ grafana:
                 }
               ]
             },
-            "editable": false,
+            "description": "ONZACK Standard Cluster Monitoring (Grafana.com 17404 rev 11, with recording rules). Vendored into otaru; Prometheus rules live in monitoring chart recording_rules.yml (adapted for kubernetes-service-endpoints node-exporter and unlabeled worker nodes).",
+            "editable": true,
             "fiscalYearStartMonth": 0,
             "graphTooltip": 0,
-            "id": 3,
-            "iteration": 1656595011732,
-            "links": [],
+            "links": [
+              {
+                "asDropdown": false,
+                "icon": "external link",
+                "includeVars": false,
+                "keepTime": true,
+                "tags": [],
+                "targetBlank": true,
+                "title": "Standard Namespace Monitoring",
+                "tooltip": "",
+                "type": "link",
+                "url": "d/ozk-std-ns-mon"
+              },
+              {
+                "asDropdown": false,
+                "icon": "external link",
+                "includeVars": false,
+                "keepTime": false,
+                "tags": [],
+                "targetBlank": true,
+                "title": "GitHub",
+                "tooltip": "",
+                "type": "link",
+                "url": "https://github.com/onzack/grafana-dashboards"
+              }
+            ],
             "liveNow": false,
             "panels": [
               {
                 "collapsed": false,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
                   "y": 0
                 },
-                "id": 16,
-                "panels": [],
+                "id": 222,
                 "title": "Overview",
                 "type": "row"
               },
@@ -61,13 +135,12 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "#EAB839",
@@ -94,6 +167,7 @@ grafana:
                   "graphMode": "area",
                   "justifyMode": "auto",
                   "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -101,9 +175,11 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "textMode": "auto"
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -111,8 +187,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(kube_node_status_condition{condition!=\"Ready\", status!=\"false\"})\n+\nsum(kube_node_spec_unschedulable)",
-                    "hide": false,
+                    "expr": "sum(kube_node_status_condition{condition!~\"(Ready|EtcdIsVoter)\", status!=\"false\"})\n+\nsum(kube_node_spec_unschedulable)",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -133,40 +208,45 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
-                      "drawStyle": "line",
-                      "fillOpacity": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "bars",
+                      "fillOpacity": 70,
                       "gradientMode": "none",
                       "hideFrom": {
                         "legend": false,
                         "tooltip": false,
                         "viz": false
                       },
+                      "insertNulls": false,
                       "lineInterpolation": "linear",
                       "lineWidth": 1,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
-                        "mode": "none"
+                        "mode": "normal"
                       },
                       "thresholdsStyle": {
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "red",
@@ -185,6 +265,10 @@ grafana:
                 },
                 "id": 28,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [
                       "max",
@@ -192,14 +276,18 @@ grafana:
                     ],
                     "displayMode": "table",
                     "placement": "right",
+                    "showLegend": true,
                     "sortBy": "Max",
                     "sortDesc": true
                   },
                   "tooltip": {
+                    "hideZeros": false,
+                    "maxHeight": 600,
                     "mode": "multi",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -207,8 +295,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(kube_node_status_condition{condition!=\"Ready\", status!=\"false\"}) by (condition)",
-                    "hide": false,
+                    "expr": "sum by (condition) (kube_node_status_condition{condition!=\"Ready\", condition!=\"EtcdIsVoter\", status!=\"false\"})",
                     "interval": "",
                     "legendFormat": "{{condition}}",
                     "refId": "A"
@@ -218,16 +305,17 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "exemplar": true,
+                    "editorMode": "code",
+                    "exemplar": false,
                     "expr": "sum(kube_node_spec_unschedulable)",
-                    "hide": false,
                     "interval": "",
                     "legendFormat": "Unschedulable",
+                    "range": true,
                     "refId": "B"
                   }
                 ],
                 "timeFrom": "24h",
-                "title": "Failures",
+                "title": "Failures (all nodes)",
                 "type": "timeseries"
               },
               {
@@ -241,9 +329,13 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
+                      "barWidthFactor": 0.6,
                       "drawStyle": "line",
                       "fillOpacity": 0,
                       "gradientMode": "none",
@@ -252,13 +344,15 @@ grafana:
                         "tooltip": false,
                         "viz": false
                       },
-                      "lineInterpolation": "linear",
-                      "lineWidth": 1,
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 2,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
@@ -268,14 +362,13 @@ grafana:
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "red",
@@ -294,6 +387,10 @@ grafana:
                 },
                 "id": 24,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [
                       "min",
@@ -301,24 +398,29 @@ grafana:
                       "lastNotNull"
                     ],
                     "displayMode": "table",
-                    "placement": "right"
+                    "placement": "right",
+                    "showLegend": true
                   },
                   "tooltip": {
+                    "hideZeros": false,
+                    "maxHeight": 600,
                     "mode": "multi",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "exemplar": true,
+                    "editorMode": "code",
+                    "exemplar": false,
                     "expr": "sum(kube_node_info)",
-                    "hide": false,
                     "interval": "",
                     "legendFormat": "total",
+                    "range": true,
                     "refId": "B"
                   },
                   {
@@ -327,14 +429,344 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(kube_node_role) by (role)",
+                    "expr": "sum by (role) (instance:kube_node_role)",
                     "interval": "",
                     "legendFormat": "{{role}}",
                     "refId": "A"
                   }
                 ],
                 "timeFrom": "24h",
-                "title": "Workload",
+                "title": "Nodes",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "axisSoftMax": 2,
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "bars",
+                      "fillOpacity": 70,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "showValues": false,
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "area"
+                      }
+                    },
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": 0
+                        },
+                        {
+                          "color": "red",
+                          "value": 0.5
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 5,
+                  "w": 8,
+                  "x": 0,
+                  "y": 7
+                },
+                "id": 208,
+                "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
+                  "legend": {
+                    "calcs": [
+                      "max",
+                      "last"
+                    ],
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false,
+                    "sortBy": "Max",
+                    "sortDesc": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "13.0.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "exemplar": false,
+                    "expr": "sum by (node) (kube_node_spec_unschedulable * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                    "interval": "",
+                    "legendFormat": "{{node}}",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Unschedulable Nodes",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "axisSoftMax": 2,
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "bars",
+                      "fillOpacity": 70,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "showValues": false,
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "area"
+                      }
+                    },
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": 0
+                        },
+                        {
+                          "color": "red",
+                          "value": 0.5
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 5,
+                  "w": 8,
+                  "x": 8,
+                  "y": 7
+                },
+                "id": 214,
+                "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
+                  "legend": {
+                    "calcs": [
+                      "max",
+                      "last"
+                    ],
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false,
+                    "sortBy": "Max",
+                    "sortDesc": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "13.0.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "exemplar": false,
+                    "expr": "sum by (node) (kube_node_status_condition{condition=\"NetworkUnavailable\", status!=\"false\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"}) or vector(0)",
+                    "interval": "",
+                    "legendFormat": "{{node}}",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Nodes with unavailable Network",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "axisSoftMax": 2,
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "bars",
+                      "fillOpacity": 70,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "showValues": false,
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "area"
+                      }
+                    },
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": 0
+                        },
+                        {
+                          "color": "red",
+                          "value": 0.5
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 5,
+                  "w": 8,
+                  "x": 16,
+                  "y": 7
+                },
+                "id": 219,
+                "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
+                  "legend": {
+                    "calcs": [
+                      "max",
+                      "last"
+                    ],
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false,
+                    "sortBy": "Max",
+                    "sortDesc": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "13.0.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by(node, operation_type) (ceil(rate(kubelet_runtime_operations_errors_total{cluster=\"\",job=~\"kubelet|kubernetes-api-servers\", metrics_path=\"/metrics\"}[5m])) * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"}) or vector(0)",
+                    "legendFormat": "{{node}}/{{operation_type}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Kubernetes Operation Errors",
                 "type": "timeseries"
               },
               {
@@ -347,7 +779,6 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "max": 100,
                     "min": 0,
                     "thresholds": {
@@ -355,7 +786,7 @@ grafana:
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "orange",
@@ -372,13 +803,23 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 0,
-                  "y": 7
+                  "y": 12
                 },
                 "id": 30,
                 "options": {
+                  "barShape": "flat",
+                  "barWidthFactor": 0.5,
+                  "effects": {
+                    "barGlow": false,
+                    "centerGlow": false,
+                    "gradient": false
+                  },
+                  "endpointMarker": "point",
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
                   "orientation": "auto",
                   "reduceOptions": {
                     "calcs": [
@@ -387,10 +828,16 @@ grafana:
                     "fields": "",
                     "values": false
                   },
+                  "segmentCount": 1,
+                  "segmentSpacing": 0.3,
+                  "shape": "gauge",
                   "showThresholdLabels": true,
-                  "showThresholdMarkers": true
+                  "showThresholdMarkers": true,
+                  "sizing": "auto",
+                  "sparkline": false,
+                  "textMode": "auto"
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -398,14 +845,14 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                    "expr": "100\n/\n(\n  sum(kube_node_status_capacity:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_capacity:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
-                    "legendFormat": "{{pod}}",
+                    "legendFormat": "",
                     "refId": "A"
                   }
                 ],
-                "title": "Cores Used",
+                "title": "Cores Used (from capacity)",
                 "type": "gauge"
               },
               {
@@ -418,7 +865,6 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "max": 100,
                     "min": 0,
                     "thresholds": {
@@ -426,7 +872,7 @@ grafana:
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "orange",
@@ -443,13 +889,23 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 3,
-                  "y": 7
+                  "y": 12
                 },
                 "id": 33,
                 "options": {
+                  "barShape": "flat",
+                  "barWidthFactor": 0.5,
+                  "effects": {
+                    "barGlow": false,
+                    "centerGlow": false,
+                    "gradient": false
+                  },
+                  "endpointMarker": "point",
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
                   "orientation": "auto",
                   "reduceOptions": {
                     "calcs": [
@@ -458,10 +914,16 @@ grafana:
                     "fields": "",
                     "values": false
                   },
+                  "segmentCount": 1,
+                  "segmentSpacing": 0.3,
+                  "shape": "gauge",
                   "showThresholdLabels": true,
-                  "showThresholdMarkers": true
+                  "showThresholdMarkers": true,
+                  "sizing": "auto",
+                  "sparkline": false,
+                  "textMode": "auto"
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -469,8 +931,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n  *\n  sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
-                    "hide": false,
+                    "expr": "topk(1,\n  100\n  /\n  (sum by (node) (kube_node_status_capacity:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))\n  *\n  sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})\n)",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -491,24 +952,30 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
+                      "barWidthFactor": 0.6,
                       "drawStyle": "line",
-                      "fillOpacity": 0,
+                      "fillOpacity": 10,
                       "gradientMode": "none",
                       "hideFrom": {
                         "legend": false,
                         "tooltip": false,
                         "viz": false
                       },
-                      "lineInterpolation": "linear",
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
@@ -518,14 +985,13 @@ grafana:
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "red",
@@ -537,23 +1003,31 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 18,
                   "x": 6,
-                  "y": 7
+                  "y": 12
                 },
                 "id": 11,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [],
-                    "displayMode": "hidden",
-                    "placement": "right"
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false
                   },
                   "tooltip": {
-                    "mode": "multi",
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -561,7 +1035,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
+                    "expr": "sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                     "interval": "",
                     "legendFormat": "{{node}}",
                     "refId": "A"
@@ -580,7 +1054,6 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "max": 100,
                     "min": 0,
                     "thresholds": {
@@ -588,7 +1061,7 @@ grafana:
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "orange",
@@ -605,13 +1078,23 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 0,
-                  "y": 12
+                  "y": 18
                 },
                 "id": 73,
                 "options": {
+                  "barShape": "flat",
+                  "barWidthFactor": 0.5,
+                  "effects": {
+                    "barGlow": false,
+                    "centerGlow": false,
+                    "gradient": false
+                  },
+                  "endpointMarker": "point",
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
                   "orientation": "auto",
                   "reduceOptions": {
                     "calcs": [
@@ -620,10 +1103,16 @@ grafana:
                     "fields": "",
                     "values": false
                   },
+                  "segmentCount": 1,
+                  "segmentSpacing": 0.3,
+                  "shape": "gauge",
                   "showThresholdLabels": true,
-                  "showThresholdMarkers": true
+                  "showThresholdMarkers": true,
+                  "sizing": "auto",
+                  "sparkline": false,
+                  "textMode": "auto"
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -631,14 +1120,14 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
+                    "expr": "100\n/\n(\n  sum(kube_node_status_capacity:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_capacity:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
-                    "legendFormat": "{{pod}}",
+                    "legendFormat": "",
                     "refId": "A"
                   }
                 ],
-                "title": "Memory Used",
+                "title": "Memory Used (form capacity)",
                 "type": "gauge"
               },
               {
@@ -651,7 +1140,6 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "max": 100,
                     "min": 0,
                     "thresholds": {
@@ -659,7 +1147,7 @@ grafana:
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "orange",
@@ -676,13 +1164,23 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 3,
-                  "y": 12
+                  "y": 18
                 },
                 "id": 32,
                 "options": {
+                  "barShape": "flat",
+                  "barWidthFactor": 0.5,
+                  "effects": {
+                    "barGlow": false,
+                    "centerGlow": false,
+                    "gradient": false
+                  },
+                  "endpointMarker": "point",
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
                   "orientation": "auto",
                   "reduceOptions": {
                     "calcs": [
@@ -691,10 +1189,16 @@ grafana:
                     "fields": "",
                     "values": false
                   },
+                  "segmentCount": 1,
+                  "segmentSpacing": 0.3,
+                  "shape": "gauge",
                   "showThresholdLabels": true,
-                  "showThresholdMarkers": true
+                  "showThresholdMarkers": true,
+                  "sizing": "auto",
+                  "sparkline": false,
+                  "textMode": "auto"
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -702,7 +1206,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "topk(1,\n  100\n  /\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n  *\n  (\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  )\n)",
+                    "expr": "topk(1,\n  100\n  /\n  (sum by (node) (kube_node_status_capacity:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))\n  *\n  sum by (node) (node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})\n)",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -723,24 +1227,30 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
+                      "barWidthFactor": 0.6,
                       "drawStyle": "line",
-                      "fillOpacity": 0,
+                      "fillOpacity": 10,
                       "gradientMode": "none",
                       "hideFrom": {
                         "legend": false,
                         "tooltip": false,
                         "viz": false
                       },
-                      "lineInterpolation": "linear",
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
                       "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
@@ -750,14 +1260,13 @@ grafana:
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "red",
@@ -770,23 +1279,31 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 18,
                   "x": 6,
-                  "y": 12
+                  "y": 18
                 },
                 "id": 12,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [],
-                    "displayMode": "hidden",
-                    "placement": "right"
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false
                   },
                   "tooltip": {
-                    "mode": "multi",
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -794,7 +1311,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
+                    "expr": "sum by (node) (node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
                     "interval": "",
                     "legendFormat": "{{node}}",
                     "refId": "A"
@@ -813,14 +1330,13 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         }
                       ]
                     },
@@ -829,10 +1345,10 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 0,
-                  "y": 17
+                  "y": 24
                 },
                 "id": 75,
                 "options": {
@@ -840,6 +1356,7 @@ grafana:
                   "graphMode": "none",
                   "justifyMode": "auto",
                   "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -847,9 +1364,11 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "textMode": "auto"
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -857,7 +1376,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                    "expr": "sum(node_disk_read_bytes_total:sum_rate5m{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -877,14 +1396,13 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         }
                       ]
                     },
@@ -893,10 +1411,10 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 3,
-                  "y": 17
+                  "y": 24
                 },
                 "id": 74,
                 "options": {
@@ -904,6 +1422,7 @@ grafana:
                   "graphMode": "none",
                   "justifyMode": "auto",
                   "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -911,9 +1430,11 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "textMode": "auto"
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -921,7 +1442,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                    "expr": "sum(node_disk_written_bytes_total:sum_rate5m{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -942,9 +1463,13 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "barAlignment": 0,
+                      "barWidthFactor": 0.6,
                       "drawStyle": "line",
                       "fillOpacity": 10,
                       "gradientMode": "none",
@@ -953,13 +1478,15 @@ grafana:
                         "tooltip": false,
                         "viz": false
                       },
-                      "lineInterpolation": "linear",
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
-                      "pointSize": 3,
+                      "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
@@ -969,38 +1496,45 @@ grafana:
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         }
                       ]
                     },
-                    "unit": "bytes"
+                    "unit": "binBps"
                   },
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 18,
                   "x": 6,
-                  "y": 17
+                  "y": 24
                 },
                 "id": 19,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [],
-                    "displayMode": "hidden",
-                    "placement": "right"
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false
                   },
                   "tooltip": {
-                    "mode": "multi",
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -1008,10 +1542,9 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                    "hide": false,
+                    "expr": "sum by (node) (node_disk_read_bytes_total:sum_rate5m{role=~\"$noderole\"})",
                     "interval": "",
-                    "legendFormat": "{{node}} (read)",
+                    "legendFormat": "(read) {{node}}",
                     "refId": "B"
                   },
                   {
@@ -1020,10 +1553,9 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node) * -1",
-                    "hide": false,
+                    "expr": "sum by (node) (node_disk_written_bytes_total:sum_rate5m{role=~\"$noderole\"}) * -1",
                     "interval": "",
-                    "legendFormat": "{{node}} (write)",
+                    "legendFormat": " (write) {{node}}",
                     "refId": "C"
                   }
                 ],
@@ -1040,14 +1572,13 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         }
                       ]
                     },
@@ -1056,10 +1587,10 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 0,
-                  "y": 22
+                  "y": 30
                 },
                 "id": 76,
                 "options": {
@@ -1067,6 +1598,7 @@ grafana:
                   "graphMode": "none",
                   "justifyMode": "auto",
                   "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -1074,9 +1606,11 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "textMode": "auto"
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -1084,14 +1618,14 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                    "expr": "sum(node_network_receive_bytes_total:sum_rate5m{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "A"
                   }
                 ],
-                "title": "Network Reveive",
+                "title": "Network Receive",
                 "type": "stat"
               },
               {
@@ -1104,14 +1638,13 @@ grafana:
                     "color": {
                       "mode": "thresholds"
                     },
-                    "mappings": [],
                     "min": 0,
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         }
                       ]
                     },
@@ -1120,10 +1653,10 @@ grafana:
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 3,
                   "x": 3,
-                  "y": 22
+                  "y": 30
                 },
                 "id": 77,
                 "options": {
@@ -1131,6 +1664,7 @@ grafana:
                   "graphMode": "none",
                   "justifyMode": "auto",
                   "orientation": "auto",
+                  "percentChangeColorMode": "standard",
                   "reduceOptions": {
                     "calcs": [
                       "lastNotNull"
@@ -1138,9 +1672,11 @@ grafana:
                     "fields": "",
                     "values": false
                   },
-                  "textMode": "auto"
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
                 },
-                "pluginVersion": "8.5.3",
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -1148,7 +1684,7 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                    "expr": "sum(node_network_transmit_bytes_total:sum_rate5m{role=~\"$noderole\"})",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
@@ -1169,11 +1705,15 @@ grafana:
                       "mode": "palette-classic"
                     },
                     "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
                       "axisLabel": "",
                       "axisPlacement": "auto",
                       "axisSoftMax": 200,
                       "axisSoftMin": -200,
                       "barAlignment": 0,
+                      "barWidthFactor": 0.6,
                       "drawStyle": "line",
                       "fillOpacity": 10,
                       "gradientMode": "none",
@@ -1182,13 +1722,15 @@ grafana:
                         "tooltip": false,
                         "viz": false
                       },
-                      "lineInterpolation": "linear",
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
                       "lineWidth": 1,
-                      "pointSize": 3,
+                      "pointSize": 5,
                       "scaleDistribution": {
                         "type": "linear"
                       },
-                      "showPoints": "auto",
+                      "showPoints": "never",
+                      "showValues": false,
                       "spanNulls": false,
                       "stacking": {
                         "group": "A",
@@ -1198,13 +1740,12 @@ grafana:
                         "mode": "off"
                       }
                     },
-                    "mappings": [],
                     "thresholds": {
                       "mode": "absolute",
                       "steps": [
                         {
                           "color": "green",
-                          "value": null
+                          "value": 0
                         },
                         {
                           "color": "red",
@@ -1212,28 +1753,36 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "bytes"
+                    "unit": "binBps"
                   },
                   "overrides": []
                 },
                 "gridPos": {
-                  "h": 5,
+                  "h": 6,
                   "w": 18,
                   "x": 6,
-                  "y": 22
+                  "y": 30
                 },
                 "id": 14,
                 "options": {
+                  "annotations": {
+                    "clustering": -1,
+                    "multiLane": false
+                  },
                   "legend": {
                     "calcs": [],
-                    "displayMode": "hidden",
-                    "placement": "right"
+                    "displayMode": "list",
+                    "placement": "right",
+                    "showLegend": false
                   },
                   "tooltip": {
-                    "mode": "multi",
+                    "hideZeros": false,
+                    "maxHeight": 600,
+                    "mode": "single",
                     "sort": "none"
                   }
                 },
+                "pluginVersion": "13.0.1",
                 "targets": [
                   {
                     "datasource": {
@@ -1241,9 +1790,9 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                    "expr": "node_network_receive_bytes_total:sum_rate5m{role=~\"$noderole\"}",
                     "interval": "",
-                    "legendFormat": "{{node}} (receive)",
+                    "legendFormat": "(receive) {{node}}",
                     "refId": "A"
                   },
                   {
@@ -1252,44 +1801,45 @@ grafana:
                       "uid": "${datasource}"
                     },
                     "exemplar": false,
-                    "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node) * -1",
-                    "hide": false,
+                    "expr": "node_network_transmit_bytes_total:sum_rate5m{role=~\"$noderole\"} * -1",
                     "interval": "",
-                    "legendFormat": "{{node}} (transmit)",
+                    "legendFormat": "(transmit) {{node}}",
                     "refId": "B"
                   }
                 ],
-                "title": "Network Bandwith (receive & transmit) by Pod",
+                "title": "Network Bandwidth (receive & transmit) by Node",
                 "type": "timeseries"
               },
               {
                 "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
-                  "y": 27
+                  "y": 36
                 },
-                "id": 21,
+                "id": 223,
                 "panels": [
                   {
                     "gridPos": {
                       "h": 3,
-                      "w": 14,
+                      "w": 22,
                       "x": 0,
-                      "y": 28
+                      "y": 37
                     },
                     "id": 85,
                     "options": {
-                      "content": "- CPU / Memory allocatable (brutto) = Total allocatable  \n- CPU / Memory allocatable (netto) = Total allocatable - spare nodes ---> All requested, used and limits values are calculated with the allocatable (netto) values",
+                      "code": {
+                        "language": "plaintext",
+                        "showLineNumbers": false,
+                        "showMiniMap": false
+                      },
+                      "content": "- CPU / Memory capacity = total hardware resources\n- CPU / Memory allocatable (brutto) = total allocatable  \n- CPU / Memory allocatable (netto) = total allocatable - cpu/mem reserve - spare nodes  \n  -> All requested, used and limits values are calculated with the allocatable (netto) values",
                       "mode": "markdown"
                     },
-                    "pluginVersion": "8.3.6",
-                    "title": "Comments",
+                    "pluginVersion": "13.0.1",
+                    "targets": [],
+                    "title": "",
                     "type": "text"
                   },
                   {
@@ -1302,12 +1852,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1315,14 +1865,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 2,
-                      "x": 14,
-                      "y": 28
+                      "x": 22,
+                      "y": 37
                     },
                     "id": 87,
                     "options": {
@@ -1330,6 +1879,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -1337,17 +1887,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1366,12 +1918,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1379,21 +1931,21 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
-                      "w": 2,
-                      "x": 16,
-                      "y": 28
+                      "w": 3,
+                      "x": 0,
+                      "y": 40
                     },
-                    "id": 88,
+                    "id": 215,
                     "options": {
                       "colorMode": "none",
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -1401,17 +1953,221 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n-\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Available (requestable)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 3,
+                      "x": 3,
+                      "y": 40
+                    },
+                    "id": 216,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n-\nsum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Available (for usage)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 2,
+                      "x": 6,
+                      "y": 40
+                    },
+                    "id": 203,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_capacity:cpu:sum{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores (capacity)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 2,
+                      "x": 8,
+                      "y": 40
+                    },
+                    "id": 88,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"})",
+                        "instant": true,
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1430,12 +2186,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1443,21 +2199,21 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 2,
-                      "x": 18,
-                      "y": 28
+                      "x": 10,
+                      "y": 40
                     },
-                    "id": 89,
+                    "id": 204,
                     "options": {
                       "colorMode": "none",
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -1465,17 +2221,20 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor",
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "instant": true,
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1494,12 +2253,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1508,21 +2267,21 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
-                      "w": 2,
-                      "x": 20,
-                      "y": 28
+                      "w": 3,
+                      "x": 12,
+                      "y": 40
                     },
-                    "id": 90,
+                    "id": 217,
                     "options": {
                       "colorMode": "none",
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -1530,17 +2289,224 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n-\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Mem Available (requestable)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 3,
+                      "x": 15,
+                      "y": 40
+                    },
+                    "id": 218,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n-\nsum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Mem Available (for usage)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 2,
+                      "x": 18,
+                      "y": 40
+                    },
+                    "id": 205,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_capacity:memory:sum{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory (capacity)",
+                    "type": "stat"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 3,
+                      "w": 2,
+                      "x": 20,
+                      "y": 40
+                    },
+                    "id": 90,
+                    "options": {
+                      "colorMode": "none",
+                      "graphMode": "none",
+                      "justifyMode": "auto",
+                      "orientation": "auto",
+                      "percentChangeColorMode": "standard",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"})",
+                        "instant": true,
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1559,12 +2525,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1573,14 +2539,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 2,
                       "x": 22,
-                      "y": 28
+                      "y": 40
                     },
                     "id": 91,
                     "options": {
@@ -1588,6 +2553,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -1595,17 +2561,20 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "instant": true,
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1624,14 +2593,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 100,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -1644,17 +2613,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 0,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 93,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -1663,10 +2641,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -1674,7 +2658,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1694,14 +2678,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 100,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -1714,17 +2698,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 3,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 95,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -1733,10 +2726,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -1744,7 +2743,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1764,14 +2763,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
-                        "max": 150,
+                        "max": 200,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -1779,22 +2778,31 @@ grafana:
                             },
                             {
                               "color": "red",
-                              "value": 125
+                              "value": 175
                             }
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 6,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 96,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -1803,10 +2811,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -1814,8 +2828,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})\n*\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1835,14 +2848,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 500,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -1851,17 +2864,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 9,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 97,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -1870,10 +2892,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -1881,8 +2909,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1902,14 +2929,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 100,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -1922,17 +2949,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 12,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 98,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -1941,10 +2977,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -1952,7 +2994,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -1972,14 +3014,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 100,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -1992,17 +3034,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 15,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 99,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -2011,10 +3062,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2022,7 +3079,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2042,14 +3099,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
-                        "max": 150,
+                        "max": 200,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "yellow"
+                              "color": "yellow",
+                              "value": 0
                             },
                             {
                               "color": "green",
@@ -2057,22 +3114,31 @@ grafana:
                             },
                             {
                               "color": "red",
-                              "value": 125
+                              "value": 175
                             }
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 18,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 100,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -2081,10 +3147,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2092,8 +3164,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
-                        "hide": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})\n*\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2113,14 +3184,14 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 250,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2129,17 +3200,26 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 4,
                       "w": 3,
                       "x": 21,
-                      "y": 31
+                      "y": 43
                     },
                     "id": 94,
                     "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -2148,10 +3228,16 @@ grafana:
                         "fields": "",
                         "values": false
                       },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2159,7 +3245,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2179,12 +3265,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2192,14 +3278,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 0,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 110,
                     "options": {
@@ -2207,6 +3292,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2214,9 +3300,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2224,7 +3312,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2244,12 +3332,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2257,14 +3345,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 3,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 111,
                     "options": {
@@ -2272,6 +3359,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2279,17 +3367,20 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "instant": false,
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2308,28 +3399,27 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "noValue": "0",
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
-                              "color": "purple",
+                              "color": "semi-dark-purple",
                               "value": 0
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 6,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 112,
                     "options": {
@@ -2337,6 +3427,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2344,17 +3435,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2373,12 +3466,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2386,14 +3479,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 9,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 113,
                     "options": {
@@ -2401,6 +3493,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2408,9 +3501,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2418,7 +3513,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2438,12 +3533,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2452,14 +3547,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 12,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 116,
                     "options": {
@@ -2467,6 +3561,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2474,9 +3569,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2484,7 +3581,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2504,24 +3601,23 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             }
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 15,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 121,
                     "options": {
@@ -2529,6 +3625,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2536,17 +3633,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2565,29 +3664,28 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "noValue": "0",
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
-                              "color": "purple",
+                              "color": "semi-dark-purple",
                               "value": 0
                             }
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 18,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 123,
                     "options": {
@@ -2595,6 +3693,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2602,23 +3701,25 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
                       }
                     ],
-                    "title": "Cores Wasted (apps)",
+                    "title": "Memory Wasted (apps)",
                     "type": "stat"
                   },
                   {
@@ -2631,12 +3732,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2645,14 +3746,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 21,
-                      "y": 35
+                      "y": 47
                     },
                     "id": 125,
                     "options": {
@@ -2660,6 +3760,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2667,17 +3768,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2696,12 +3799,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2709,14 +3812,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 0,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 106,
                     "options": {
@@ -2724,6 +3826,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2731,9 +3834,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2741,7 +3846,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2761,12 +3866,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2774,14 +3879,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 3,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 109,
                     "options": {
@@ -2789,6 +3893,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2796,17 +3901,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2825,27 +3932,27 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
+                        "noValue": "0",
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
-                              "color": "purple",
+                              "color": "semi-dark-purple",
                               "value": 0
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 6,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 105,
                     "options": {
@@ -2853,6 +3960,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2860,17 +3968,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2889,12 +3999,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2902,14 +4012,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 9,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 108,
                     "options": {
@@ -2917,6 +4026,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2924,9 +4034,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -2934,7 +4046,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -2954,12 +4066,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -2968,14 +4080,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 12,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 115,
                     "options": {
@@ -2983,6 +4094,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -2990,9 +4102,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -3000,7 +4114,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3020,24 +4134,23 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             }
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 15,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 120,
                     "options": {
@@ -3045,6 +4158,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3052,17 +4166,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3081,28 +4197,28 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
+                        "noValue": "0",
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
-                              "color": "purple",
+                              "color": "semi-dark-purple",
                               "value": 0
                             }
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 18,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 122,
                     "options": {
@@ -3110,6 +4226,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3117,23 +4234,25 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) > 0",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
                       }
                     ],
-                    "title": "Cores Wasted (k8s)",
+                    "title": "Memory Wasted (k8s)",
                     "type": "stat"
                   },
                   {
@@ -3146,12 +4265,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3160,14 +4279,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 21,
-                      "y": 38
+                      "y": 50
                     },
                     "id": 124,
                     "options": {
@@ -3175,6 +4293,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3182,17 +4301,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3211,12 +4332,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3224,14 +4345,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 0,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 101,
                     "options": {
@@ -3239,6 +4359,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3246,9 +4367,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -3256,7 +4379,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3276,12 +4399,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3289,14 +4412,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 3,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 102,
                     "options": {
@@ -3304,6 +4426,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3311,17 +4434,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
+                        "exemplar": false,
+                        "expr": "sum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3340,12 +4465,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3353,14 +4478,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 9,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 103,
                     "options": {
@@ -3368,6 +4492,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3375,9 +4500,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -3385,7 +4512,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3405,12 +4532,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3419,14 +4546,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 12,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 114,
                     "options": {
@@ -3434,6 +4560,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3441,9 +4568,11 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -3451,7 +4580,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3471,24 +4600,23 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             }
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 15,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 117,
                     "options": {
@@ -3496,6 +4624,7 @@ grafana:
                       "graphMode": "area",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3503,17 +4632,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
+                        "exemplar": false,
+                        "expr": "sum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3532,12 +4663,12 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3546,14 +4677,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 3,
                       "w": 3,
                       "x": 21,
-                      "y": 41
+                      "y": 53
                     },
                     "id": 119,
                     "options": {
@@ -3561,6 +4691,7 @@ grafana:
                       "graphMode": "none",
                       "justifyMode": "auto",
                       "orientation": "auto",
+                      "percentChangeColorMode": "standard",
                       "reduceOptions": {
                         "calcs": [
                           "lastNotNull"
@@ -3568,17 +4699,19 @@ grafana:
                         "fields": "",
                         "values": false
                       },
-                      "textMode": "auto"
+                      "showPercentChange": false,
+                      "textMode": "auto",
+                      "wideLayout": true
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -3599,16 +4732,23 @@ grafana:
                         },
                         "custom": {
                           "align": "center",
-                          "displayMode": "auto",
-                          "filterable": false
+                          "cellOptions": {
+                            "type": "auto"
+                          },
+                          "filterable": false,
+                          "footer": {
+                            "reducers": []
+                          },
+                          "inspect": false,
+                          "width": 140
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
@@ -3625,36 +4765,11 @@ grafana:
                           },
                           "properties": [
                             {
-                              "id": "displayName",
-                              "value": "Node"
-                            },
-                            {
                               "id": "custom.align",
                               "value": "left"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #requests"
-                          },
-                          "properties": [
+                            },
                             {
-                              "id": "displayName",
-                              "value": "Requests"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Used"
+                              "id": "custom.width"
                             }
                           ]
                         },
@@ -3665,16 +4780,15 @@ grafana:
                           },
                           "properties": [
                             {
-                              "id": "displayName",
-                              "value": "Used (from requests)"
-                            },
-                            {
                               "id": "unit",
-                              "value": "percent"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -3682,66 +4796,49 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "blue"
+                                    "color": "blue",
+                                    "value": 0
                                   },
                                   {
                                     "color": "green",
-                                    "value": 80
+                                    "value": 0.75
                                   },
                                   {
                                     "color": "red",
-                                    "value": 120
+                                    "value": 1.75
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 150
+                              "value": 2
                             },
                             {
                               "id": "decimals",
                               "value": 2
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used-average-absolut"
-                          },
-                          "properties": [
+                            },
                             {
-                              "id": "displayName",
-                              "value": "Average Usage"
+                              "id": "custom.width"
                             }
                           ]
                         },
                         {
                           "matcher": {
                             "id": "byName",
-                            "options": "Value #limits"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Limits"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used-from-limits"
+                            "options": "Value #limits-from-netto"
                           },
                           "properties": [
                             {
                               "id": "unit",
-                              "value": "percent"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -3749,62 +4846,45 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "green"
-                                  },
-                                  {
-                                    "color": "yellow",
-                                    "value": 75
+                                    "color": "blue",
+                                    "value": 0
                                   },
                                   {
                                     "color": "red",
-                                    "value": 90
+                                    "value": 2
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 100
+                              "value": 2.5
                             },
                             {
                               "id": "decimals",
                               "value": 2
                             },
                             {
-                              "id": "displayName",
-                              "value": "Used (from limits)"
+                              "id": "custom.width"
                             }
                           ]
                         },
                         {
                           "matcher": {
                             "id": "byName",
-                            "options": "Value #allocatable"
+                            "options": "Value #used-average-from-netto"
                           },
                           "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Allocatable"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used-average"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Average Usage"
-                            },
                             {
                               "id": "unit",
-                              "value": "percent"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -3812,22 +4892,61 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "green"
+                                    "color": "green",
+                                    "value": 0
                                   },
                                   {
                                     "color": "yellow",
-                                    "value": 75
+                                    "value": 0.75
                                   },
                                   {
                                     "color": "red",
-                                    "value": 90
+                                    "value": 0.9
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 100
+                              "value": 1
+                            },
+                            {
+                              "id": "custom.width"
+                            }
+                          ]
+                        },
+                        {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #available",
+                            "scope": "series"
+                          },
+                          "properties": [
+                            {
+                              "id": "thresholds",
+                              "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                  {
+                                    "color": "red",
+                                    "value": 0
+                                  },
+                                  {
+                                    "color": "dark-yellow",
+                                    "value": 2
+                                  },
+                                  {
+                                    "color": "text",
+                                    "value": 3
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "type": "color-text"
+                              }
                             }
                           ]
                         }
@@ -3837,26 +4956,20 @@ grafana:
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 44
+                      "y": 56
                     },
-                    "id": 190,
+                    "id": 206,
                     "options": {
-                      "footer": {
-                        "fields": "",
-                        "reducer": [
-                          "sum"
-                        ],
-                        "show": false
-                      },
+                      "cellHeight": "sm",
                       "showHeader": true,
                       "sortBy": [
                         {
-                          "desc": true,
-                          "displayName": "Used"
+                          "desc": false,
+                          "displayName": "Available"
                         }
                       ]
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -3864,9 +4977,21 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_node_status_capacity:cpu:sum{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "capacity"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"})",
+                        "format": "table",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3877,10 +5002,24 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) -\nsum by (node) (kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "available"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
+                        "format": "table",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3892,9 +5031,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3906,9 +5044,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})\n/\nsum by (node) (kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3920,9 +5057,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "avg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (avg_over_time(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"}[1d]))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3934,13 +5070,12 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\navg(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (avg_over_time(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"}[1d]))\n/\n(sum by (node) (kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
-                        "refId": "used-average"
+                        "refId": "used-average-from-netto"
                       },
                       {
                         "datasource": {
@@ -3948,9 +5083,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3962,13 +5096,12 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})\n/\n(sum by (node) (kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
-                        "refId": "used-from-limits"
+                        "refId": "limits-from-netto"
                       }
                     ],
                     "title": "CPU Cores by Node",
@@ -3983,8 +5116,27 @@ grafana:
                           "excludeByName": {
                             "Time": true
                           },
+                          "includeByName": {},
                           "indexByName": {},
-                          "renameByName": {}
+                          "orderByMode": "manual",
+                          "renameByName": {
+                            "Value #A": "Available",
+                            "Value #allocatable": "Allocatable",
+                            "Value #available": "Available",
+                            "Value #capacity": "Capacity",
+                            "Value #limits": "Limits",
+                            "Value #limits-from-allocatable": "Limits (from allocatable)",
+                            "Value #limits-from-netto": "Limits (from netto)",
+                            "Value #requests": "Requests",
+                            "Value #used": "Used",
+                            "Value #used-average": "Average Usage (from capacity, 1d)",
+                            "Value #used-average-absolut": "Average Usage (1d)",
+                            "Value #used-average-from-capacity": "Average Usage (from capacity, 1d)",
+                            "Value #used-average-from-netto": "Average Usage (from netto, 1d)",
+                            "Value #used-from-limits": "Used (from limits)",
+                            "Value #used-from-requests": "Used (from requests)",
+                            "node": "Node"
+                          }
                         }
                       }
                     ],
@@ -4002,23 +5154,31 @@ grafana:
                         },
                         "custom": {
                           "align": "center",
-                          "displayMode": "auto",
-                          "filterable": false
+                          "cellOptions": {
+                            "type": "auto"
+                          },
+                          "filterable": false,
+                          "footer": {
+                            "reducers": []
+                          },
+                          "inspect": false,
+                          "width": 140
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
                             {
-                              "color": "green"
+                              "color": "green",
+                              "value": 0
                             },
                             {
                               "color": "red",
                               "value": 80
                             }
                           ]
-                        }
+                        },
+                        "unit": "bytes"
                       },
                       "overrides": [
                         {
@@ -4028,44 +5188,11 @@ grafana:
                           },
                           "properties": [
                             {
-                              "id": "displayName",
-                              "value": "Node"
-                            },
-                            {
                               "id": "custom.align",
                               "value": "left"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #requests"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Requests"
                             },
                             {
-                              "id": "unit",
-                              "value": "bytes"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Used"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "bytes"
+                              "id": "custom.width"
                             }
                           ]
                         },
@@ -4076,16 +5203,15 @@ grafana:
                           },
                           "properties": [
                             {
-                              "id": "displayName",
-                              "value": "Used (from requests)"
-                            },
-                            {
                               "id": "unit",
-                              "value": "percent"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -4093,74 +5219,49 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "blue"
+                                    "color": "blue",
+                                    "value": 0
                                   },
                                   {
                                     "color": "green",
-                                    "value": 80
+                                    "value": 0.75
                                   },
                                   {
                                     "color": "red",
-                                    "value": 120
+                                    "value": 1.75
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 150
+                              "value": 2
                             },
                             {
                               "id": "decimals",
                               "value": 2
+                            },
+                            {
+                              "id": "custom.width"
                             }
                           ]
                         },
                         {
                           "matcher": {
                             "id": "byName",
-                            "options": "Value #used-average-absolut"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Average Usage (1d)"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "bytes"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #limits"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Limits"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "bytes"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used-from-limits"
+                            "options": "Value #limits-from-netto"
                           },
                           "properties": [
                             {
                               "id": "unit",
-                              "value": "percent"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -4168,66 +5269,45 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "green"
-                                  },
-                                  {
-                                    "color": "yellow",
-                                    "value": 75
+                                    "color": "blue",
+                                    "value": 0
                                   },
                                   {
                                     "color": "red",
-                                    "value": 90
+                                    "value": 2
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 100
+                              "value": 2.5
                             },
                             {
                               "id": "decimals",
                               "value": 2
                             },
                             {
-                              "id": "displayName",
-                              "value": "Used (from limits)"
+                              "id": "custom.width"
                             }
                           ]
                         },
                         {
                           "matcher": {
                             "id": "byName",
-                            "options": "Value #allocatable"
+                            "options": "Value #used-average-from-netto"
                           },
                           "properties": [
                             {
-                              "id": "displayName",
-                              "value": "Allocatable"
-                            },
-                            {
                               "id": "unit",
-                              "value": "bytes"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #used-average"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Average Usage (1d)"
+                              "value": "percentunit"
                             },
                             {
-                              "id": "unit",
-                              "value": "percent"
-                            },
-                            {
-                              "id": "custom.displayMode",
-                              "value": "lcd-gauge"
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "mode": "lcd",
+                                "type": "gauge"
+                              }
                             },
                             {
                               "id": "thresholds",
@@ -4235,22 +5315,61 @@ grafana:
                                 "mode": "absolute",
                                 "steps": [
                                   {
-                                    "color": "green"
+                                    "color": "green",
+                                    "value": 0
                                   },
                                   {
                                     "color": "yellow",
-                                    "value": 75
+                                    "value": 0.75
                                   },
                                   {
                                     "color": "red",
-                                    "value": 90
+                                    "value": 0.9
                                   }
                                 ]
                               }
                             },
                             {
                               "id": "max",
-                              "value": 100
+                              "value": 1
+                            },
+                            {
+                              "id": "custom.width"
+                            }
+                          ]
+                        },
+                        {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #available",
+                            "scope": "series"
+                          },
+                          "properties": [
+                            {
+                              "id": "thresholds",
+                              "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                  {
+                                    "color": "red",
+                                    "value": 0
+                                  },
+                                  {
+                                    "color": "orange",
+                                    "value": 3221225472
+                                  },
+                                  {
+                                    "color": "text",
+                                    "value": 5368709120
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                "type": "color-text"
+                              }
                             }
                           ]
                         }
@@ -4260,26 +5379,20 @@ grafana:
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 51
+                      "y": 63
                     },
-                    "id": 191,
+                    "id": 207,
                     "options": {
-                      "footer": {
-                        "fields": "",
-                        "reducer": [
-                          "sum"
-                        ],
-                        "show": false
-                      },
+                      "cellHeight": "sm",
                       "showHeader": true,
                       "sortBy": [
                         {
-                          "desc": true,
-                          "displayName": "Used"
+                          "desc": false,
+                          "displayName": "Available"
                         }
                       ]
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "13.0.1",
                     "targets": [
                       {
                         "datasource": {
@@ -4287,9 +5400,21 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_node_status_capacity:memory:sum{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "capacity"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_node_status_allocatable:memory:sum{role=~\"$noderole\"})",
+                        "format": "table",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4300,10 +5425,24 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) -\nsum by (node) (kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "available"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
+                        "format": "table",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4315,9 +5454,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4329,9 +5467,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
+                        "expr": "sum by (node) (node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})\n/\nsum by (node) (kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4343,9 +5480,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "avg(sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))) by (node)\n-\navg(sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))) by (node)",
+                        "expr": "sum by (node) (avg_over_time(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"}[1d]))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4357,13 +5493,12 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\navg(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n-\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n) by (node)",
+                        "expr": "sum by (node) (avg_over_time(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"}[1d]))\n/\n(sum by (node) (kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
-                        "refId": "used-average"
+                        "refId": "used-average-from-netto"
                       },
                       {
                         "datasource": {
@@ -4371,9 +5506,8 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)",
+                        "expr": "sum by (node) (kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4385,13 +5519,12 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (node)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info))) by (node)\n)",
+                        "expr": "sum by (node) (kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})\n/\n(sum by (node) (kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve))",
                         "format": "table",
-                        "hide": false,
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
-                        "refId": "used-from-limits"
+                        "refId": "limits-from-netto"
                       }
                     ],
                     "title": "Memory by Node",
@@ -4406,8 +5539,25 @@ grafana:
                           "excludeByName": {
                             "Time": true
                           },
+                          "includeByName": {},
                           "indexByName": {},
-                          "renameByName": {}
+                          "renameByName": {
+                            "Value #allocatable": "Allocatable",
+                            "Value #available": "Available",
+                            "Value #capacity": "Capacity",
+                            "Value #limits": "Limits",
+                            "Value #limits-from-allocatable": "Limits (from allocatable)",
+                            "Value #limits-from-netto": "Limits (from netto)",
+                            "Value #requests": "Requests",
+                            "Value #used": "Used",
+                            "Value #used-average": "Average Usage (from capacity)",
+                            "Value #used-average-absolut": "Average Usage (1d)",
+                            "Value #used-average-from-capacity": "Average Usage (from capacity, 1d)",
+                            "Value #used-average-from-netto": "Average Usage (from netto, 1d)",
+                            "Value #used-from-limits": "Limits (from allocatable)",
+                            "Value #used-from-requests": "Used (from requests)",
+                            "node": "Node"
+                          }
                         }
                       }
                     ],
@@ -4424,9 +5574,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -4435,13 +5589,15 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
                           "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
+                          "showValues": false,
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -4451,7 +5607,2772 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
+                        "decimals": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 24,
+                      "x": 0,
+                      "y": 70
+                    },
+                    "id": 220,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [
+                          "max",
+                          "mean",
+                          "lastNotNull"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last *",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "desc"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "expr": "sum by(node) (kube_pod_info) * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"}",
+                        "instant": false,
+                        "legendFormat": "{{node}}",
+                        "range": true,
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Pods per Node",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 2,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "bars",
+                          "fillOpacity": 70,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "linear",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.5
+                            }
+                          ]
+                        },
+                        "unit": "short"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 24,
+                      "x": 0,
+                      "y": 76
+                    },
+                    "id": 212,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [
+                          "max",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_node_status_condition{condition=\"MemoryPressure\", status!=\"false\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Nodes with Memory Pressure",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 2,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "bars",
+                          "fillOpacity": 70,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "linear",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.5
+                            }
+                          ]
+                        },
+                        "unit": "short"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 24,
+                      "x": 0,
+                      "y": 82
+                    },
+                    "id": 211,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [
+                          "max",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_node_status_condition{condition=\"DiskPressure\", status!=\"false\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Nodes with Disk Pressure",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 2,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "bars",
+                          "fillOpacity": 70,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "linear",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.5
+                            }
+                          ]
+                        },
+                        "unit": "short"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 24,
+                      "x": 0,
+                      "y": 88
+                    },
+                    "id": 213,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [
+                          "max",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum by (node) (kube_node_status_condition{condition=\"PIDPressure\", status!=\"false\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Nodes with PID Pressure",
+                    "type": "timeseries"
+                  }
+                ],
+                "title": "Capacity Management - Overview",
+                "type": "row"
+              },
+              {
+                "collapsed": true,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 37
+                },
+                "id": 224,
+                "panels": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 38
+                    },
+                    "id": 155,
+                    "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Requested (from netto)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 100,
+                          "axisSoftMin": -9,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.4
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.8
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 38
+                    },
+                    "id": 156,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Cores Requested (from netto)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            }
+                          ]
+                        },
+                        "unit": "none"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 38
+                    },
+                    "id": 137,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "interval": "",
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Requested & Allocatable",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 44
+                    },
+                    "id": 170,
+                    "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory Requested (from netto)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 1,
+                          "axisSoftMin": 0,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.4
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.8
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 44
+                    },
+                    "id": 171,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Memory Requested (from netto)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 44
+                    },
+                    "id": 172,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "interval": "",
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory Requested & Allocatable",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 50
+                    },
+                    "id": 157,
+                    "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Used (from netto)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 1,
+                          "axisSoftMin": 0,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.4
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.8
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 50
+                    },
+                    "id": 142,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "nodes (total)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Used (from netto)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            }
+                          ]
+                        },
+                        "unit": "none"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 50
+                    },
+                    "id": 154,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "nodes (total)",
+                        "refId": "D"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "interval": "",
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Used & Allocatable",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 56
+                    },
+                    "id": 173,
+                    "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory Used (from netto)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 1,
+                          "axisSoftMin": 0,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.4
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.8
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 56
+                    },
+                    "id": 174,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "nodes (total)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory Used (from netto)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 56
+                    },
+                    "id": 175,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "nodes (total used)",
+                        "refId": "D"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
+                        "interval": "",
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Memory Used & Allocatable",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 200,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 75
+                            },
+                            {
+                              "color": "red",
+                              "value": 175
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 62
+                    },
+                    "id": 158,
+                    "options": {
+                      "barShape": "flat",
+                      "barWidthFactor": 0.5,
+                      "effects": {
+                        "barGlow": false,
+                        "centerGlow": false,
+                        "gradient": false
+                      },
+                      "endpointMarker": "point",
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "segmentCount": 1,
+                      "segmentSpacing": 0.3,
+                      "shape": "gauge",
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto",
+                      "sparkline": false,
+                      "textMode": "auto"
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})\n*\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Cores Used (from requested)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 200,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "max": 2,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 1.75
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 62
+                    },
+                    "id": 159,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Cores Used (from requested)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "showValues": false,
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            }
+                          ]
+                        },
+                        "unit": "none"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 62
+                    },
+                    "id": 160,
+                    "options": {
+                      "annotations": {
+                        "clustering": -1,
+                        "multiLane": false
+                      },
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "13.0.1",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "A"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "D"
+                      }
+                    ],
+                    "title": "Cores Used & Requested",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 200,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow"
+                            },
+                            {
+                              "color": "green",
+                              "value": 75
+                            },
+                            {
+                              "color": "red",
+                              "value": 175
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 68
+                    },
+                    "id": 176,
+                    "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})\n*\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Memory Used (from requested)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 2,
+                          "axisSoftMin": 0,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 4,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "yellow"
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 1.75
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 68
+                    },
+                    "id": 177,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Memory Used (from requested)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 68
+                    },
+                    "id": 178,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "A"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "E"
+                      }
+                    ],
+                    "title": "Memory Used & Requested",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "semi-dark-purple",
+                              "value": 25
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 74
+                    },
+                    "id": 161,
+                    "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})\n*\n(\n  sum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"})\n  -\n  sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})\n)\n> 0",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Cores Wasted (from requested)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": -1,
+                          "axisSoftMin": 0,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "semi-dark-purple",
+                              "value": 0.25
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 74
+                    },
+                    "id": 162,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "(\n  sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n  -\n  sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n)\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": " apps (wasted)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "(\n  sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n  -\n  sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n)\n/\nsum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "k8s (wasted)",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Cores Wasted (from requested)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            }
+                          ]
+                        },
+                        "unit": "none"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 74
+                    },
+                    "id": 163,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "apps (wasted)",
+                        "refId": "A"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "k8s (wasted)",
+                        "refId": "D"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "F"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "E"
+                      }
+                    ],
+                    "title": "Cores Used, Requested & Wasted",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -4464,14 +8385,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 58
+                      "y": 80
                     },
                     "id": 201,
                     "options": {
@@ -4483,20 +8403,26 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (namespace)\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\",pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) by (namespace) > 0",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:cpu:running:namespace{role=~\"$noderole\"}) by (namespace)\n-\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"}) by (namespace)\n> 0",
                         "interval": "",
                         "legendFormat": "{{namespace}}",
                         "refId": "A"
@@ -4513,12 +8439,86 @@ grafana:
                     "fieldConfig": {
                       "defaults": {
                         "color": {
+                          "mode": "thresholds"
+                        },
+                        "max": 100,
+                        "min": 0,
+                        "noValue": "0",
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "purple",
+                              "value": 25
+                            }
+                          ]
+                        },
+                        "unit": "percent"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 3,
+                      "x": 0,
+                      "y": 88
+                    },
+                    "id": 179,
+                    "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
+                      "orientation": "auto",
+                      "reduceOptions": {
+                        "calcs": [
+                          "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                      },
+                      "showThresholdLabels": true,
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})\n*\n(\n  sum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"})\n  -\n  sum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})\n) > 0",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Memory Wasted (from requested)",
+                    "type": "gauge"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
+                          "axisSoftMax": 1,
+                          "axisSoftMin": 0,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -4527,13 +8527,121 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
                           "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "noValue": "0",
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "purple",
+                              "value": 0.25
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 10,
+                      "x": 3,
+                      "y": 88
+                    },
+                    "id": 180,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "(\n  sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n  -\n  sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n)\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": " apps (wasted)",
+                        "refId": "A"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "(\n  sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n  -\n  sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n)\n/\nsum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "k8s (wasted)",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Memory Wasted (from requested)",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -4543,7 +8651,153 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
+                        "noValue": "0",
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            }
+                          ]
+                        },
+                        "unit": "bytes"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 6,
+                      "w": 11,
+                      "x": 13,
+                      "y": 88
+                    },
+                    "id": 181,
+                    "options": {
+                      "legend": {
+                        "calcs": [],
+                        "displayMode": "list",
+                        "placement": "bottom",
+                        "showLegend": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "apps (wasted)",
+                        "refId": "A"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (requested)",
+                        "refId": "C"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "apps (used)",
+                        "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n-\nsum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n> 0",
+                        "interval": "",
+                        "legendFormat": "k8s (wasted)",
+                        "refId": "D"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (requested)",
+                        "refId": "F"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "k8s (used)",
+                        "refId": "E"
+                      }
+                    ],
+                    "title": "Cores Used, Requested & Wasted",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 0,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -4557,14 +8811,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 66
+                      "y": 94
                     },
                     "id": 202,
                     "options": {
@@ -4576,20 +8829,26 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info)) by (namespace)\n-\nsum(container_memory_working_set_bytes{container=\"\",pod!=\"\"} * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")) by (namespace) > 0",
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_requests:memory:running:namespace{role=~\"$noderole\"}) by (namespace)\n-\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"}) by (namespace)\n> 0",
                         "interval": "",
                         "legendFormat": "{{namespace}}",
                         "refId": "A"
@@ -4597,322 +8856,6 @@ grafana:
                     ],
                     "title": "Namespaces Wasting Memory",
                     "type": "timeseries"
-                  }
-                ],
-                "title": "Capacity Management - Overview",
-                "type": "row"
-              },
-              {
-                "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "gridPos": {
-                  "h": 1,
-                  "w": 24,
-                  "x": 0,
-                  "y": 28
-                },
-                "id": 189,
-                "panels": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 3
-                    },
-                    "id": 155,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Cores Requested (from netto)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": -9,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 3
-                    },
-                    "id": 156,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Cores Requested (from netto)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "none"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 3
-                    },
-                    "id": 137,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
-                        "interval": "",
-                        "legendFormat": "allocatable (netto)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (requested)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (requested)",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Cores Allocatable & Requested",
-                    "type": "timeseries"
                   },
                   {
                     "datasource": {
@@ -4924,2178 +8867,6 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 9
-                    },
-                    "id": 170,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Memory Requested (from netto)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": -9,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 9
-                    },
-                    "id": 171,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Memory Requested (from netto)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 9
-                    },
-                    "id": 172,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "allocatable (netto)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (requested)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (requested)",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Memory Allocatable & Requested",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 15
-                    },
-                    "id": 157,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Cores Used (from netto)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": -9,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 15
-                    },
-                    "id": 142,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(\nsum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info))\n-\navg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor\n)\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Cores Used (from netto)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "none"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 15
-                    },
-                    "id": 154,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
-                        "interval": "",
-                        "legendFormat": "allocatable (netto)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "D"
-                      }
-                    ],
-                    "title": "Cores Allocatable & Used",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 21
-                    },
-                    "id": 173,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Memory Used (from netto)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": -9,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 40
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 21
-                    },
-                    "id": 174,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  -\n  avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info))\n  * $sparenodesfactor\n)\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Memory Used (from netto)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 21
-                    },
-                    "id": 175,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "allocatable (netto)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (node)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "D"
-                      }
-                    ],
-                    "title": "Memory Allocatable & Used",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 150,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 75
-                            },
-                            {
-                              "color": "red",
-                              "value": 125
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 27
-                    },
-                    "id": 158,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Cores Used (from requested)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 150,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 75
-                            },
-                            {
-                              "color": "red",
-                              "value": 125
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 27
-                    },
-                    "id": 159,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Cores Used (from requested)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "none"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 27
-                    },
-                    "id": 160,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "requested",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "D"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Cores Requested & Used",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 150,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 75
-                            },
-                            {
-                              "color": "red",
-                              "value": 125
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 33
-                    },
-                    "id": 176,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Memory Used (from requested)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 150,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "yellow"
-                            },
-                            {
-                              "color": "green",
-                              "value": 75
-                            },
-                            {
-                              "color": "red",
-                              "value": 125
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 33
-                    },
-                    "id": 177,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n  -\n  sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n)",
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Memory Used (from requested)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 33
-                    },
-                    "id": 178,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "requested",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) ((node_uname_info)))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "D"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "C"
-                      }
-                    ],
-                    "title": "Memory Requested & Used",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "purple",
-                              "value": 25
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 39
-                    },
-                    "id": 161,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Cores Wasted (from requested)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": 0,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "purple",
-                              "value": 25
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 39
-                    },
-                    "id": 162,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": " apps (wasted)",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\")))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (wasted)",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Cores Wasted (from requested)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "none"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 39
-                    },
-                    "id": 163,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "multi"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (wasted)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (wasted)",
-                        "refId": "D"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "E"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "apps (requested)",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (requested)",
-                        "refId": "F"
-                      }
-                    ],
-                    "title": "Cores Requested, Used & Wasted",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
-                        "max": 100,
-                        "min": 0,
-                        "noValue": "0",
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "purple",
-                              "value": 25
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 3,
-                      "x": 0,
-                      "y": 45
-                    },
-                    "id": 179,
-                    "options": {
-                      "orientation": "auto",
-                      "reduceOptions": {
-                        "calcs": [
-                          "lastNotNull"
-                        ],
-                        "fields": "",
-                        "values": false
-                      },
-                      "showThresholdLabels": true,
-                      "showThresholdMarkers": true
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Memory Wasted (from requested)",
-                    "type": "gauge"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "axisSoftMax": 100,
-                          "axisSoftMin": 0,
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "area"
-                          }
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "purple",
-                              "value": 25
-                            }
-                          ]
-                        },
-                        "unit": "percent"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 10,
-                      "x": 3,
-                      "y": 45
-                    },
-                    "id": 180,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "multi"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": " apps (wasted)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\n(\n  sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n  -\n  sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))\n)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (wasted)",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Memory Wasted (from requested)",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 0,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "noValue": "0",
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 6,
-                      "w": 11,
-                      "x": 13,
-                      "y": 45
-                    },
-                    "id": 181,
-                    "options": {
-                      "legend": {
-                        "calcs": [],
-                        "displayMode": "list",
-                        "placement": "bottom"
-                      },
-                      "tooltip": {
-                        "mode": "multi"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (wasted)",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n-\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (wasted)",
-                        "refId": "D"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "apps (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (used)",
-                        "refId": "E"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "apps (requested)",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s (requested)",
-                        "refId": "F"
-                      }
-                    ],
-                    "title": "Memory Requested, Used & Wasted",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "mappings": [],
                         "max": 500,
                         "min": 0,
                         "thresholds": {
@@ -7111,17 +8882,18 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 3,
                       "x": 0,
-                      "y": 51
+                      "y": 102
                     },
                     "id": 164,
                     "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -7131,9 +8903,10 @@ grafana:
                         "values": false
                       },
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -7141,8 +8914,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -7163,10 +8935,14 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 500,
+                          "axisSoftMax": 5,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7175,13 +8951,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7191,7 +8968,6 @@ grafana:
                             "mode": "area"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7201,67 +8977,56 @@ grafana:
                             },
                             {
                               "color": "red",
-                              "value": 401
+                              "value": 4
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 10,
                       "x": 3,
-                      "y": 51
+                      "y": 102
                     },
                     "id": 165,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total",
-                        "refId": "C"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "(100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "k8s",
-                        "refId": "A"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
                         "interval": "",
                         "legendFormat": "apps",
                         "refId": "B"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
+                        "interval": "",
+                        "legendFormat": "k8s",
+                        "refId": "A"
                       }
                     ],
                     "title": "Cores Limits (from netto)",
@@ -7278,9 +9043,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7289,13 +9058,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7305,7 +9075,6 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7316,26 +9085,29 @@ grafana:
                           ]
                         },
                         "unit": "none"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 11,
                       "x": 13,
-                      "y": 51
+                      "y": 102
                     },
                     "id": 166,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -7343,19 +9115,18 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
+                        "legendFormat": "apps",
+                        "refId": "B"
                       },
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s",
                         "refId": "D"
@@ -7365,12 +9136,11 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_node_status_allocatable:cpu:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:cpu:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
                         "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "B"
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "C"
                       }
                     ],
                     "title": "Cores Limits",
@@ -7386,7 +9156,6 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 500,
                         "min": 0,
                         "thresholds": {
@@ -7402,17 +9171,18 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 3,
                       "x": 0,
-                      "y": 57
+                      "y": 108
                     },
                     "id": 182,
                     "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -7422,9 +9192,10 @@ grafana:
                         "values": false
                       },
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -7432,8 +9203,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -7454,10 +9224,14 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 500,
+                          "axisSoftMax": 2.5,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7466,13 +9240,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7482,7 +9257,6 @@ grafana:
                             "mode": "area"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7492,52 +9266,53 @@ grafana:
                             },
                             {
                               "color": "red",
-                              "value": 401
+                              "value": 2
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 10,
                       "x": 3,
-                      "y": 57
+                      "y": 108
                     },
                     "id": 183,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
                         "interval": "",
-                        "legendFormat": "total",
-                        "refId": "C"
+                        "legendFormat": "apps",
+                        "refId": "B"
                       },
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\n(\n  sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor\n)",
                         "interval": "",
                         "legendFormat": "k8s",
                         "refId": "A"
@@ -7547,12 +9322,11 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "100\n/\n(sum(kube_node_status_allocatable{resource=\"memory\"} * on(node) group_left() group by (node) (kube_node_info)) - avg(kube_node_status_allocatable{resource=\"cpu\"} * on(node) group_left() group by (node) (kube_node_info)) * $sparenodesfactor)\n*\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum * on(node) group_left(role) instance:kube_node_role{role=~\"$noderole\"})\n  -\n  sum(kube_node_status_allocatable:memory:avg * on(node) group_left(role) instance:kube_node_role{role=~\"$noderole\"}) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:memory:running:namespace * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
-                        "legendFormat": "apps",
-                        "refId": "B"
+                        "legendFormat": "total",
+                        "refId": "C"
                       }
                     ],
                     "title": "Memory Limits (from netto)",
@@ -7569,9 +9343,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7580,13 +9358,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7596,7 +9375,6 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7607,35 +9385,37 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 11,
                       "x": 13,
-                      "y": 57
+                      "y": 108
                     },
                     "id": 184,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "multi"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps",
                         "refId": "B"
@@ -7645,9 +9425,8 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s",
                         "refId": "D"
@@ -7658,10 +9437,10 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
+                        "expr": "sum(kube_node_status_allocatable:memory:sum{role=~\"$noderole\"}) * (1 - $nodecpumemreserve)\n-\nsum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * (1 - $nodecpumemreserve) * $sparenodesfactor",
                         "interval": "",
-                        "legendFormat": "total",
-                        "refId": "A"
+                        "legendFormat": "allocatable (netto)",
+                        "refId": "C"
                       }
                     ],
                     "title": "Memory Limits",
@@ -7677,7 +9456,6 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
                         "max": 98,
                         "min": 0,
                         "thresholds": {
@@ -7697,17 +9475,18 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 3,
                       "x": 0,
-                      "y": 63
+                      "y": 114
                     },
                     "id": 167,
                     "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -7717,9 +9496,10 @@ grafana:
                         "values": false
                       },
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -7727,8 +9507,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})\n*\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -7743,16 +9522,21 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
+                    "description": "Not all workloads have limits defined but still use CPU resources. Thas why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 100,
+                          "axisSoftMax": 1,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7761,13 +9545,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7777,7 +9562,6 @@ grafana:
                             "mode": "area"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7787,44 +9571,46 @@ grafana:
                             },
                             {
                               "color": "orange",
-                              "value": 75
+                              "value": 0.75
                             },
                             {
                               "color": "red",
-                              "value": 90
+                              "value": 0.9
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 10,
                       "x": 3,
-                      "y": 63
+                      "y": 114
                     },
                     "id": 168,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (used)",
                         "refId": "A"
@@ -7834,27 +9620,14 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "(100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))) or on() vector(0)",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (used)",
                         "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(rate(container_cpu_usage_seconds_total{container=\"\",}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "C"
                       }
                     ],
-                    "title": "Cores Limits (from netto)",
+                    "title": "Cores Used (from LImits)",
                     "type": "timeseries"
                   },
                   {
@@ -7862,15 +9635,20 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
+                    "description": "Not all workloads have limits defined but still use CPU resources. Thas why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -7879,13 +9657,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -7895,7 +9674,6 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -7906,35 +9684,37 @@ grafana:
                           ]
                         },
                         "unit": "none"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 11,
                       "x": 13,
-                      "y": 63
+                      "y": 114
                     },
                     "id": 169,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (used)",
                         "refId": "D"
@@ -7944,9 +9724,8 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (limits)",
                         "refId": "C"
@@ -7956,9 +9735,8 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_cpu_usage_seconds_total:sum_rate5m:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (used)",
                         "refId": "F"
@@ -7968,38 +9746,14 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "(sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))) or on() vector(0)",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (limits)",
                         "refId": "E"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"\", pod!=\"\"}[5m]) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "total (limits)",
-                        "refId": "A"
                       }
                     ],
-                    "title": "Cores Limits & Used",
+                    "title": "Cores Used & Limits",
                     "type": "timeseries"
                   },
                   {
@@ -8012,8 +9766,7 @@ grafana:
                         "color": {
                           "mode": "thresholds"
                         },
-                        "mappings": [],
-                        "max": 98,
+                        "max": 100,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8032,17 +9785,18 @@ grafana:
                           ]
                         },
                         "unit": "percent"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 3,
                       "x": 0,
-                      "y": 69
+                      "y": 120
                     },
                     "id": 185,
                     "options": {
+                      "minVizHeight": 75,
+                      "minVizWidth": 75,
                       "orientation": "auto",
                       "reduceOptions": {
                         "calcs": [
@@ -8052,9 +9806,10 @@ grafana:
                         "values": false
                       },
                       "showThresholdLabels": true,
-                      "showThresholdMarkers": true
+                      "showThresholdMarkers": true,
+                      "sizing": "auto"
                     },
-                    "pluginVersion": "8.3.6",
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8062,8 +9817,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (kube_pod_status_phase{phase=\"Running\"}==1) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "expr": "100\n/\nsum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})\n*\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -8078,16 +9832,21 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
+                    "description": "Not all workloads have limits defined but still use Memory resources. Thas why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 100,
+                          "axisSoftMax": 1,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -8096,13 +9855,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -8112,7 +9872,6 @@ grafana:
                             "mode": "area"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8122,35 +9881,38 @@ grafana:
                             },
                             {
                               "color": "orange",
-                              "value": 75
+                              "value": 0.75
                             },
                             {
                               "color": "red",
-                              "value": 90
+                              "value": 0.9
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 10,
                       "x": 3,
-                      "y": 69
+                      "y": 120
                     },
                     "id": 186,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "multi"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8158,8 +9920,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (used)",
                         "refId": "A"
@@ -8170,26 +9931,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})\n/\nsum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (used)",
                         "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits{resource=\"memory\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))\n*\nsum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "C"
                       }
                     ],
-                    "title": "Memory Limits (from netto)",
+                    "title": "Memory Used (from Limits)",
                     "type": "timeseries"
                   },
                   {
@@ -8197,15 +9945,20 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
+                    "description": "Not all workloads have limits defined but still use Memory resources. Thas why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -8214,13 +9967,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -8230,7 +9984,6 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8241,35 +9994,37 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 6,
                       "w": 11,
                       "x": 13,
-                      "y": 69
+                      "y": 120
                     },
                     "id": 187,
                     "options": {
                       "legend": {
                         "calcs": [],
                         "displayMode": "list",
-                        "placement": "bottom"
+                        "placement": "bottom",
+                        "showLegend": true
                       },
                       "tooltip": {
-                        "mode": "multi"
+                        "hideZeros": false,
+                        "mode": "multi",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (used)",
                         "refId": "D"
@@ -8279,9 +10034,8 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace!~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "apps (limits)",
                         "refId": "C"
@@ -8291,9 +10045,8 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(container_memory_working_set_bytes:sum:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (used)",
                         "refId": "F"
@@ -8303,38 +10056,14 @@ grafana:
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
-                        "exemplar": true,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "hide": false,
+                        "exemplar": false,
+                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "k8s (limits)",
                         "refId": "E"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": true,
-                        "expr": "sum(container_memory_working_set_bytes{container=\"\", pod!=\"\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(instance) group_left() label_replace(group by (node) (kube_node_info), \"instance\", \"$1\", \"node\", \"(.*)\"))",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "total (used)",
-                        "refId": "B"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"} * on(pod, namespace) group_left() (topk(1,kube_pod_status_phase{phase=\"Running\"}==1) by (pod)) * on(node) group_left() group by (node) (kube_node_info))",
-                        "interval": "",
-                        "legendFormat": "total (limits)",
-                        "refId": "A"
                       }
                     ],
-                    "title": "Memory Limits & Used",
+                    "title": "Memory Used & Limits",
                     "type": "timeseries"
                   }
                 ],
@@ -8343,17 +10072,13 @@ grafana:
               },
               {
                 "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
-                  "y": 29
+                  "y": 38
                 },
-                "id": 38,
+                "id": 225,
                 "panels": [
                   {
                     "datasource": {
@@ -8366,9 +10091,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -8377,13 +10106,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -8393,8 +10123,7 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "decimals": 4,
-                        "mappings": [],
+                        "decimals": 2,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8408,14 +10137,13 @@ grafana:
                             }
                           ]
                         }
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 30
+                      "y": 39
                     },
                     "id": 52,
                     "options": {
@@ -8428,13 +10156,17 @@ grafana:
                         ],
                         "displayMode": "table",
                         "placement": "right",
+                        "showLegend": true,
                         "sortBy": "Last",
-                        "sortDesc": false
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8442,13 +10174,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "CPU Cores Usage by Node",
+                    "title": "CPU Cores Usage by Node (absolute)",
                     "type": "timeseries"
                   },
                   {
@@ -8462,25 +10194,29 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 100,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
-                          "fillOpacity": 10,
+                          "fillOpacity": 0,
                           "gradientMode": "none",
                           "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -8491,7 +10227,7 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8500,24 +10236,23 @@ grafana:
                               "color": "green"
                             },
                             {
-                              "color": "yellow",
-                              "value": 75
+                              "color": "light-orange",
+                              "value": 0.75
                             },
                             {
                               "color": "red",
-                              "value": 90
+                              "value": 0.9
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 37
+                      "y": 173
                     },
                     "id": 194,
                     "options": {
@@ -8530,13 +10265,17 @@ grafana:
                         ],
                         "displayMode": "table",
                         "placement": "right",
+                        "showLegend": true,
                         "sortBy": "Last",
-                        "sortDesc": false
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8544,13 +10283,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) ((node_uname_info))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "sum by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})\n/\ncount by (node) (node_cpu_seconds_total:sum_rate5m{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "CPU Cores Usage by Node",
+                    "title": "CPU Cores Usage by Node (%)",
                     "type": "timeseries"
                   }
                 ],
@@ -8559,17 +10298,13 @@ grafana:
               },
               {
                 "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
-                  "y": 30
+                  "y": 39
                 },
-                "id": 62,
+                "id": 226,
                 "panels": [
                   {
                     "datasource": {
@@ -8582,9 +10317,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -8593,13 +10332,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -8610,7 +10350,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8625,14 +10364,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 31
+                      "y": 40
                     },
                     "id": 55,
                     "options": {
@@ -8644,12 +10382,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8657,13 +10401,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n-\nsum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
+                        "expr": "node_memory_MemUsed_bytes:sum{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "Memory Usage by Node",
+                    "title": "Memory Usage by Node (absolute)",
                     "type": "timeseries"
                   },
                   {
@@ -8677,35 +10421,40 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
-                          "fillOpacity": 10,
+                          "fillOpacity": 0,
                           "gradientMode": "none",
                           "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
                             "mode": "none"
                           },
                           "thresholdsStyle": {
-                            "mode": "off"
+                            "mode": "area"
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -8714,20 +10463,23 @@ grafana:
                               "color": "green"
                             },
                             {
+                              "color": "semi-dark-orange",
+                              "value": 0.75
+                            },
+                            {
                               "color": "red",
-                              "value": 80
+                              "value": 0.9
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 38
+                      "y": 126
                     },
                     "id": 195,
                     "options": {
@@ -8739,12 +10491,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -8752,13 +10510,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n*\n(\n sum(node_memory_MemTotal_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n -\n sum(node_memory_MemAvailable_bytes{job=~\"kubernetes-service-endpoints|node-exporter\"} * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n)",
+                        "expr": "sum by (node) (node_memory_MemUsed_bytes:sum{role=~\"$noderole\"})\n/\nsum by (node) (kube_node_status_capacity:memory:sum{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "Memory Usage by Node",
+                    "title": "Memory Usage by Node (%)",
                     "type": "timeseries"
                   }
                 ],
@@ -8767,285 +10525,14 @@ grafana:
               },
               {
                 "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
-                  "y": 31
+                  "y": 40
                 },
-                "id": 66,
+                "id": 227,
                 "panels": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "custom": {
-                          "align": "center",
-                          "displayMode": "auto",
-                          "filterable": false
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "binBps"
-                      },
-                      "overrides": [
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #bytes-read"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Read Thoughput"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #bytes-write"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Write Throughput"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #iops-read"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Read IOPS"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "iops"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #iops-write"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Write IOPS"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "iops"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "node"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Node"
-                            },
-                            {
-                              "id": "custom.align",
-                              "value": "left"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #read-wait"
-                          },
-                          "properties": [
-                            {
-                              "id": "unit",
-                              "value": "s"
-                            },
-                            {
-                              "id": "displayName",
-                              "value": "Read Wait"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #write-wait"
-                          },
-                          "properties": [
-                            {
-                              "id": "unit",
-                              "value": "s"
-                            },
-                            {
-                              "id": "displayName",
-                              "value": "Write Wait"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "gridPos": {
-                      "h": 7,
-                      "w": 24,
-                      "x": 0,
-                      "y": 46
-                    },
-                    "id": 69,
-                    "options": {
-                      "footer": {
-                        "fields": "",
-                        "reducer": [
-                          "sum"
-                        ],
-                        "show": false
-                      },
-                      "showHeader": true,
-                      "sortBy": [
-                        {
-                          "desc": true,
-                          "displayName": "Used"
-                        }
-                      ]
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "bytes-read"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "bytes-write"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "iops-read"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "iops-write"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "read-wait"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "write-wait"
-                      }
-                    ],
-                    "title": "Current Storage Usage by Node",
-                    "transformations": [
-                      {
-                        "id": "merge",
-                        "options": {}
-                      },
-                      {
-                        "id": "organize",
-                        "options": {
-                          "excludeByName": {
-                            "Time": true
-                          },
-                          "indexByName": {},
-                          "renameByName": {}
-                        }
-                      }
-                    ],
-                    "type": "table"
-                  },
                   {
                     "datasource": {
                       "type": "prometheus",
@@ -9057,9 +10544,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -9068,13 +10559,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9085,7 +10577,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9099,14 +10590,13 @@ grafana:
                           ]
                         },
                         "unit": "bytes"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 53
+                      "y": 41
                     },
                     "id": 57,
                     "options": {
@@ -9119,13 +10609,17 @@ grafana:
                         ],
                         "displayMode": "table",
                         "placement": "right",
+                        "showLegend": true,
                         "sortBy": "Last",
                         "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -9133,10 +10627,9 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n-\nmax((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)",
-                        "hide": false,
+                        "expr": "max(node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}\n-\nmax(node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) by (mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}",
                         "interval": "",
-                        "legendFormat": "{{node}} {{mountpoint}}",
+                        "legendFormat": "{{node}} ({{mountpoint}})",
                         "refId": "B"
                       }
                     ],
@@ -9154,10 +10647,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 100,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 0,
                           "gradientMode": "none",
@@ -9166,13 +10662,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9183,7 +10680,8 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
+                        "max": 1,
+                        "min": 0,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9191,24 +10689,23 @@ grafana:
                               "color": "green"
                             },
                             {
-                              "color": "yellow",
-                              "value": 75
+                              "color": "semi-dark-orange",
+                              "value": 0.75
                             },
                             {
                               "color": "red",
-                              "value": 90
+                              "value": 0.9
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 61
+                      "y": 49
                     },
                     "id": 198,
                     "options": {
@@ -9221,25 +10718,30 @@ grafana:
                         ],
                         "displayMode": "table",
                         "placement": "right",
+                        "showLegend": true,
                         "sortBy": "Last",
                         "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "100\n/\nmax((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n*\n(\n  max((node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n  -\n  max((node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) * on(instance,pod) group_left(node) (topk(1, node_uname_info) by (instance))) by (mountpoint,node)\n)",
-                        "hide": false,
+                        "expr": "(\n  max(node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}\n  -\n  max(node_filesystem_avail_bytes{mountpoint!~\"/run.*\"}) by (mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}\n)\n/\n(max(node_filesystem_size_bytes{mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
-                        "legendFormat": "{{node}} {{mountpoint}}",
-                        "refId": "B"
+                        "legendFormat": "{{node}} ({{mountpoint}})",
+                        "range": true,
+                        "refId": "A"
                       }
                     ],
                     "title": "Filesystem Usage by Node",
@@ -9256,25 +10758,29 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
-                          "axisSoftMax": 100,
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
-                          "fillOpacity": 10,
+                          "fillOpacity": 0,
                           "gradientMode": "none",
                           "hideFrom": {
                             "legend": false,
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9285,7 +10791,118 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "semi-dark-orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        },
+                        "unit": "percentunit"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 8,
+                      "w": 24,
+                      "x": 0,
+                      "y": 57
+                    },
+                    "id": 221,
+                    "options": {
+                      "legend": {
+                        "calcs": [
+                          "min",
+                          "max",
+                          "mean",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\n  max(node_filesystem_files{fstype!~\"tmpfs|devtmpfs|fuse.lxcfs|squashfs\",mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}\n  -\n  max(node_filesystem_files_free{fstype!~\"tmpfs|devtmpfs|fuse.lxcfs|squashfs\",mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"}\n)\n/\n(max(node_filesystem_files{fstype!~\"tmpfs|devtmpfs|fuse.lxcfs|squashfs\",mountpoint!~\"/run.*\"}) by(mountpoint,instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"})",
+                        "interval": "",
+                        "legendFormat": "{{node}} ({{mountpoint}})",
+                        "range": true,
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Filesystem Inodes Usage by Node",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "axisSoftMax": 0.1,
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 10,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "area"
+                          }
+                        },
+                        "decimals": 2,
                         "min": 0,
                         "thresholds": {
                           "mode": "absolute",
@@ -9295,23 +10912,18 @@ grafana:
                             },
                             {
                               "color": "yellow",
-                              "value": 75
-                            },
-                            {
-                              "color": "red",
-                              "value": 90
+                              "value": 0.05
                             }
                           ]
                         },
-                        "unit": "percent"
-                      },
-                      "overrides": []
+                        "unit": "percentunit"
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 69
+                      "y": 65
                     },
                     "id": 199,
                     "options": {
@@ -9324,23 +10936,29 @@ grafana:
                         ],
                         "displayMode": "table",
                         "placement": "right",
+                        "showLegend": true,
                         "sortBy": "Last",
-                        "sortDesc": false
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
                           "type": "prometheus",
                           "uid": "${datasource}"
                         },
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "100\n/\ncount((node_cpu_seconds_total{mode=\"idle\"}) * on(instance) group_left(node) ((node_uname_info))) by (node)\n*\nsum(rate(node_cpu_seconds_total{mode=\"iowait\"}[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "(sum(rate(node_cpu_seconds_total{mode=\"iowait\"}[5m])) by (instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"})\n/\n(count(node_cpu_seconds_total{mode=\"idle\"}) by (instance) * on(instance) group_left(node) instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "{{node}}",
+                        "range": true,
                         "refId": "A"
                       }
                     ],
@@ -9358,9 +10976,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -9369,13 +10991,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9386,7 +11009,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9399,15 +11021,14 @@ grafana:
                             }
                           ]
                         },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
+                        "unit": "binBps"
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 76
+                      "y": 72
                     },
                     "id": 196,
                     "options": {
@@ -9419,12 +11040,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -9432,8 +11059,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
+                        "expr": "node_disk_read_bytes_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "B"
@@ -9453,9 +11079,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -9464,13 +11094,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9481,7 +11112,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9494,204 +11124,14 @@ grafana:
                             }
                           ]
                         },
-                        "unit": "iops"
-                      },
-                      "overrides": []
+                        "unit": "binBps"
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 84
-                    },
-                    "id": 70,
-                    "options": {
-                      "legend": {
-                        "calcs": [
-                          "min",
-                          "max",
-                          "mean",
-                          "last"
-                        ],
-                        "displayMode": "table",
-                        "placement": "right"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "{{node}}",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Read Storage IOPS by Node",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 10,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "mappings": [],
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "s"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 8,
-                      "w": 24,
-                      "x": 0,
-                      "y": 92
-                    },
-                    "id": 192,
-                    "options": {
-                      "legend": {
-                        "calcs": [
-                          "min",
-                          "max",
-                          "mean",
-                          "last"
-                        ],
-                        "displayMode": "table",
-                        "placement": "right"
-                      },
-                      "tooltip": {
-                        "mode": "multi"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n/\nsum(rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
-                        "interval": "",
-                        "legendFormat": "{{node}}",
-                        "refId": "B"
-                      }
-                    ],
-                    "title": "Read Wait by Node",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 10,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "decimals": 2,
-                        "mappings": [],
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 8,
-                      "w": 24,
-                      "x": 0,
-                      "y": 100
+                      "y": 80
                     },
                     "id": 56,
                     "options": {
@@ -9703,12 +11143,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -9716,8 +11162,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
+                        "expr": "node_disk_written_bytes_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "C"
@@ -9737,9 +11182,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -9748,13 +11197,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9764,7 +11214,7 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
+                        "decimals": 2,
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9778,14 +11228,115 @@ grafana:
                           ]
                         },
                         "unit": "iops"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 108
+                      "y": 88
+                    },
+                    "id": 70,
+                    "options": {
+                      "legend": {
+                        "calcs": [
+                          "min",
+                          "max",
+                          "mean",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "node_disk_reads_completed_total:sum_rate5m{role=~\"$noderole\"}",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Read Storage IOPS by Node",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 10,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "iops"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 8,
+                      "w": 24,
+                      "x": 0,
+                      "y": 96
                     },
                     "id": 71,
                     "options": {
@@ -9797,12 +11348,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -9810,8 +11367,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
+                        "expr": "node_disk_writes_completed_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "B"
@@ -9831,9 +11387,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -9842,13 +11402,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -9858,7 +11419,6 @@ grafana:
                             "mode": "off"
                           }
                         },
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -9872,14 +11432,115 @@ grafana:
                           ]
                         },
                         "unit": "s"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 8,
                       "w": 24,
                       "x": 0,
-                      "y": 116
+                      "y": 104
+                    },
+                    "id": 192,
+                    "options": {
+                      "legend": {
+                        "calcs": [
+                          "min",
+                          "max",
+                          "mean",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "node_disk_read_time_seconds_total:sum_rate5m{role=~\"$noderole\"}\n/\nnode_disk_reads_completed_total:sum_rate5m{role=~\"$noderole\"}",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "B"
+                      }
+                    ],
+                    "title": "Read Wait by Node",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 10,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "s"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 8,
+                      "w": 24,
+                      "x": 0,
+                      "y": 112
                     },
                     "id": 193,
                     "options": {
@@ -9891,12 +11552,18 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "multi"
+                        "hideZeros": false,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -9904,8 +11571,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)\n/\nsum(rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node) (topk(1, node_uname_info) by (instance))) by (node)",
-                        "hide": false,
+                        "expr": "node_disk_write_time_seconds_total:sum_rate5m{role=~\"$noderole\"}\n/\nnode_disk_writes_completed_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "B"
@@ -9920,277 +11586,14 @@ grafana:
               },
               {
                 "collapsed": true,
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
                 "gridPos": {
                   "h": 1,
                   "w": 24,
                   "x": 0,
-                  "y": 32
+                  "y": 41
                 },
-                "id": 64,
+                "id": 228,
                 "panels": [
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "thresholds"
-                        },
-                        "custom": {
-                          "align": "center",
-                          "displayMode": "auto",
-                          "filterable": false
-                        },
-                        "mappings": [],
-                        "min": 0,
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "pps"
-                      },
-                      "overrides": [
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #receive-bandwidth"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Receive Bandwidth"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "binBps"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #transmit-bandwidht"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Transmit Bandwidth"
-                            },
-                            {
-                              "id": "unit",
-                              "value": "binBps"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #receive-packets"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Received Packets"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #transmit-packets"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Transmitted Packets"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #receive-packets-dropped"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Received Packets Dropped"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "Value #transmit-packets-dropped"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Transmitted Packets Dropped"
-                            }
-                          ]
-                        },
-                        {
-                          "matcher": {
-                            "id": "byName",
-                            "options": "node"
-                          },
-                          "properties": [
-                            {
-                              "id": "displayName",
-                              "value": "Node"
-                            },
-                            {
-                              "id": "custom.align",
-                              "value": "left"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "gridPos": {
-                      "h": 7,
-                      "w": 24,
-                      "x": 0,
-                      "y": 33
-                    },
-                    "id": 58,
-                    "options": {
-                      "footer": {
-                        "fields": "",
-                        "reducer": [
-                          "sum"
-                        ],
-                        "show": false
-                      },
-                      "showHeader": true,
-                      "sortBy": [
-                        {
-                          "desc": true,
-                          "displayName": "Used"
-                        }
-                      ]
-                    },
-                    "pluginVersion": "8.3.6",
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "receive-bandwidth"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "transmit-bandwidht"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "receive-packets"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "transmit-packets"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "receive-packets-dropped"
-                      },
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "format": "table",
-                        "hide": false,
-                        "instant": true,
-                        "interval": "",
-                        "legendFormat": "",
-                        "refId": "transmit-packets-dropped"
-                      }
-                    ],
-                    "title": "Current Network Usage by Node",
-                    "transformations": [
-                      {
-                        "id": "merge",
-                        "options": {}
-                      },
-                      {
-                        "id": "organize",
-                        "options": {
-                          "excludeByName": {
-                            "Time": true
-                          },
-                          "indexByName": {},
-                          "renameByName": {}
-                        }
-                      }
-                    ],
-                    "type": "table"
-                  },
                   {
                     "datasource": {
                       "type": "prometheus",
@@ -10202,9 +11605,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -10213,13 +11620,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -10230,7 +11638,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -10243,15 +11650,14 @@ grafana:
                             }
                           ]
                         },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
+                        "unit": "binBps"
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 40
+                      "y": 42
                     },
                     "id": 83,
                     "options": {
@@ -10263,12 +11669,19 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -10276,13 +11689,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "node_network_receive_bytes_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "Reveive Network Bandwith by Node",
+                    "title": "Receive Network Bandwidth by Node",
                     "type": "timeseries"
                   },
                   {
@@ -10296,9 +11709,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -10307,13 +11724,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -10324,7 +11742,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -10337,109 +11754,14 @@ grafana:
                             }
                           ]
                         },
-                        "unit": "pps"
-                      },
-                      "overrides": []
+                        "unit": "binBps"
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 47
-                    },
-                    "id": 59,
-                    "options": {
-                      "legend": {
-                        "calcs": [
-                          "min",
-                          "max",
-                          "mean",
-                          "last"
-                        ],
-                        "displayMode": "table",
-                        "placement": "right"
-                      },
-                      "tooltip": {
-                        "mode": "single"
-                      }
-                    },
-                    "targets": [
-                      {
-                        "datasource": {
-                          "type": "prometheus",
-                          "uid": "${datasource}"
-                        },
-                        "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
-                        "interval": "",
-                        "legendFormat": "{{node}}",
-                        "refId": "A"
-                      }
-                    ],
-                    "title": "Reveive Network Packets by Node",
-                    "type": "timeseries"
-                  },
-                  {
-                    "datasource": {
-                      "type": "prometheus",
-                      "uid": "${datasource}"
-                    },
-                    "fieldConfig": {
-                      "defaults": {
-                        "color": {
-                          "mode": "palette-classic"
-                        },
-                        "custom": {
-                          "axisLabel": "",
-                          "axisPlacement": "auto",
-                          "barAlignment": 0,
-                          "drawStyle": "line",
-                          "fillOpacity": 10,
-                          "gradientMode": "none",
-                          "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                          },
-                          "lineInterpolation": "linear",
-                          "lineWidth": 1,
-                          "pointSize": 3,
-                          "scaleDistribution": {
-                            "type": "linear"
-                          },
-                          "showPoints": "auto",
-                          "spanNulls": false,
-                          "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                          },
-                          "thresholdsStyle": {
-                            "mode": "off"
-                          }
-                        },
-                        "decimals": 2,
-                        "mappings": [],
-                        "thresholds": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 80
-                            }
-                          ]
-                        },
-                        "unit": "bytes"
-                      },
-                      "overrides": []
-                    },
-                    "gridPos": {
-                      "h": 7,
-                      "w": 24,
-                      "x": 0,
-                      "y": 54
+                      "y": 49
                     },
                     "id": 54,
                     "options": {
@@ -10451,12 +11773,19 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -10464,13 +11793,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "node_network_transmit_bytes_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "Transmit Network Bandwith by Node",
+                    "title": "Transmit Network Bandwidth by Node",
                     "type": "timeseries"
                   },
                   {
@@ -10484,9 +11813,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -10495,13 +11828,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -10512,7 +11846,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -10526,14 +11859,117 @@ grafana:
                           ]
                         },
                         "unit": "pps"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 61
+                      "y": 56
+                    },
+                    "id": 59,
+                    "options": {
+                      "legend": {
+                        "calcs": [
+                          "min",
+                          "max",
+                          "mean",
+                          "last"
+                        ],
+                        "displayMode": "table",
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
+                      },
+                      "tooltip": {
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
+                      }
+                    },
+                    "pluginVersion": "12.0.2",
+                    "targets": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                        },
+                        "exemplar": false,
+                        "expr": "node_network_receive_packets_total:sum_rate5m{role=~\"$noderole\"}",
+                        "interval": "",
+                        "legendFormat": "{{node}}",
+                        "refId": "A"
+                      }
+                    ],
+                    "title": "Receive Network Packets by Node",
+                    "type": "timeseries"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                    },
+                    "fieldConfig": {
+                      "defaults": {
+                        "color": {
+                          "mode": "palette-classic"
+                        },
+                        "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
+                          "axisLabel": "",
+                          "axisPlacement": "auto",
+                          "barAlignment": 0,
+                          "barWidthFactor": 0.6,
+                          "drawStyle": "line",
+                          "fillOpacity": 10,
+                          "gradientMode": "none",
+                          "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                          },
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
+                          "lineWidth": 1,
+                          "pointSize": 5,
+                          "scaleDistribution": {
+                            "type": "linear"
+                          },
+                          "showPoints": "never",
+                          "spanNulls": false,
+                          "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                          },
+                          "thresholdsStyle": {
+                            "mode": "off"
+                          }
+                        },
+                        "decimals": 2,
+                        "thresholds": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        },
+                        "unit": "pps"
+                      }
+                    },
+                    "gridPos": {
+                      "h": 7,
+                      "w": 24,
+                      "x": 0,
+                      "y": 63
                     },
                     "id": 60,
                     "options": {
@@ -10545,12 +11981,19 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -10558,7 +12001,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "node_network_transmit_packets_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10578,9 +12021,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -10589,13 +12036,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -10606,7 +12054,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -10620,14 +12067,13 @@ grafana:
                           ]
                         },
                         "unit": "pps"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 68
+                      "y": 70
                     },
                     "id": 67,
                     "options": {
@@ -10639,12 +12085,19 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -10652,13 +12105,13 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "node_network_receive_drop_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
                       }
                     ],
-                    "title": "Reveive Network Packets Dropped by Node",
+                    "title": "Receive Network Packets Dropped by Node",
                     "type": "timeseries"
                   },
                   {
@@ -10672,9 +12125,13 @@ grafana:
                           "mode": "palette-classic"
                         },
                         "custom": {
+                          "axisBorderShow": false,
+                          "axisCenteredZero": false,
+                          "axisColorMode": "text",
                           "axisLabel": "",
                           "axisPlacement": "auto",
                           "barAlignment": 0,
+                          "barWidthFactor": 0.6,
                           "drawStyle": "line",
                           "fillOpacity": 10,
                           "gradientMode": "none",
@@ -10683,13 +12140,14 @@ grafana:
                             "tooltip": false,
                             "viz": false
                           },
-                          "lineInterpolation": "linear",
+                          "insertNulls": false,
+                          "lineInterpolation": "smooth",
                           "lineWidth": 1,
-                          "pointSize": 3,
+                          "pointSize": 5,
                           "scaleDistribution": {
                             "type": "linear"
                           },
-                          "showPoints": "auto",
+                          "showPoints": "never",
                           "spanNulls": false,
                           "stacking": {
                             "group": "A",
@@ -10700,7 +12158,6 @@ grafana:
                           }
                         },
                         "decimals": 2,
-                        "mappings": [],
                         "thresholds": {
                           "mode": "absolute",
                           "steps": [
@@ -10714,14 +12171,13 @@ grafana:
                           ]
                         },
                         "unit": "pps"
-                      },
-                      "overrides": []
+                      }
                     },
                     "gridPos": {
                       "h": 7,
                       "w": 24,
                       "x": 0,
-                      "y": 75
+                      "y": 77
                     },
                     "id": 68,
                     "options": {
@@ -10733,12 +12189,19 @@ grafana:
                           "last"
                         ],
                         "displayMode": "table",
-                        "placement": "right"
+                        "placement": "right",
+                        "showLegend": true,
+                        "sortBy": "Last",
+                        "sortDesc": true
                       },
                       "tooltip": {
-                        "mode": "single"
+                        "hideZeros": false,
+                        "maxHeight": 600,
+                        "mode": "single",
+                        "sort": "none"
                       }
                     },
+                    "pluginVersion": "12.0.2",
                     "targets": [
                       {
                         "datasource": {
@@ -10746,7 +12209,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node) ((node_uname_info))) by (node)",
+                        "expr": "node_network_transmit_drop_total:sum_rate5m{role=~\"$noderole\"}",
                         "interval": "",
                         "legendFormat": "{{node}}",
                         "refId": "A"
@@ -10760,31 +12223,38 @@ grafana:
                 "type": "row"
               }
             ],
-            "refresh": "1m",
-            "schemaVersion": 36,
-            "style": "dark",
-            "tags": [],
+            "preload": false,
+            "refresh": "5m",
+            "schemaVersion": 42,
+            "tags": [
+              "kubernetes",
+              "openshift",
+              "cluster",
+              "recording-rules",
+              "prometheus",
+              "otaru",
+              "onzack"
+            ],
             "templating": {
               "list": [
                 {
+                  "allowCustomValue": true,
                   "current": {
-                    "selected": false,
-                    "text": "prometheus",
-                    "value": "prometheus"
+                    "selected": true,
+                    "text": "Prometheus",
+                    "value": "Prometheus"
                   },
-                  "hide": 0,
                   "includeAll": false,
                   "label": "Datasource",
-                  "multi": false,
                   "name": "datasource",
                   "options": [],
                   "query": "prometheus",
                   "refresh": 1,
                   "regex": "",
-                  "skipUrlSync": false,
                   "type": "datasource"
                 },
                 {
+                  "allowCustomValue": true,
                   "current": {
                     "selected": true,
                     "text": "All",
@@ -10794,34 +12264,30 @@ grafana:
                     "type": "prometheus",
                     "uid": "${datasource}"
                   },
-                  "definition": "label_values(kube_node_role,role)",
-                  "hide": 0,
+                  "definition": "label_values(instance:kube_node_role,role)",
                   "includeAll": true,
                   "label": "Node Role",
-                  "multi": false,
                   "name": "noderole",
                   "options": [],
                   "query": {
-                    "query": "label_values(kube_node_role,role)",
+                    "query": "label_values(instance:kube_node_role,role)",
                     "refId": "StandardVariableQuery"
                   },
                   "refresh": 1,
                   "regex": "",
-                  "skipUrlSync": false,
-                  "sort": 0,
+                  "regexApplyTo": "value",
                   "type": "query",
+                  "multi": false,
                   "allValue": ".*"
                 },
                 {
+                  "allowCustomValue": true,
                   "current": {
-                    "selected": true,
                     "text": "1",
                     "value": "1"
                   },
-                  "hide": 0,
                   "includeAll": false,
                   "label": "Spare Nodes",
-                  "multi": false,
                   "name": "sparenodesfactor",
                   "options": [
                     {
@@ -10836,19 +12302,63 @@ grafana:
                     },
                     {
                       "selected": false,
-                      "text": "1.5",
-                      "value": "1.5"
+                      "text": "2",
+                      "value": "2"
                     },
                     {
                       "selected": false,
-                      "text": "2",
-                      "value": "2"
+                      "text": "3",
+                      "value": "3"
                     }
                   ],
-                  "query": "0,1,1.5,2",
-                  "queryValue": "",
-                  "skipUrlSync": false,
-                  "type": "custom"
+                  "query": "0, 1, 2, 3",
+                  "type": "custom",
+                  "valuesFormat": "csv"
+                },
+                {
+                  "allowCustomValue": true,
+                  "current": {
+                    "text": "0.1",
+                    "value": "0.1"
+                  },
+                  "includeAll": false,
+                  "label": "Node CPU/Mem Reserve",
+                  "name": "nodecpumemreserve",
+                  "options": [
+                    {
+                      "selected": false,
+                      "text": "0",
+                      "value": "0"
+                    },
+                    {
+                      "selected": true,
+                      "text": "0.1",
+                      "value": "0.1"
+                    },
+                    {
+                      "selected": false,
+                      "text": "0.2",
+                      "value": "0.2"
+                    },
+                    {
+                      "selected": false,
+                      "text": "0.25",
+                      "value": "0.25"
+                    },
+                    {
+                      "selected": false,
+                      "text": "0.333",
+                      "value": "0.333"
+                    },
+                    {
+                      "selected": false,
+                      "text": "0.5",
+                      "value": "0.5"
+                    }
+                  ],
+                  "query": "0, 0.1, 0.2, 0.25, 0.333, 0.5",
+                  "type": "custom",
+                  "valuesFormat": "csv"
                 }
               ]
             },
@@ -10856,10 +12366,24 @@ grafana:
               "from": "now-6h",
               "to": "now"
             },
-            "timepicker": {},
-            "timezone": "",
-            "title": "Cluster Monitoring",
-            "uid": "ozk-std-clstr-mon-norec",
-            "version": 19,
-            "weekStart": ""
+            "timepicker": {
+              "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+              ]
+            },
+            "timezone": "browser",
+            "title": "Standard Cluster Monitoring",
+            "uid": "ozk-std-clstr-mon",
+            "version": 113,
+            "weekStart": "",
+            "gnetId": 17404
           }

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -129,6 +129,145 @@ prometheus:
                 sum by (namespace, pod) (
                   container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", pod!="", container!="", container!="POD"}
                 )
+        # ONZACK Standard Cluster Monitoring (grafana.com/dashboards/17404) recording rules.
+        # Source: github.com/onzack/grafana-dashboards prometheus/recording-rules.
+        # otaru adaptations: unlabeled nodes get role=worker; node-exporter job is
+        # kubernetes-service-endpoints (not job=node-exporter).
+        - name: onzack-cluster-common
+          rules:
+            - record: instance:kube_node_role
+              expr: |
+                (
+                  topk by (node) (1,
+                    max by (node, role) (
+                      (kube_node_role{role="control-plane"} * 2)
+                      OR
+                      (kube_node_role{role!="control-plane"} * 1)
+                    )
+                    /
+                    max by (node, role) (
+                      (kube_node_role{role="control-plane"} * 2)
+                      OR
+                      (kube_node_role{role!="control-plane"} * 1)
+                    )
+                    * on(node) group_left(instance)
+                    label_replace(node_uname_info, "node", "$1", "nodename", "(.*)")
+                  )
+                )
+                OR
+                (
+                  label_replace(
+                    (
+                      group by (node) (kube_node_info)
+                      unless on (node) group by (node) (kube_node_role)
+                    )
+                    * on(node) group_left(instance)
+                    label_replace(node_uname_info, "node", "$1", "nodename", "(.*)"),
+                    "role", "worker", "", ""
+                  )
+                )
+        - name: onzack-cluster-cpu
+          rules:
+            - record: node_cpu_seconds_total:sum_rate5m
+              expr: sum by (cpu,instance,node,role) (rate(node_cpu_seconds_total{mode!="idle"}[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: kube_node_status_capacity:cpu:sum
+              expr: sum by (node,role) (kube_node_status_capacity{resource="cpu"} * on(node) group_left(role) instance:kube_node_role)
+            - record: role:kube_node_status_capacity:cpu:avg
+              expr: avg by (role) (kube_node_status_capacity{resource="cpu"} * on(node) group_left(role) instance:kube_node_role)
+            - record: kube_node_status_allocatable:cpu:sum
+              expr: sum by (node,role) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(role) instance:kube_node_role)
+            - record: role:kube_node_status_allocatable:cpu:avg
+              expr: avg by (role) (kube_node_status_allocatable{resource="cpu"} * on(node) group_left(role) instance:kube_node_role)
+        - name: onzack-cluster-memory
+          rules:
+            - record: node_memory_MemUsed_bytes:sum
+              expr: |
+                sum by (instance,node,role) (
+                  (
+                    node_memory_MemTotal_bytes{job=~"kubernetes-service-endpoints|node-exporter"}
+                    - node_memory_MemAvailable_bytes{job=~"kubernetes-service-endpoints|node-exporter"}
+                  ) * on(instance) group_left(node,role) instance:kube_node_role
+                )
+            - record: kube_node_status_capacity:memory:sum
+              expr: sum by (node,role) (kube_node_status_capacity{resource="memory"} * on(node) group_left(role) instance:kube_node_role)
+            - record: role:kube_node_status_capacity:memory:avg
+              expr: avg by (role) (kube_node_status_capacity{resource="memory"} * on(node) group_left(role) instance:kube_node_role)
+            - record: kube_node_status_allocatable:memory:sum
+              expr: sum by (node,role) (kube_node_status_allocatable{resource="memory"} * on(node) group_left(role) instance:kube_node_role)
+            - record: role:kube_node_status_allocatable:memory:avg
+              expr: avg by (role) (kube_node_status_allocatable{resource="memory"} * on(node) group_left(role) instance:kube_node_role)
+        - name: onzack-cluster-storage
+          rules:
+            - record: node_disk_read_bytes_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_read_bytes_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_disk_reads_completed_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_reads_completed_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_disk_read_time_seconds_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_read_time_seconds_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_disk_written_bytes_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_written_bytes_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_disk_writes_completed_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_writes_completed_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_disk_write_time_seconds_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_disk_write_time_seconds_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+        - name: onzack-cluster-network
+          rules:
+            - record: node_network_receive_bytes_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_receive_bytes_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_network_receive_packets_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_receive_packets_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_network_receive_drop_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_receive_drop_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_network_transmit_bytes_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_transmit_bytes_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_network_transmit_packets_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_transmit_packets_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+            - record: node_network_transmit_drop_total:sum_rate5m
+              expr: sum by (instance,node,role) (rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
+        - name: onzack-cluster-container
+          rules:
+            - record: container_cpu_usage_seconds_total:sum_rate5m:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  rate(container_cpu_usage_seconds_total{container!="", container!="POD"}[5m])
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
+            - record: container_memory_working_set_bytes:sum:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  container_memory_working_set_bytes{container!="", container!="POD"}
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
+            - record: kube_pod_container_resource_requests:cpu:running:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  kube_pod_container_resource_requests{resource="cpu"}
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
+            - record: kube_pod_container_resource_limits:cpu:running:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  kube_pod_container_resource_limits{resource="cpu"}
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
+            - record: kube_pod_container_resource_requests:memory:running:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  kube_pod_container_resource_requests{resource="memory"}
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
+            - record: kube_pod_container_resource_limits:memory:running:namespace
+              expr: |
+                sum by (namespace,node,role) (
+                  kube_pod_container_resource_limits{resource="memory"}
+                  * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
+                  * on(node) group_left(role) instance:kube_node_role
+                )
     alerting_rules.yml:
       groups:
         - name: cluster-health


### PR DESCRIPTION
## Summary
- Replace the frozen **without-recording-rules** Cluster Monitoring JSON (`ozk-std-clstr-mon-norec` v19) with upstream **Standard Cluster Monitoring** ([Grafana.com 17404](https://grafana.com/grafana/dashboards/17404) revision **11**, uid `ozk-std-clstr-mon`, dashboard version 113).
- Install ONZACK Prometheus recording rules into `prometheus.serverFiles.recording_rules.yml`.

## otaru adaptations
- `instance:kube_node_role`: nodes with no `kube_node_role` (e.g. `nuc-00`, `raspberrypi-03`) get `role=worker` so capacity panels include all nodes.
- Memory rules use `job=~"kubernetes-service-endpoints|node-exporter"` (this cluster does not scrape `job=node-exporter`).
- Dashboard: `noderole` includes **All** (`.*`); kubelet errors match `job=~"kubelet|kubernetes-api-servers"`.

## Test plan
- [x] `make test` / dashboard validator
- [x] Live PromQL for adapted `instance:kube_node_role` returns 5 nodes (3 control-plane + 2 worker)
- [ ] After deploy: Grafana title **Standard Cluster Monitoring**; recording metrics such as `instance:kube_node_role` and `node_memory_MemUsed_bytes:sum` present in Prometheus
- [ ] Overview panels show data (allow ~5m after rules load for rate windows)