### PR TITLE
chore(infra): raise provider version floors, migrate Cloudflare to 5.22

### DIFF
--- a/infrastructure/cloud/cloudflare/access/.terraform.lock.hcl
+++ b/infrastructure/cloud/cloudflare/access/.terraform.lock.hcl
@@ -2,25 +2,32 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
-  version     = "5.4.0"
-  constraints = "~> 5.4.0"
+  version     = "5.22.0"
+  constraints = "~> 5.22"
   hashes = [
-    "h1:KjToQWBCake9Stqj8aZ5cld29sWRCTy/2CIM3MJJEvQ=",
-    "zh:08b35ad7c1125bd0f34a0e719231389a679dc4a0247aa7c46374a55f13658a5a",
-    "zh:10c68c3a847b22c85db45d401febb9b34e0c0dadc38c4cc8f22b031cc9ff53de",
-    "zh:1750f58bd37db19f1d92a4232db359505993f1e2d8ba7d6732b1b59f098da902",
-    "zh:3929072b8dab83cc630d18a2ec04b339342d6dea7da7f51b733ffbd2543177b8",
-    "zh:9b297eeb027cd7e01f392d94a408070dcb801f09bf58a60a1a7f356bd78b40f5",
-    "zh:9d90bd226699737d00532927491e7ae0c30a5df407d39d0a29fa0bb2eedb5a7e",
-    "zh:a3b28a5e0114488b50ef0887e3fb8f8baa74058d1b33a57b1c8917e5be954ef1",
-    "zh:afd7388049fdbe3b0c21f3141ad623c970ab6c341c8fbab91041dc665c4331f7",
+    "h1:EOm3pWL+XqsFNVhupvcedWz7XrYurk52G6ElTSJ+Fxk=",
+    "h1:H3XmcpcMLeDyuGU6QsBXeVOB2CQGnIVRt6PJf7hfrtE=",
+    "h1:IqMMtu1KnqHhdRt3He18R1VZ6yijKjCVGL+qvGh5wbM=",
+    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
+    "h1:RPY1abVjmPNOL79CeRmh1wgpgxoSXskz11HOU01ZX9c=",
+    "h1:bEk4C6AqKLPIUFijHpzP4yxim+hybvDX15smKqhlL1M=",
+    "h1:dEU3MBWyHJQh3OHGYi4QTiBxWtcuQKtijYa403txMaM=",
+    "h1:u3j/+0nmwTHvVg4lTziT8c9YvzGLlJOmFEOv/42yPuQ=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }
 
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.13.0"
-  constraints = "~> 6.6"
+  constraints = "~> 6.13"
   hashes = [
     "h1:2kD+4leuV8tBBXv+EPeehmfW6cDhIzVki61OXsGCtRI=",
     "h1:99s0C+KmzXIsUJY0tKlgfcFUIuuXjCK0TAeeZ8HaOZQ=",

--- a/infrastructure/cloud/cloudflare/dns/.terraform.lock.hcl
+++ b/infrastructure/cloud/cloudflare/dns/.terraform.lock.hcl
@@ -2,18 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
-  version     = "5.4.0"
-  constraints = "~> 5.4.0"
+  version     = "5.22.0"
+  constraints = "~> 5.22"
   hashes = [
-    "h1:KjToQWBCake9Stqj8aZ5cld29sWRCTy/2CIM3MJJEvQ=",
-    "zh:08b35ad7c1125bd0f34a0e719231389a679dc4a0247aa7c46374a55f13658a5a",
-    "zh:10c68c3a847b22c85db45d401febb9b34e0c0dadc38c4cc8f22b031cc9ff53de",
-    "zh:1750f58bd37db19f1d92a4232db359505993f1e2d8ba7d6732b1b59f098da902",
-    "zh:3929072b8dab83cc630d18a2ec04b339342d6dea7da7f51b733ffbd2543177b8",
-    "zh:9b297eeb027cd7e01f392d94a408070dcb801f09bf58a60a1a7f356bd78b40f5",
-    "zh:9d90bd226699737d00532927491e7ae0c30a5df407d39d0a29fa0bb2eedb5a7e",
-    "zh:a3b28a5e0114488b50ef0887e3fb8f8baa74058d1b33a57b1c8917e5be954ef1",
-    "zh:afd7388049fdbe3b0c21f3141ad623c970ab6c341c8fbab91041dc665c4331f7",
+    "h1:EOm3pWL+XqsFNVhupvcedWz7XrYurk52G6ElTSJ+Fxk=",
+    "h1:H3XmcpcMLeDyuGU6QsBXeVOB2CQGnIVRt6PJf7hfrtE=",
+    "h1:IqMMtu1KnqHhdRt3He18R1VZ6yijKjCVGL+qvGh5wbM=",
+    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
+    "h1:RPY1abVjmPNOL79CeRmh1wgpgxoSXskz11HOU01ZX9c=",
+    "h1:bEk4C6AqKLPIUFijHpzP4yxim+hybvDX15smKqhlL1M=",
+    "h1:dEU3MBWyHJQh3OHGYi4QTiBxWtcuQKtijYa403txMaM=",
+    "h1:u3j/+0nmwTHvVg4lTziT8c9YvzGLlJOmFEOv/42yPuQ=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/infrastructure/cloud/cloudflare/tunnel/.terraform.lock.hcl
+++ b/infrastructure/cloud/cloudflare/tunnel/.terraform.lock.hcl
@@ -2,18 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
-  version     = "5.4.0"
-  constraints = "~> 5.4.0"
+  version     = "5.22.0"
+  constraints = "~> 5.22"
   hashes = [
-    "h1:KjToQWBCake9Stqj8aZ5cld29sWRCTy/2CIM3MJJEvQ=",
-    "zh:08b35ad7c1125bd0f34a0e719231389a679dc4a0247aa7c46374a55f13658a5a",
-    "zh:10c68c3a847b22c85db45d401febb9b34e0c0dadc38c4cc8f22b031cc9ff53de",
-    "zh:1750f58bd37db19f1d92a4232db359505993f1e2d8ba7d6732b1b59f098da902",
-    "zh:3929072b8dab83cc630d18a2ec04b339342d6dea7da7f51b733ffbd2543177b8",
-    "zh:9b297eeb027cd7e01f392d94a408070dcb801f09bf58a60a1a7f356bd78b40f5",
-    "zh:9d90bd226699737d00532927491e7ae0c30a5df407d39d0a29fa0bb2eedb5a7e",
-    "zh:a3b28a5e0114488b50ef0887e3fb8f8baa74058d1b33a57b1c8917e5be954ef1",
-    "zh:afd7388049fdbe3b0c21f3141ad623c970ab6c341c8fbab91041dc665c4331f7",
+    "h1:EOm3pWL+XqsFNVhupvcedWz7XrYurk52G6ElTSJ+Fxk=",
+    "h1:H3XmcpcMLeDyuGU6QsBXeVOB2CQGnIVRt6PJf7hfrtE=",
+    "h1:IqMMtu1KnqHhdRt3He18R1VZ6yijKjCVGL+qvGh5wbM=",
+    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
+    "h1:RPY1abVjmPNOL79CeRmh1wgpgxoSXskz11HOU01ZX9c=",
+    "h1:bEk4C6AqKLPIUFijHpzP4yxim+hybvDX15smKqhlL1M=",
+    "h1:dEU3MBWyHJQh3OHGYi4QTiBxWtcuQKtijYa403txMaM=",
+    "h1:u3j/+0nmwTHvVg4lTziT8c9YvzGLlJOmFEOv/42yPuQ=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/infrastructure/modules/cloudflare-access/application.tf
+++ b/infrastructure/modules/cloudflare-access/application.tf
@@ -5,6 +5,12 @@ resource "cloudflare_zero_trust_access_application" "this" {
   type                      = var.type
   session_duration          = var.session_duration
   auto_redirect_to_identity = var.auto_redirect_to_identity
+  # Binds the auth cookie to the client, hardening against compromised
+  # authorization tokens and CSRF attacks (Cloudflare-recommended).
+  enable_binding_cookie = true
+  # No cross-origin CORS preflight requirement for this application; keep
+  # OPTIONS requests behind Access rather than bypassing auth for them.
+  options_preflight_bypass = false
 
   policies = [
     {

--- a/infrastructure/version.hcl
+++ b/infrastructure/version.hcl
@@ -1,7 +1,7 @@
 locals {
   aws_version        = "~> 6.55"
   b2_version         = "~> 0.13"
-  cloudflare_version = "~> 5.4.0"
+  cloudflare_version = "~> 5.22"
   github_version     = "~> 6.13"
   unifi_version      = "~> 0.41"
 }

--- a/infrastructure/version.hcl
+++ b/infrastructure/version.hcl
@@ -1,7 +1,7 @@
 locals {
-  aws_version        = "~> 6.0"
-  b2_version         = "~> 0.8"
+  aws_version        = "~> 6.55"
+  b2_version         = "~> 0.13"
   cloudflare_version = "~> 5.4.0"
-  github_version     = "~> 6.6"
+  github_version     = "~> 6.13"
   unifi_version      = "~> 0.41"
 }


### PR DESCRIPTION
## Summary

- Raise `version.hcl` floors for AWS, B2, and GitHub to match what was already locked (`~> 6.0` → `~> 6.55`, `~> 0.8` → `~> 0.13`, `~> 6.6` → `~> 6.13`); no provider version changes, purely reflects reality
- Widen Cloudflare from the long-pinned `~> 5.4.0` to `~> 5.22` and migrate the affected Terraform state
- Explicitly set `enable_binding_cookie = true` on the Access application per Cloudflare's own hardening guidance, and pin `options_preflight_bypass = false` to match current behaviour

## Why

The Cloudflare provider had been pinned to `5.4.0` since PR #1569 (Aug 2025) after a prior bad experience floating it. Re-investigating found the provider had moved 18 minor versions since, carrying real plan-noise fixes for `dns` and `tunnel`. The `access` unit's state predates several schema changes (fields the provider removed between `5.5.0` and `5.10.0`: `created_at`, `app_count`, `updated_at`, `reusable`) that its own `schema_version=0` upgrader doesn't cover for this specific state shape, so the version bump alone was not enough.

## What this actually changed

**Terraform state (already applied against the S3 backend, not gated by this PR):** `state rm` + `import` was used to re-read `cloudflare_zero_trust_list` (x4), `cloudflare_zero_trust_access_policy` (x4), `cloudflare_zero_trust_access_application`, and `cloudflare_zero_trust_tunnel_cloudflared_config` fresh from the live Cloudflare API under the new provider schema. This only rewrites Terraform's own bookkeeping — at no point did this create, modify, or delete a live Cloudflare resource. Verified: reimported list item counts match a pre-surgery snapshot exactly (cluster 1, github 6, telegram 14, webgazer 10), and every unit's plan showed zero destroy/replace both before and after.

**One near-miss, caught before it could apply:** the Access application is scoped by `zone_id`, not `account_id` — the first import attempt used the Cloudflare docs' generic `accounts/<account_id>/<app_id>` example without checking the module's actual config, which produced a destroy-and-recreate plan for the live Access application in front of `otaru.siutsin.com`. Caught at the read-only `plan` stage; fixed by reimporting with the correct `zones/<zone_id>/<app_id>` scope.

**Config change requiring apply:** `enable_binding_cookie = false → true` is a real, not-yet-applied behaviour change. Cloudflare's docs state this "increases security against compromised authorization tokens and CSRF attacks." `options_preflight_bypass` stays `false`, matching current live behaviour (no CORS preflight use case for this app).

## Result

- `cloud/cloudflare/dns`: was 21 changes (metadata noise) → now `No changes`
- `cloud/cloudflare/tunnel`: was 4 changes → now `No changes`
- `cloud/cloudflare/access`: was 9 changes (opaque schema churn) → now exactly one intended change (`enable_binding_cookie`)

## Testing

- `make test` passes
- `terragrunt run --all -- init -upgrade` clean across all 13 units, no lockfile drift beyond the intended version bumps
- Every touched unit re-verified with a read-only `terragrunt plan`: zero destroy/replace anywhere
- UniFi units (`local/lhr/unifi`, `local/lhr/unifi-firewall-rules`) intentionally untouched — archived provider, out of scope for this change