### PR TITLE
feat(unifi-mcp): add Helm chart for sirkirby/unifi-mcp

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -182,6 +182,7 @@ local application = [
   { wave: '11', name: 'openclaw', namespace: 'openclaw', helm: openClawHelm },
   { wave: '10', name: 'teslamate', namespace: 'teslamate' },
   { wave: '10', name: 'umami', namespace: 'umami' },
+  { wave: '10', name: 'unifi-mcp', namespace: 'unifi-mcp' },
   { wave: '11', name: 'changedetection', namespace: 'changedetection' },
   { wave: '11', name: 'home-assistant', namespace: 'home-assistant' },
   { wave: '30', name: 'jung2bot', namespace: 'jung2bot', path: 'helm-charts/jung2bot', helm: jung2botHelm },

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -43,6 +43,8 @@ clusterSecretStorePolicy:
       - b2-secret-cloudnative-pg
       - heartbeats
       - teslamate
+    unifi-mcp:
+      - unifi-mcp
 
 workloadResourcesPolicy:
   enabled: true

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -40,3 +40,4 @@ namespaces:
   - name: reloader
   - name: teslamate
   - name: umami
+  - name: unifi-mcp

--- a/helm-charts/unifi-mcp/.helmignore
+++ b/helm-charts/unifi-mcp/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp

--- a/helm-charts/unifi-mcp/Chart.yaml
+++ b/helm-charts/unifi-mcp/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: unifi-mcp
+description: sirkirby/unifi-mcp servers (Network, and future Protect/Access), one pod per otaru instance
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/unifi-mcp/templates/authorization-policy.yaml
+++ b/helm-charts/unifi-mcp/templates/authorization-policy.yaml
@@ -1,0 +1,27 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+      to:
+        - operation:
+            ports:
+              {{- range $key, $c := .Values.containers }}
+              {{- if $c.enabled }}
+              - {{ $c.port | quote }}
+              {{- end }}
+              {{- end }}

--- a/helm-charts/unifi-mcp/templates/deployment.yaml
+++ b/helm-charts/unifi-mcp/templates/deployment.yaml
@@ -1,0 +1,122 @@
+{{- $shared := .Values.sharedEnv -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.name }}
+    spec:
+      serviceAccountName: {{ .Values.name }}
+      automountServiceAccountToken: false
+      # Upstream images (apps/*/Dockerfile) have no USER directive and run
+      # as root by default. Force a non-root UID and a read-only rootfs
+      # here at the pod level -- these are stateless HTTP servers with no
+      # persistent volume, so none of them need root or a writable image
+      # layer.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ .Values.name }}
+                topologyKey: kubernetes.io/hostname
+      containers:
+        {{- range $key, $c := .Values.containers }}
+        {{- if $c.enabled }}
+        - name: {{ $key }}
+          image: {{ $c.image.repository }}:{{ $c.image.tag }}
+          imagePullPolicy: {{ $c.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ $.Values.secret.name }}
+          env:
+            - name: UNIFI_PORT
+              value: {{ $shared.controllerPort | quote }}
+            - name: UNIFI_VERIFY_SSL
+              value: {{ $c.env.verifySsl | quote }}
+            {{- if $c.env.networkSite }}
+            - name: UNIFI_NETWORK_SITE
+              value: {{ $c.env.networkSite | quote }}
+            {{- end }}
+            - name: UNIFI_TOOL_PERMISSION_MODE
+              value: {{ $c.env.toolPermissionMode | quote }}
+            - name: UNIFI_MCP_HTTP_ENABLED
+              value: "true"
+            - name: UNIFI_MCP_HTTP_TRANSPORT
+              value: streamable-http
+            - name: UNIFI_MCP_HOST
+              value: 0.0.0.0
+            - name: UNIFI_MCP_PORT
+              value: {{ $c.port | quote }}
+            - name: UNIFI_MCP_ENABLE_DNS_REBINDING_PROTECTION
+              value: {{ $c.env.enableDnsRebindingProtection | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          ports:
+            - name: {{ $key }}
+              containerPort: {{ $c.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ $c.probes.liveness.path | quote }}
+              port: {{ $key }}
+            initialDelaySeconds: {{ $c.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ $c.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ $c.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ $c.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ $c.probes.readiness.path | quote }}
+              port: {{ $key }}
+            periodSeconds: {{ $c.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ $c.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ $c.probes.readiness.failureThreshold }}
+          resources:
+            requests:
+              cpu: {{ $c.resources.requests.cpu }}
+              memory: {{ $c.resources.requests.memory }}
+              ephemeral-storage: {{ $c.resources.requests.ephemeralStorage }}
+            limits:
+              memory: {{ $c.resources.limits.memory }}
+              ephemeral-storage: {{ $c.resources.limits.ephemeralStorage }}
+          volumeMounts:
+            - name: {{ $key }}-tmp
+              mountPath: /tmp
+        {{- end }}
+        {{- end }}
+      volumes:
+        {{- range $key, $c := .Values.containers }}
+        {{- if $c.enabled }}
+        - name: {{ $key }}-tmp
+          emptyDir: {}
+        {{- end }}
+        {{- end }}

--- a/helm-charts/unifi-mcp/templates/external-secret.yaml
+++ b/helm-charts/unifi-mcp/templates/external-secret.yaml
@@ -36,11 +36,3 @@ spec:
         key: {{ .Values.externalSecret.remoteRef.key }}
         metadataPolicy: None
         property: {{ .Values.externalSecret.remoteRef.properties.password }}
-    - secretKey: UNIFI_API_KEY
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        nullBytePolicy: Ignore
-        key: {{ .Values.externalSecret.remoteRef.key }}
-        metadataPolicy: None
-        property: {{ .Values.externalSecret.remoteRef.properties.apiKey }}

--- a/helm-charts/unifi-mcp/templates/external-secret.yaml
+++ b/helm-charts/unifi-mcp/templates/external-secret.yaml
@@ -1,0 +1,46 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.secret.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.externalSecret.secretStoreRef.kind }}
+    name: {{ .Values.externalSecret.secretStoreRef.name }}
+  target:
+    name: {{ .Values.secret.name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: UNIFI_HOST
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: {{ .Values.externalSecret.remoteRef.properties.host }}
+    - secretKey: UNIFI_USERNAME
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: {{ .Values.externalSecret.remoteRef.properties.username }}
+    - secretKey: UNIFI_PASSWORD
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: {{ .Values.externalSecret.remoteRef.properties.password }}
+    - secretKey: UNIFI_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.externalSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: {{ .Values.externalSecret.remoteRef.properties.apiKey }}

--- a/helm-charts/unifi-mcp/templates/route-internal.yaml
+++ b/helm-charts/unifi-mcp/templates/route-internal.yaml
@@ -1,0 +1,40 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}-internal
+  namespace: {{ .Values.namespace }}
+spec:
+  hostnames:
+    - {{ printf "%s.internal.siutsin.com" .Values.name }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayName }}
+      namespace: {{ $gatewayNamespace }}
+  rules:
+    {{- range $key, $c := .Values.containers }}
+    {{- if $c.enabled }}
+    # Each sirkirby/unifi-mcp server serves Streamable HTTP at a fixed
+    # /mcp path with no way to change it, so the client-facing prefix
+    # below is rewritten to /mcp before it reaches the container.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ printf "/%s" $key }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /mcp
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $.Values.name }}
+          port: {{ $c.port }}
+          weight: 1
+    {{- end }}
+    {{- end }}

