### PR TITLE
docs(self-healing): document UniFi network MCP for node triage

### DIFF
--- a/.claude/skills/self-healing/references/cluster.md
+++ b/.claude/skills/self-healing/references/cluster.md
@@ -42,6 +42,29 @@ kubectl cluster-info
 kubectl get nodes -o wide
 ```
 
+## Network layer (UniFi)
+
+The otaru VLAN (`192.168.10.0/24`, see Network table above) is one VLAN on a
+UniFi Network controller that also serves other household VLANs. When a node
+Reachability check fails, `unifi-network` MCP tools give read-only visibility
+below the Kubernetes layer, without needing SSH or physical access:
+
+- `unifi_get_network_health` — per-subsystem (WAN/LAN/WLAN/VPN) status.
+- `unifi_list_alarms` / `unifi_list_events` — connectivity and firmware
+  alarms, connect/disconnect/roam events.
+- `unifi_list_devices` — switch/AP/gateway online status and uptime.
+- `unifi_get_port_stats` (`device_mac` argument) — per-port link state,
+  speed, duplex, and error/drop counters for the switch a node's cable
+  lands on.
+- `unifi_get_lldp_neighbors` — confirms physical switch-to-switch topology.
+
+Read-only only. Do not adopt, reboot, or toggle devices, change WLANs, or
+touch ACL/firewall/VPN config from this skill — that is out of scope and may
+conflict with other in-flight network changes elsewhere. Journal and
+escalate any UniFi-side finding (port errors, alarms, WAN down) rather than
+acting on it; do not name specific device models, MAC addresses, or port
+numbers in the journal beyond what is already in this file's Network table.
+
 ## Validation
 
 Before opening a PR, from the repo root:

--- a/.claude/skills/self-healing/runbooks/access-and-nodes.md
+++ b/.claude/skills/self-healing/runbooks/access-and-nodes.md
@@ -18,7 +18,10 @@ Journal **any** NotReady node as P0 before lower-priority categories.
 
 **Reachability.** Ping the node IP from `references/cluster.md`. If the host
 is dark (no ping, no SSH) but power may still be on, do not assume a clean
-reboot — see hardware gotchas below.
+reboot. If `unifi-network` MCP tools are available, check switch-port link
+state and error counters first (`references/cluster.md` Network layer
+section) — read-only, and can distinguish a dead host from a dead link
+before escalating hardware. See hardware gotchas below.
 
 **LUKS / initramfs.** Several nodes use LUKS-encrypted root
 (`luks_root_nodes` in `ansible/inventory.yaml`). After a reboot they sit in


### PR DESCRIPTION
## Summary
- Documents the new `unifi-network` MCP tools as a read-only network-layer diagnostic aid in the self-healing skill's cluster reference.
- Points node-reachability triage at checking switch-port link state/error counters before escalating hardware, without naming specific devices, MAC addresses, or ports.

## Test plan
- [ ] `make test` (docs-only change; no functional cluster behaviour affected)