### PR TITLE
fix(blocky): correct descheduler exclusion via labelSelector

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1413,7 +1413,7 @@ which is misleading.
 ### Symptoms: VIP Answers Without Hitting Blocky
 
 | Path                            | `doubleclick.net` | `unifi`                                   |
-| ------------------------------- | ----------------- | ----------------------------------------- |
+|---------------------------------|-------------------|-------------------------------------------|
 | Blocky pod IP (hostNetwork dig) | `0.0.0.0`         | `192.168.10.1` (TTL 3600, one answer)     |
 | VIP while capture is on         | real Google IPs   | often TTL 5, two answers, or wrong source |
 | VIP after capture is off        | `0.0.0.0`         | `192.168.10.1` (TTL 3600, one answer)     |
@@ -1555,5 +1555,61 @@ produced a `-/+ destroy and then create replacement` plan for a live
 production Access application. Caught at the read-only `plan` stage
 before any apply; fixed by reimporting with `zones/<zone_id>/<app_id>`
 instead.
+
+---
+
+## `descheduler.alpha.kubernetes.io/evict: "false"` Does Not Stop Eviction
+
+**Problem:** blocky was being evicted from `raspberrypi-00` roughly every
+5 minutes by the `consolidate` profile's `HighNodeUtilization` plugin (see
+"Multi-Container Pods Fail to Schedule Despite \"Enough\" Free Cluster
+Memory" above for that profile's purpose). The first attempted fix added
+the pod annotation `descheduler.alpha.kubernetes.io/evict: "false"` to
+blocky's Deployment template, on the assumption this is the standard
+descheduler opt-out. Confirmed live in `kubectl get events -n blocky` and
+descheduler's own logs that eviction continued unchanged after this
+"fix" rolled out.
+
+**Why it happens:** the annotation is real, but descheduler v0.36 only
+checks whether the key is **present**, not its value -- `"false"` is
+treated identically to `"true"` or any other string, and a pod carrying
+it in *any* form is treated as unconditionally evictable. This is a
+confirmed upstream limitation
+([kubernetes-sigs/descheduler#1659](https://github.com/kubernetes-sigs/descheduler/issues/1659)),
+not a local misconfiguration. Do not trust this annotation to protect a
+pod from eviction on this or any similarly-versioned descheduler.
+
+### Symptoms: Descheduler-Annotated Pod Still Gets Evicted
+
+- A pod carries `descheduler.alpha.kubernetes.io/evict: "false"`, but
+  `kubectl get events -n <namespace>` still shows
+  `Reason: HighNodeUtilization` (or any other strategy) evicting it.
+- Descheduler logs show the pod being selected and evicted with no
+  mention of the annotation at all.
+
+### Resolution: Scope the Exclusion via `DefaultEvictor`'s `labelSelector`
+
+`DefaultEvictor`'s `labelSelector` arg is a real allow-list -- only pods
+matching the selector are eligible for eviction under that profile.
+Exclude specific workloads with a `NotIn` match instead of relying on the
+per-pod annotation:
+
+```yaml
+- name: DefaultEvictor
+  args:
+    labelSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values:
+            - blocky
+```
+
+Scoped to one profile's `DefaultEvictor` config, this only exempts the
+workload from that profile's strategies (here, `consolidate`'s
+`HighNodeUtilization`) -- other profiles (e.g. `default`'s `PodLifeTime`,
+`RemovePodsHavingTooManyRestarts`) still apply normally. Verified live:
+zero further blocky evictions across multiple 5-minute descheduler cycles
+after this rolled out, versus one roughly every cycle beforehand.
 
 ---

--- a/helm-charts/blocky/templates/deployment.yaml
+++ b/helm-charts/blocky/templates/deployment.yaml
@@ -22,16 +22,6 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: {{ .Values.deployment.ports.http | quote }}
         prometheus.io/scrape: "true"
-        # 2026-07-20: descheduler's "consolidate" HighNodeUtilization strategy
-        # repeatedly evicted blocky from raspberrypi-00 every ~5 minutes --
-        # it is the only node under the 90% memory threshold while the other
-        # four sit at 98-100%, so the evicted pod has nowhere else to fit and
-        # reschedules straight back, causing a disruptive no-op loop (~40-50s
-        # of reduced capacity per cycle, protected only by the PDB's
-        # maxUnavailable: 1). Opt this DNS-critical, disruption-sensitive
-        # workload out of all descheduler strategies rather than tuning the
-        # shared cluster-wide policy.
-        descheduler.alpha.kubernetes.io/evict: "false"
     spec:
       affinity:
         podAntiAffinity:

--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -81,6 +81,25 @@ descheduler:
               podProtections:
                 defaultDisabled:
                   - PodsWithLocalStorage
+              # 2026-07-20: blocky (DNS-critical) was repeatedly evicted from
+              # raspberrypi-00 by this profile's HighNodeUtilization -- it was
+              # the only node under the 90% memory threshold while the other
+              # four sat at 98-100%, so the evicted pod had nowhere else to
+              # fit and rescheduled straight back onto the same node, a
+              # disruptive no-op loop every ~5 minutes. Tried opting blocky
+              # out via the descheduler.alpha.kubernetes.io/evict: "false"
+              # pod annotation first -- confirmed via descheduler v0.36
+              # source that this annotation only checks presence, not value
+              # (kubernetes-sigs/descheduler#1659), so it had no effect.
+              # labelSelector is an allow-list (only matching pods are
+              # eligible for eviction under this profile), so excluding
+              # blocky here is the correct mechanism.
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: NotIn
+                    values:
+                      - blocky
           - name: HighNodeUtilization
             args:
               thresholds:


### PR DESCRIPTION
## Summary

- PR #2890 tried to stop blocky's descheduler eviction churn by adding
  `descheduler.alpha.kubernetes.io/evict: "false"` to its pod template.
  Confirmed live (`kubectl get events -n blocky` and descheduler's own
  logs) that eviction continued unchanged after that PR rolled out --
  descheduler v0.36 only checks whether the annotation key is present,
  not its value, so `"false"` has no effect
  ([kubernetes-sigs/descheduler#1659](https://github.com/kubernetes-sigs/descheduler/issues/1659)).
- Replace it with a `labelSelector` on the `consolidate` profile's
  `DefaultEvictor`, which is a real allow-list: only pods matching the
  selector are eligible for eviction under that profile. Excluding
  blocky there stops `HighNodeUtilization` specifically, while leaving
  the `default` profile's `PodLifeTime` / `RemovePodsHavingTooManyRestarts`
  unaffected.
- Documented the annotation gotcha in `documentation/gotcha.md` so this
  isn't re-attempted the same way in future.

## Test plan

- [x] `make test` passes locally
- [ ] After merge: confirm zero blocky eviction events across multiple
      5-minute descheduler cycles (was previously ~1 per cycle)