--- a/helm-charts/unifi-mcp/templates/service.yaml
+++ b/helm-charts/unifi-mcp/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    {{- range $key, $c := .Values.containers }}
+    {{- if $c.enabled }}
+    - name: {{ $key }}
+      port: {{ $c.port }}
+      protocol: TCP
+      targetPort: {{ $key }}
+    {{- end }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/unifi-mcp/templates/serviceaccount.yaml
+++ b/helm-charts/unifi-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+automountServiceAccountToken: false

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -16,20 +16,16 @@ externalSecret:
       host: UNIFI_HOST
       username: UNIFI_USERNAME
       password: UNIFI_PASSWORD
-      apiKey: UNIFI_API_KEY
 
 secret:
   name: unifi-mcp-secrets
 
 # Shared across every container in the pod -- same controller, same
 # runtime transport settings. Credentials (UNIFI_HOST, UNIFI_USERNAME,
-# UNIFI_PASSWORD, UNIFI_API_KEY) come from the ExternalSecret above and
-# are injected via envFrom, not here. UNIFI_USERNAME/UNIFI_PASSWORD must
-# be a local admin/service account, not a Ubiquiti SSO account, and must
-# not have MFA enabled -- the login flow does not support a TOTP prompt.
-# UNIFI_API_KEY is optional and only unlocks a handful of extra
-# capabilities (e.g. firewall rule ordering); username/password are
-# required regardless.
+# UNIFI_PASSWORD) come from the ExternalSecret above and are injected via
+# envFrom, not here. UNIFI_USERNAME/UNIFI_PASSWORD must be a local
+# admin/service account, not a Ubiquiti SSO account, and must not have MFA
+# enabled -- the login flow does not support a TOTP prompt.
 sharedEnv:
   controllerPort: "443"
 

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -1,0 +1,86 @@
+name: unifi-mcp
+namespace: unifi-mcp
+
+gateway:
+  name: gateway
+  namespace: gateway
+
+externalSecret:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  remoteRef:
+    key: unifi-mcp
+    properties:
+      host: UNIFI_HOST
+      username: UNIFI_USERNAME
+      password: UNIFI_PASSWORD
+      apiKey: UNIFI_API_KEY
+
+secret:
+  name: unifi-mcp-secrets
+
+# Shared across every container in the pod -- same controller, same
+# runtime transport settings. Credentials (UNIFI_HOST, UNIFI_USERNAME,
+# UNIFI_PASSWORD, UNIFI_API_KEY) come from the ExternalSecret above and
+# are injected via envFrom, not here. UNIFI_USERNAME/UNIFI_PASSWORD must
+# be a local admin/service account, not a Ubiquiti SSO account, and must
+# not have MFA enabled -- the login flow does not support a TOTP prompt.
+# UNIFI_API_KEY is optional and only unlocks a handful of extra
+# capabilities (e.g. firewall rule ordering); username/password are
+# required regardless.
+sharedEnv:
+  controllerPort: "443"
+
+# One entry per sirkirby/unifi-mcp server. All containers land in the same
+# pod so they share node placement, restart together, and reuse the one
+# ExternalSecret -- this repo has exactly one UniFi controller, so there is
+# nothing to gain from separate pods. Add a "protect" or "access" entry
+# here (own image/port/probes/resources, same shape as "network") to grow
+# the pod later; no template changes needed.
+containers:
+  network:
+    enabled: true
+    image:
+      repository: ghcr.io/sirkirby/unifi-network-mcp
+      tag: 0.24.0@sha256:b212059aaf707c0d3764a32bf348bdfa948ed6418883e8bb7e9bddadfc9eafa5
+      pullPolicy: IfNotPresent
+    port: 3000
+    env:
+      networkSite: default
+      verifySsl: "true"
+      # confirm (default) requires preview-then-confirm on every mutating
+      # tool call; never set this to bypass while Claude Code also runs
+      # with its own permission prompts bypassed -- with both bypassed
+      # there is no remaining safety net before a live network change.
+      toolPermissionMode: confirm
+      # Envoy Gateway forwards the client's original Host header, which
+      # UNIFI_MCP_ALLOWED_HOSTS can't reliably enumerate through a proxy
+      # chain. The upstream project's own runtime.py comments recommend
+      # disabling DNS rebinding protection for exactly this
+      # Kubernetes/proxy deployment shape.
+      enableDnsRebindingProtection: "false"
+    probes:
+      liveness:
+        path: /healthz
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 4
+      readiness:
+        path: /healthz
+        periodSeconds: 10
+        timeoutSeconds: 10
+        failureThreshold: 3
+    resources:
+      # New workload, no KRR history yet -- conservative starting estimate
+      # for a single-replica async Python HTTP server with no persistent
+      # state. Revisit after the first right-sizing pass has real data.
+      requests:
+        cpu: 50m
+        memory: 192Mi
+        ephemeralStorage: 128Mi
+      limits:
+        memory: 192Mi
+        ephemeralStorage: 128Mi


### PR DESCRIPTION
## Summary

- Add a self-authored Helm chart for `sirkirby/unifi-mcp` (no upstream chart) so Claude Code can talk to the UniFi Network controller over Streamable HTTP.
- One Deployment with a values-driven `containers` map (starts with `network` only; Protect/Access can be added later as values entries).
- Path-based internal route: `https://unifi-mcp.internal.siutsin.com/network` rewritten to `/mcp`.
- ExternalSecret pulls `UNIFI_HOST` / `UNIFI_USERNAME` / `UNIFI_PASSWORD` from 1Password item `unifi-mcp` (vault `github-otaru`). API key intentionally omitted — username/password are required; API key only unlocks a small optional read-only subset.
- Force non-root UID 1000 + read-only rootfs at the pod level (upstream image runs as root by default).
- Keep `UNIFI_TOOL_PERMISSION_MODE=confirm` so mutations stay gated.
- Wire Argo CD app (wave 10), namespace ambient defaults, and Kyverno `clusterSecretStorePolicy` allowlist entry.

## Test plan

- [x] `make test` green locally
- [ ] After merge: ExternalSecret `unifi-mcp-secrets` Ready in `unifi-mcp`
- [ ] Pod Ready with `/healthz` probes succeeding
- [ ] MCP endpoint responds at `https://unifi-mcp.internal.siutsin.com/network`