### PR TITLE
chore(monitoring): right-size prometheus-server CPU and memory

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -54,12 +54,17 @@ prometheus:
       secret.reloader.stakater.com/reload: blackbox-scrape-config
     resources:
       # KRR 2026-07-05: live peak ~3.16Gi working set; prior 3Gi bump (#2309) was still ~40Mi short.
+      # KRR 2026-07-22: CPU CRITICAL, 14d peak only ~155m against the 800m
+      # request (retained series count grew, not compute cost -- reduced to
+      # 200m for headroom). Memory WARNING, 14d peak ~3675Mi against the
+      # 3264Mi request/limit -- continued organic growth from retained
+      # metrics volume; bumped to 3840Mi for headroom above that peak.
       requests:
-        cpu: 800m
-        memory: 3264Mi
+        cpu: 200m
+        memory: 3840Mi
         ephemeral-storage: 256Mi
       limits:
-        memory: 3264Mi
+        memory: 3840Mi
         ephemeral-storage: 256Mi
     persistentVolume:
       size: 100Gi


### PR DESCRIPTION
## Summary

KRR pass (2026-07-22) flagged `monitoring-prometheus-server`:

- CPU CRITICAL: 14d peak only ~155m against the 800m request (retained
  series count grew, not compute cost). Reduced to 200m for headroom.
- Memory WARNING: 14d peak ~3675Mi against the 3264Mi request/limit --
  continued organic growth from retained metrics volume. Bumped to
  3840Mi for headroom above that peak.

Other non-GOOD KRR findings this pass were skipped: guarded workloads
(blocky, changedetection, jellyfin, argocd, grafanas) per the
right-sizing skill's guardrail list; several WARNINGs (descheduler,
istio-waypoints, keda\*, kubernetes-mcp-server) whose sub-metrics were
already GOOD (flagged only for an unnecessary CPU limit, already a
documented, deliberate choice elsewhere); `changedetection-browser`
CPU (repeat of an already-attempted-and-reverted recommendation due to
real scheduling failures, per existing inline comment); and several
Longhorn system-managed/dynamic components (`engine-image-*`,
recurring `backup`/`trim` jobs, `longhorn-csi-plugin`) that are either
not directly configurable via this chart or already have an extensive,
deliberate, already-confirmed sizing history.

## Test plan

- [x] `make test` passes locally
- [ ] After merge: confirm Argo CD syncs monitoring to the new revision
      and the prometheus-server pod stays Ready with no OOM/CPU throttling