### PR TITLE
fix(blocky): bump memory to 768Mi for second denylist group

### DIFF
--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -16,13 +16,16 @@ deployment:
   ports:
     http: 4000
   resources:
-    # Keep memory at 512Mi: Blocky spikes during denylist refresh/import and was OOMKilled at 192Mi.
+    # 2026-07-20: OOMKilled (exit 137) at 512Mi after adding a second denylist
+    # group ("malware", HaGeZi TIF + URLhaus) alongside the existing "ads"
+    # group -- concurrent import/parse of both groups spikes higher than a
+    # single group did. Bumped to 768Mi for headroom.
     requests:
       cpu: 100m
-      memory: 512Mi
+      memory: 768Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 512Mi
+      memory: 768Mi
       ephemeral-storage: 100Mi
 
 hpa:


### PR DESCRIPTION
## Summary
- Adding a `malware` denylist group (HaGeZi TIF + URLhaus) alongside the existing `ads` group pushed concurrent list import over the 512Mi memory limit, OOMKilling the pod (exit 137) on every restart.
- Bumps request/limit to 768Mi for headroom during concurrent multi-group list import.

## Test plan
- [x] `make test` passes
- [ ] Confirm rollout completes and pods stay Ready after merge