### PR TITLE
fix(blocky): raise memory limit for periodic refresh OOM, lower request

### DIFF
--- a/helm-charts/blocky/templates/hpa.yaml
+++ b/helm-charts/blocky/templates/hpa.yaml
@@ -20,6 +20,14 @@ spec:
     - type: Resource
       resource:
         name: memory
+        # 2026-07-22: switched from Utilization (% of request) to a fixed
+        # AverageValue. The memory request was intentionally lowered to
+        # 350Mi (see values.yaml) while the limit stayed high to cover a
+        # periodic refresh spike, so a request-relative target would put
+        # ordinary ~290Mi steady-state usage permanently over a 60%-of-350Mi
+        # threshold, pinning replicas at max continuously. 500Mi keeps
+        # roughly the same absolute trigger point as the previous
+        # 60%-of-768Mi (~461Mi) target, decoupled from the request value.
         target:
-          type: Utilization
-          averageUtilization: 60
+          type: AverageValue
+          averageValue: 500Mi

--- a/helm-charts/blocky/values.yaml
+++ b/helm-charts/blocky/values.yaml
@@ -20,12 +20,34 @@ deployment:
     # group ("malware", HaGeZi TIF + URLhaus) alongside the existing "ads"
     # group -- concurrent import/parse of both groups spikes higher than a
     # single group did. Bumped to 768Mi for headroom.
+    #
+    # 2026-07-21/22: still OOMKilling every ~4h in production (confirmed via
+    # Prometheus: working-set memory flat at ~290Mi steady state the entire
+    # 4h between kills, no leak -- the config has no explicit refreshPeriod,
+    # so blocky's default 4h denylist refresh was the trigger). Startup-only
+    # spikes peaked 550-670Mi with no prior list resident; a refresh spikes
+    # higher still because the old list (~290Mi) stays resident and serving
+    # queries while the new one is concurrently downloaded and parsed,
+    # stacking to an estimated ~840-960Mi peak -- over the 768Mi limit.
+    # Limit raised to 1280Mi for headroom above that estimate.
+    #
+    # Deliberate exception to this repo's "memory request equal to memory
+    # limit" convention (see CLAUDE.md): request is lowered to 350Mi (just
+    # above the ~290Mi steady state) while the limit stays at 1280Mi. Only
+    # the limit needs to cover the transient refresh spike -- steady-state
+    # usage never approaches it -- so requests==limits here was reserving
+    # ~930Mi of phantom, permanently-unused node capacity per replica
+    # against a spike that only ever happens for a few seconds every ~4h.
+    # See the paired HPA memory metric change (Utilization -> AverageValue)
+    # in templates/hpa.yaml: it must be decoupled from this request, or a
+    # lower request alone would push HPA's 60%-of-request memory target
+    # permanently over threshold at ordinary steady-state usage.
     requests:
       cpu: 100m
-      memory: 768Mi
+      memory: 350Mi
       ephemeral-storage: 100Mi
     limits:
-      memory: 768Mi
+      memory: 1280Mi
       ephemeral-storage: 100Mi
 
 hpa:


### PR DESCRIPTION
## Summary

- blocky has been OOMKilling every ~4h in production (confirmed via
  Prometheus: working-set memory flat at ~290Mi steady state for the
  entire 4h between kills -- no leak). The config has no explicit
  `refreshPeriod`, so blocky's default 4h denylist refresh was the
  trigger: the old list (~290Mi) stays resident and serving queries
  while the new one is concurrently downloaded and parsed, stacking to
  an estimated ~840-960Mi peak against the previous 768Mi limit
  (which was only ever sized for the one-time startup spike, ~550-670Mi
  with no prior list resident).
- Raise the memory limit to 1280Mi for headroom above that estimate.
- Deliberate, documented exception to this repo's request-equal-to-limit
  convention (see CLAUDE.md): lower the request to 350Mi, since only the
  limit needs to cover the transient refresh spike -- requests==limits
  here was reserving ~930Mi of phantom, permanently-unused node capacity
  per replica.
- Pair this with switching the HPA memory metric from `Utilization`
  (% of request) to a fixed `AverageValue` (500Mi) in `templates/hpa.yaml`,
  so the lower request doesn't push ordinary steady-state usage
  permanently over a request-relative scaling threshold (which would
  otherwise pin replicas at max continuously).

## Test plan

- [x] `make test` passes locally
- [ ] After merge: confirm blocky survives at least one full refresh
      cycle (~4h) without an OOM, and that HPA reports a sane memory
      utilization line (not permanently maxed)