### PR TITLE
fix(monitoring): Standard Cluster Monitoring 1m auto-refresh

### DIFF
--- a/helm-charts/monitoring/AGENTS.md
+++ b/helm-charts/monitoring/AGENTS.md
@@ -21,6 +21,9 @@ Path: `dashboards/*.yaml` (Grafana helm `grafana.dashboards.default` embeds).
 `container-log-dashboard`, which pins a Grafana.com revision). Editing UI is
 disabled (`allowUiUpdates: false`). Changes require a PR and Argo reconcile.
 
+Standard Cluster Monitoring auto-refreshes every **1m** (Prometheus scrape
+interval). Keep that cadence when re-vendoring unless scrape interval changes.
+
 Validate with `python3 scripts/validate-grafana-dashboards.py` (also via
 `make test`). Forbidden selectors include bare `job="node-exporter"` and the
 broken `cattle-.*openshift` regex.

--- a/helm-charts/monitoring/AGENTS.md
+++ b/helm-charts/monitoring/AGENTS.md
@@ -65,6 +65,9 @@ When re-vendoring 17404, re-apply:
 4. **Dashboard** — `noderole` include All (`.*`); kubelet errors match
    `job=~"kubelet|kubernetes-api-servers"`. Recording metric names use the
    `role:` prefix where upstream records `role:kube_node_status_*:avg`.
+5. **Empty limits** — many workloads set no CPU limits. Pure sum panels for
+   limits (especially `namespace=~"kube-.*|..."`) use `or vector(0)` so Grafana
+   shows **0** instead of **No data**.
 
 ### Upgrading the dashboard
 

--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -82,7 +82,7 @@ grafana:
               ]
             },
             "description": "ONZACK Standard Cluster Monitoring (Grafana.com 17404 rev 11, with recording rules). Vendored into otaru; Prometheus rules live in monitoring chart recording_rules.yml (adapted for kubernetes-service-endpoints node-exporter and unlabeled worker nodes).",
-            "editable": true,
+            "editable": false,
             "fiscalYearStartMonth": 0,
             "graphTooltip": 0,
             "links": [
@@ -1127,7 +1127,7 @@ grafana:
                     "refId": "A"
                   }
                 ],
-                "title": "Memory Used (form capacity)",
+                "title": "Memory Used (from capacity)",
                 "type": "gauge"
               },
               {
@@ -1213,7 +1213,7 @@ grafana:
                     "refId": "A"
                   }
                 ],
-                "title": "Memory  Used Top Node",
+                "title": "Memory Used Top Node",
                 "type": "gauge"
               },
               {
@@ -9522,7 +9522,7 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "description": "Not all workloads have limits defined but still use CPU resources. Thas why the usage can be higher than the limits.",
+                    "description": "Not all workloads have limits defined but still use CPU resources. That is why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
@@ -9627,7 +9627,7 @@ grafana:
                         "refId": "B"
                       }
                     ],
-                    "title": "Cores Used (from LImits)",
+                    "title": "Cores Used (from Limits)",
                     "type": "timeseries"
                   },
                   {
@@ -9635,7 +9635,7 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "description": "Not all workloads have limits defined but still use CPU resources. Thas why the usage can be higher than the limits.",
+                    "description": "Not all workloads have limits defined but still use CPU resources. That is why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
@@ -9832,7 +9832,7 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "description": "Not all workloads have limits defined but still use Memory resources. Thas why the usage can be higher than the limits.",
+                    "description": "Not all workloads have limits defined but still use Memory resources. That is why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
@@ -9945,7 +9945,7 @@ grafana:
                       "type": "prometheus",
                       "uid": "${datasource}"
                     },
-                    "description": "Not all workloads have limits defined but still use Memory resources. Thas why the usage can be higher than the limits.",
+                    "description": "Not all workloads have limits defined but still use Memory resources. That is why the usage can be higher than the limits.",
                     "fieldConfig": {
                       "defaults": {
                         "color": {
@@ -11065,7 +11065,7 @@ grafana:
                         "refId": "B"
                       }
                     ],
-                    "title": "Read Storage Troughput by Node",
+                    "title": "Read Storage Throughput by Node",
                     "type": "timeseries"
                   },
                   {
@@ -11168,7 +11168,7 @@ grafana:
                         "refId": "C"
                       }
                     ],
