### PR TITLE
fix(monitoring): Onzack No data — fix container recording rules

### DIFF
--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -9323,7 +9323,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum * on(node) group_left(role) instance:kube_node_role{role=~\"$noderole\"})\n  -\n  sum(kube_node_status_allocatable:memory:avg * on(node) group_left(role) instance:kube_node_role{role=~\"$noderole\"}) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:memory:running:namespace * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                        "expr": "100\n/\n(\n  sum(kube_node_status_allocatable:memory:sum * on(node) group_left(role) instance:kube_node_role{role=~\"$noderole\"})\n  -\n  sum(role:kube_node_status_allocatable:memory:avg{role=~\"$noderole\"}) * $sparenodesfactor\n)\n*\nsum(kube_pod_container_resource_limits:memory:running:namespace * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
                         "interval": "",
                         "legendFormat": "total",
                         "refId": "C"

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -226,17 +226,25 @@ prometheus:
               expr: sum by (instance,node,role) (rate(node_network_transmit_drop_total[5m]) * on(instance) group_left(node,role) instance:kube_node_role)
         - name: onzack-cluster-container
           rules:
+            # cAdvisor on this cluster labels the node as `instance` (hostname), not `node`.
+            # Map instance→node before joining instance:kube_node_role on(node).
             - record: container_cpu_usage_seconds_total:sum_rate5m:namespace
               expr: |
                 sum by (namespace,node,role) (
-                  rate(container_cpu_usage_seconds_total{container!="", container!="POD"}[5m])
+                  label_replace(
+                    rate(container_cpu_usage_seconds_total{container!="", container!="POD"}[5m]),
+                    "node", "$1", "instance", "(.*)"
+                  )
                   * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
                   * on(node) group_left(role) instance:kube_node_role
                 )
             - record: container_memory_working_set_bytes:sum:namespace
               expr: |
                 sum by (namespace,node,role) (
-                  container_memory_working_set_bytes{container!="", container!="POD"}
+                  label_replace(
+                    container_memory_working_set_bytes{container!="", container!="POD"},
+                    "node", "$1", "instance", "(.*)"
+                  )
                   * on(pod, namespace) group_left() (kube_pod_status_phase{phase="Running"}==1)
                   * on(node) group_left(role) instance:kube_node_role
                 )


### PR DESCRIPTION
## Problem
Standard Cluster Monitoring showed many **No data** panels under Capacity (apps/k8s used/wasted, used-from-requested, etc.).

## Cause
`container_* :namespace` recording rules join `on(node) instance:kube_node_role`, but cAdvisor series only have **`instance`** (hostname), not **`node`**. The join produced zero series.

## Fix
- `label_replace(..., "node", "$1", "instance", "(.*)")` on container CPU/memory recording rules before the role join.
- One dashboard typo: `kube_node_status_allocatable:memory:avg` → `role:kube_node_status_allocatable:memory:avg`.

## Verify
Live PromQL after fix should show non-zero `container_cpu_usage_seconds_total:sum_rate5m:namespace` and Capacity “used” panels populate after Prometheus reloads rules (~1 min).