### PR TITLE
chore(infra): OpenTofu/Terragrunt hygiene

### DIFF
--- a/.github/workflows/auto-update-heartbeats.yaml
+++ b/.github/workflows/auto-update-heartbeats.yaml
@@ -50,12 +50,12 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
         with:
-          tofu_version: '1.12.0'
+          tofu_version: '1.12.4'
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
         with:
-          terragrunt-version: latest
+          terragrunt-version: '1.1.1'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install editorconfig-checker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,12 +42,12 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
         with:
-          tofu_version: '1.12.0'
+          tofu_version: '1.12.4'
 
       - name: Setup Terragrunt
         uses: autero1/action-terragrunt@aefb0a43c4f5503a91fefb307745c4d51c26ed0e # v3
         with:
-          terragrunt-version: latest
+          terragrunt-version: '1.1.1'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install editorconfig-checker

--- a/documentation/secrets.md
+++ b/documentation/secrets.md
@@ -51,7 +51,12 @@ export CLOUDFLARE_ZONE_TUNNEL_IP_LIST='["1.2.3.4/32"]'
 export CLOUDFLARE_DNS_IP=192.168.12.34
 export CLOUDFLARE_DNS_SUBDOMAINS='["subdomain1.internal","subdomain2.internal"]'
 
+# UniFi provider reads UNIFI_API (not UNIFI_API_URL). Keep both if other tools
+# still use UNIFI_API_URL.
 export UNIFI_API_URL=...
+export UNIFI_API="${UNIFI_API_URL}"
+export UNIFI_USERNAME=...
+export UNIFI_PASSWORD=...
 export UNIFI_LHR_WLAN01_PASSWORD=...
 export UNIFI_LHR_WLAN01_SSID=...
 export UNIFI_LHR_WLAN02_PASSWORD=...
@@ -60,13 +65,26 @@ export UNIFI_LHR_WLAN03_PASSWORD=...
 export UNIFI_LHR_WLAN03_SSID=...
 export UNIFI_LHR_WLAN04_PASSWORD=...
 export UNIFI_LHR_WLAN04_SSID=...