-                    "title": "Write Storage Troughput by Node",
+                    "title": "Write Storage Throughput by Node",
                     "type": "timeseries"
                   },
                   {
@@ -12224,7 +12224,7 @@ grafana:
               }
             ],
             "preload": false,
-            "refresh": "5m",
+            "refresh": "1m",
             "schemaVersion": 42,
             "tags": [
               "kubernetes",
@@ -12383,7 +12383,7 @@ grafana:
             "timezone": "browser",
             "title": "Standard Cluster Monitoring",
             "uid": "ozk-std-clstr-mon",
-            "version": 113,
+            "version": 114,
             "weekStart": "",
             "gnetId": 17404
           }

--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -3513,7 +3513,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -3780,7 +3780,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -4046,7 +4046,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4313,7 +4313,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -4512,7 +4512,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})) or vector(0)",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -4711,7 +4711,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -5083,7 +5083,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum by (node) (kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})",
+                        "expr": "(sum by (node) (kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})) or vector(0)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -5506,7 +5506,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum by (node) (kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})",
+                        "expr": "(sum by (node) (kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})) or vector(0)",
                         "format": "table",
                         "instant": true,
                         "interval": "",
@@ -9115,7 +9115,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "apps",
                         "refId": "B"
@@ -9126,7 +9126,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "k8s",
                         "refId": "D"
@@ -9415,7 +9415,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "apps",
                         "refId": "B"
@@ -9426,7 +9426,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "k8s",
                         "refId": "D"
@@ -9507,7 +9507,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"})\n*\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})",
+                        "expr": "100\n/\nclamp_min(sum(kube_pod_container_resource_limits:cpu:running:namespace{role=~\"$noderole\"}) or vector(0), 1e-9)\n*\nsum(container_cpu_usage_seconds_total:sum_rate5m:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -9725,7 +9725,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "apps (limits)",
                         "refId": "C"
@@ -9747,7 +9747,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\"} * on(node) group_left() instance:kube_node_role{role=~\"$noderole\"})",
+                        "expr": "sum(kube_pod_container_resource_limits:cpu:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"}) or vector(0)",
                         "interval": "",
                         "legendFormat": "k8s (limits)",
                         "refId": "E"
@@ -9817,7 +9817,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "100\n/\nsum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"})\n*\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})",
+                        "expr": "100\n/\nclamp_min(sum(kube_pod_container_resource_limits:memory:running:namespace{role=~\"$noderole\"}) or vector(0), 1e-9)\n*\nsum(container_memory_working_set_bytes:sum:namespace{role=~\"$noderole\"})",
                         "instant": true,
                         "interval": "",
                         "legendFormat": "",
@@ -10035,7 +10035,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace!~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "apps (limits)",
                         "refId": "C"
@@ -10057,7 +10057,7 @@ grafana:
                           "uid": "${datasource}"
                         },
                         "exemplar": false,
-                        "expr": "sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})",
+                        "expr": "(sum(kube_pod_container_resource_limits:memory:running:namespace{namespace=~\"kube-.*|cattle-.*|openshift-.*\", role=~\"$noderole\"})) or vector(0)",
                         "interval": "",
                         "legendFormat": "k8s (limits)",
                         "refId": "E"
@@ -12383,7 +12383,7 @@ grafana:
             "timezone": "browser",
             "title": "Standard Cluster Monitoring",
             "uid": "ozk-std-clstr-mon",
-            "version": 114,
+            "version": 115,
             "weekStart": "",
             "gnetId": 17404
           }


### PR DESCRIPTION
## Summary
- Set **auto-refresh** to **1m** (matches Prometheus scrape / Grafana `timeInterval`).
- `editable: false` for provisioned GitOps board.
- Typos: double space in Memory Used Top Node, form→from capacity, LImits, Troughput→Throughput, Thas→That is.
- Dashboard version **114**.

## Review honesty
This PR does **not** claim a full semantic review of all ~124 panels. Prior work fixed recording-rule joins (empty Capacity series) and bulk empty-query checks. A full title/unit/layout sense-pass is still open.

## Test plan
- [ ] After Argo: dashboard refresh control shows 1m and ticks
- [ ] Overview gauges still render