### PR TITLE
fix(envoy-gateway): allow unifi-mcp on HTTPS listener

### DIFF
--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -47,6 +47,7 @@ spec:
                   - openclaw
                   - teslamate
                   - umami
+                  - unifi-mcp
     - name: jellyfin-sftp
       protocol: TCP
       port: 2022


### PR DESCRIPTION
## Summary

- Add `unifi-mcp` to the Envoy Gateway HTTPS listener `allowedRoutes` namespace selector.
- Without this, `HTTPRoute/unifi-mcp-internal` stays `NotAllowedByListeners` and `https://unifi-mcp.internal.siutsin.com/network` 404s even though the pod is Ready and UniFi auth works.

## Test plan

- [x] Pod already Ready 1/1 with tcpSocket probes (#2877)
- [ ] After merge: HTTPRoute Accepted
- [ ] External `GET /network` rewrites to MCP and returns protocol response (not gateway 404)