### PR TITLE
fix(blocky): exclude from descheduler eviction

### DIFF
--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -22,6 +22,16 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: {{ .Values.deployment.ports.http | quote }}
         prometheus.io/scrape: "true"
+        # 2026-07-20: descheduler's "consolidate" HighNodeUtilization strategy
+        # repeatedly evicted blocky from raspberrypi-00 every ~5 minutes --
+        # it is the only node under the 90% memory threshold while the other
+        # four sit at 98-100%, so the evicted pod has nowhere else to fit and
+        # reschedules straight back, causing a disruptive no-op loop (~40-50s
+        # of reduced capacity per cycle, protected only by the PDB's
+        # maxUnavailable: 1). Opt this DNS-critical, disruption-sensitive
+        # workload out of all descheduler strategies rather than tuning the
+        # shared cluster-wide policy.
+        descheduler.alpha.kubernetes.io/evict: "false"
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
## Summary

- Descheduler's `consolidate` profile (`HighNodeUtilization`) has been
  evicting blocky from `raspberrypi-00` roughly every 5 minutes: that
  node is the only one under the 90% memory threshold while the other
  four sit at 98-100%, so the evicted pod has nowhere else to fit and
  reschedules straight back onto the same node -- a disruptive no-op
  loop, ~40-50s of reduced capacity each cycle (PDB `maxUnavailable: 1`
  keeps the other replica up throughout).
- Add `descheduler.alpha.kubernetes.io/evict: "false"` to blocky's pod
  template so this DNS-critical, disruption-sensitive workload opts
  out of descheduler eviction entirely, rather than tuning the shared
  cluster-wide policy that other workloads still rely on.

## Test plan

- [x] `make test` passes locally
- [ ] After merge: confirm no further blocky pod evictions in
      `kubectl get events -n blocky` and stable `RESTARTS`/age on both
      replicas