### PR TITLE
docs(infrastructure): define plan and apply workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,8 +206,8 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# Saved plans can contain sensitive values and must not be committed.
+*.tfplan
 
 # Ignore CLI configuration files
 .terraformrc

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(MAGENTA)Development & Infrastructure:$(NC)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		grep -E "^(clean-terragrunt-cache|add-helm-repos|update-helm-deps|delete-git-tags|clean-all|generate-diagrams):" | \
+		grep -E "^(clean-terragrunt-cache|plan-infrastructure|add-helm-repos|update-helm-deps|delete-git-tags|clean-all|generate-diagrams):" | \
 		sort | awk 'BEGIN {FS = ":.*?## "}; {gsub(/\(DANGEROUS!\)/, "$(RED)(DANGEROUS!)$(NC)"); printf "  $(YELLOW)%-25s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(GREEN)Validation & Quality:$(NC)"
@@ -130,6 +130,15 @@ nuke: ## Run cluster destruction playbook (DANGEROUS!)
 clean-terragrunt-cache: ## Clean up all .terragrunt-cache folders in infrastructure directory
 	@echo "$(GREEN)Cleaning Terragrunt cache...$(NC)"
 	bash $(HACK_DIR)/remove-terragrunt-cache.sh $(INFRASTRUCTURE_DIR)
+
+.PHONY: plan-infrastructure
+plan-infrastructure: ## Plan all non-UniFi infrastructure units (non-apply; exit 2 means drift)
+	@echo "$(GREEN)Planning non-UniFi infrastructure...$(NC)"
+	@command -v tofu >/dev/null 2>&1 || { echo "$(RED)tofu (OpenTofu) is required but not installed.$(NC)"; exit 1; }
+	@command -v terragrunt >/dev/null 2>&1 || { echo "$(RED)terragrunt is required but not installed.$(NC)"; exit 1; }
+	@cd $(INFRASTRUCTURE_DIR) && terragrunt run --all --non-interactive \
+		--queue-ignore-errors --filter '!./local/**' -- \
+		plan -detailed-exitcode -no-color
 
 .PHONY: add-helm-repos
 add-helm-repos: ## Add Helm repositories declared by chart dependencies

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -4,6 +4,7 @@
 |----------------------------------------------------------|---------------------------------------------------------------|
 | [Create a Raspberry Pi image](create_rpi_image.md)       | Standard Raspberry Pi 5 encrypted NVMe image workflow.        |
 | [Secrets](secrets.md)                                    | Secret management and encryption workflow for the repo.       |
+| [Infrastructure operations](infrastructure.md)           | OpenTofu and Terragrunt plan/apply operating procedure.       |
 | [Connectivity](connectivity.md)                          | North-south, east-west, and mesh security model.              |
 | [LUKS remote unlock and recovery](luks_remote_unlock.md) | Remote unlock and recovery workflow for LUKS-encrypted nodes. |
 | [LUKS passphrase handling](luks_passphrase.md)           | How LUKS passphrases are stored and loaded for automation.    |

--- a/documentation/infrastructure.md
+++ b/documentation/infrastructure.md
@@ -1,0 +1,82 @@
+# Infrastructure Operations
+
+The external AWS, Backblaze B2, Cloudflare, and UniFi resources under
+`infrastructure/` are managed with OpenTofu 1.12.4 and Terragrunt 1.1.1. This
+runbook defines the routine plan cadence and the approval boundary for applies.
+
+## Ownership and boundaries
+
+- A human operator runs remote plans and applies from a trusted workstation
+  with the environment described in [Secrets](secrets.md).
+- GitHub Actions validates and formats the configuration but does not contact
+  remote infrastructure. A hosted runner would need credentials for several
+  providers and cannot reach the private UniFi endpoint.
+- Routine plans exclude `infrastructure/local/`. UniFi plans and applies stay
+  inside an explicitly approved maintenance window because the provider
+  migration and controller ground-truth work are still gated.
+- Never use `terragrunt run --all` for apply. Apply one reviewed unit at a time.
+
+## Cadence
+
+| Trigger | Action |
+| ------- | ------ |
+| Monthly | Run the non-UniFi plan across all 11 cloud units. |
+| Infrastructure pull request | Plan every affected unit before merge. |
+| Provider or module upgrade | Plan affected units before merge and again after any approved apply. |
+| Suspected out-of-band change | Plan the affected unit and record whether Git or the live service is ground truth. |
+| UniFi maintenance | Plan only after the provider and ground-truth gates are explicitly opened. |
+
+## Routine non-UniFi plan
+
+Start from an up-to-date `master` checkout with the external environment loaded:
+
+```shell
+direnv allow
+git pull --ff-only origin master
+make test
+make plan-infrastructure
+```
+
+The Make target uses Terragrunt's negative filter `!./local/**`, which selects
+the 11 AWS, B2, and Cloudflare units while excluding both UniFi units. OpenTofu
+returns exit code `0` when every plan is clean, `2` when drift is present, and
+`1` when planning fails. A drift exit is a review signal, not permission to
+apply.
+
+Confirm the selected units without contacting provider APIs:
+
+```shell
+cd infrastructure
+terragrunt find --filter '!./local/**'
+```
+
+## Apply gate
+
+An apply requires explicit approval and a saved plan for one unit. Review the
+plan for unexpected creates, replacements, or destroys before using it:
+
+```shell
+cd infrastructure/cloud/<provider>/<unit>
+PLAN_FILE="$(pwd)/change.tfplan"
+terragrunt plan -out="$PLAN_FILE"
+tofu show -no-color "$PLAN_FILE"
+terragrunt apply "$PLAN_FILE"
+terragrunt plan -detailed-exitcode -no-color
+rm "$PLAN_FILE"
+```
+
+Saved `*.tfplan` files may contain sensitive values and are ignored by Git.
+Keep provider credentials in the environment; never add them to HCL, generated
+files, logs, or plan artifacts.
+
+## CI drift planning
+
+Scheduled remote plans remain disabled for now. Reconsider them only when each
+provider can use appropriately scoped short-lived credentials and any private
+endpoint runs on a trusted self-hosted runner. Split future jobs by provider so
+a single workflow does not receive every infrastructure credential, and treat
+plan output as sensitive rather than publishing it as a public artifact.
+
+Provider constraint changes also remain deliberate, reviewed changes. Renovate
+may maintain action and dependency pins, but it must not imply approval to apply
+an infrastructure provider upgrade.


### PR DESCRIPTION
## Summary

- add a routine non-UniFi Terragrunt plan target for the 11 cloud units
- document plan cadence, operator ownership, and one-unit apply gates
- keep scheduled hosted-runner plans disabled until credentials and private connectivity are appropriately scoped
- ignore saved OpenTofu plan files because they may contain sensitive values

## Validation

- `terragrunt find --filter '!./local/**'` selects exactly 11 cloud units\n- `make -n plan-infrastructure`\n- `make test`