-export UNIFI_PASSWORD=...
-export UNIFI_USERNAME=...
+
+# OpenTofu GitHub provider (Access unit IP data source). Prefer env over
+# embedding tokens in generated provider.tf / .terragrunt-cache.
+export GITHUB_TOKEN="$(gh auth token)"
 ```
 
-GitHub authentication is read from the GitHub CLI instead of this envrc file.
-Run `gh auth login` before using Terraform/Terragrunt targets or Helm OCI chart
-dependency updates that need GitHub access.
+OpenTofu/Terragrunt providers take credentials from the environment only
+(see `infrastructure/root.hcl`):
+
+| Provider   | Environment variables                                                      |
+| ---------- | -------------------------------------------------------------------------- |
+| AWS        | standard AWS SDK chain (`AWS_PROFILE`, keys, etc.)                         |
+| B2         | `B2_APPLICATION_KEY`, `B2_APPLICATION_KEY_ID`                              |
+| Cloudflare | `CLOUDFLARE_API_TOKEN`                                                     |
+| GitHub     | `GITHUB_TOKEN`                                                             |
+| UniFi      | `UNIFI_USERNAME`, `UNIFI_PASSWORD`, `UNIFI_API`                            |
+
+Run `gh auth login` before Terraform targets or Helm OCI chart updates that
+need GitHub. Export `GITHUB_TOKEN` as above so the GitHub provider does not
+need `gh` invoked from Terragrunt.
 
 ## `1password-credentials.json`
 

--- a/infrastructure/root.hcl
+++ b/infrastructure/root.hcl
@@ -6,25 +6,17 @@ locals {
   aws_remote_backend_region = local.region_vars.aws_remote_backend_region
   aws_region                = local.region_vars.aws_region
 
-  b2_version            = local.version_vars.b2_version
-  b2_application_key    = get_env("B2_APPLICATION_KEY")
-  b2_application_key_id = get_env("B2_APPLICATION_KEY_ID")
-
-  cloudflare_version   = local.version_vars.cloudflare_version
-  cloudflare_api_token = get_env("CLOUDFLARE_API_TOKEN")
-
-  github_token   = trimspace(run_cmd("--terragrunt-quiet", "--terragrunt-global-cache", "gh", "auth", "token"))
-  github_version = local.version_vars.github_version
-
-  unifi_username = get_env("UNIFI_USERNAME")
-  unifi_password = get_env("UNIFI_PASSWORD")
-  unifi_api_url  = get_env("UNIFI_API_URL")
-  unifi_version  = local.version_vars.unifi_version
+  b2_version         = local.version_vars.b2_version
+  cloudflare_version = local.version_vars.cloudflare_version
+  github_version     = local.version_vars.github_version
+  unifi_version      = local.version_vars.unifi_version
 }
 
 # Configure Terragrunt to use OpenTofu instead of Terraform
 terraform_binary = "tofu"
 
+# Provider credentials are read from the process environment (see documentation/secrets.md).
+# Do not interpolate secrets into this generate block — they would land in .terragrunt-cache.
 generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"
@@ -65,25 +57,17 @@ provider "aws" {
   }
 }
 
-provider "b2" {
-  application_key    = "${local.b2_application_key}"
-  application_key_id = "${local.b2_application_key_id}"
-}
+# Credentials: B2_APPLICATION_KEY, B2_APPLICATION_KEY_ID
+provider "b2" {}
 
-provider "cloudflare" {
-  api_token = "${local.cloudflare_api_token}"
-}
+# Credentials: CLOUDFLARE_API_TOKEN
+provider "cloudflare" {}
 
-provider "github" {
-  token = "${local.github_token}"
-}
+# Credentials: GITHUB_TOKEN
+provider "github" {}
 
-provider "unifi" {
-  username       = "${local.unifi_username}"
-  password       = "${local.unifi_password}"
-  api_url        = "${local.unifi_api_url}"
-  allow_insecure = true # self-signed for now
-}
+# Credentials: UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_API
+provider "unifi" {}
 EOF
 }
 

--- a/infrastructure/root.hcl
+++ b/infrastructure/root.hcl
@@ -96,10 +96,11 @@ remote_state {
   }
 
   config = {
-    bucket  = "github-otaru-${local.aws_remote_backend_region}-terraform-state"
-    key     = "${path_relative_to_include()}/terraform.tfstate"
-    region  = local.aws_remote_backend_region
-    encrypt = true
+    bucket       = "github-otaru-${local.aws_remote_backend_region}-terraform-state"
+    key          = "${path_relative_to_include()}/terraform.tfstate"
+    region       = local.aws_remote_backend_region
+    encrypt      = true
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 2 hygiene for OpenTofu/Terragrunt (no UniFi drift work):

1. **S3-native state locking** — `use_lockfile = true` on the shared backend (no DynamoDB lock table).
2. **Env-native provider credentials** — stop interpolating secrets into generated `provider.tf` / `.terragrunt-cache`; document env vars in `documentation/secrets.md` (`UNIFI_API`, `GITHUB_TOKEN`, etc.).
3. **CI pins** — OpenTofu `1.12.4` and Terragrunt `1.1.1` instead of `1.12.0` / `latest`.

## Test plan

- [x] `terragrunt plan` on `cloud/aws/oidc-provider` (no changes, lockfile backend)
- [x] `terragrunt plan` on `cloud/cloudflare/dns` after reconfigure (env-native providers)
- [x] Generated `provider.tf` contains no tokens/passwords
- [x] `make clean-terragrunt-cache` after change
- [x] `markdownlint-cli2 documentation/secrets.md`
- [ ] CI green on this PR