### PR TITLE
fix(monitoring): Standard Cluster Monitoring refresh=auto

### DIFF
--- a/helm-charts/monitoring/AGENTS.md
+++ b/helm-charts/monitoring/AGENTS.md
@@ -25,8 +25,7 @@ Every Standard Cluster Monitoring panel (and row) should keep a **description**
 explaining the metric in plain language (hover in Grafana). When re-vendoring,
 re-apply or regenerate descriptions rather than shipping empty ones.
 
-Standard Cluster Monitoring auto-refreshes every **1m** (Prometheus scrape
-interval). Keep that cadence when re-vendoring unless scrape interval changes.
+Standard Cluster Monitoring auto-refreshes with Grafana **`auto`** (same as the blocky dashboard). Keep `refresh: auto` when re-vendoring.
 
 Validate with `python3 scripts/validate-grafana-dashboards.py` (also via
 `make test`). Forbidden selectors include bare `job="node-exporter"` and the

--- a/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
+++ b/helm-charts/monitoring/dashboards/onzack-cluster-monitoring.yaml
@@ -12351,7 +12351,7 @@ grafana:
               }
             ],
             "preload": false,
-            "refresh": "1m",
+            "refresh": "auto",
             "schemaVersion": 42,
             "tags": [
               "kubernetes",
@@ -12510,7 +12510,7 @@ grafana:
             "timezone": "browser",
             "title": "Standard Cluster Monitoring",
             "uid": "ozk-std-clstr-mon",
-            "version": 116,
+            "version": 117,
             "weekStart": "",
             "gnetId": 17404
           }


### PR DESCRIPTION
## Summary
- Set dashboard `refresh` to **`auto`** (was `1m` in Git; live was already 1m after prior fix, not 5m).
- Align with blocky provisioning.
- Version **117**.

If the UI still shows 5m, check the browser URL for `?refresh=5m` (bookmark/local override) and hard-refresh after Argo applies.