### PR TITLE
fix(umami): require PDB availability for sole replica

### DIFF
--- a/helm-charts/umami/templates/pdb.yaml
+++ b/helm-charts/umami/templates/pdb.yaml
@@ -4,7 +4,13 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  minAvailable: 0
+  # 2026-07-24: minAvailable was 0, giving the descheduler free rein to evict
+  # umami's sole replica for HighNodeUtilization at will -- confirmed via
+  # events (evicted twice within an hour on nuc-00), each time costing a real
+  # ~30s gap while the pod restarts and passes DB/migration checks. umami
+  # only ever runs 1 replica, so match jung2bot's single-replica pattern
+  # (helm-charts/jung2bot/templates/pdb.yaml) and require it stay available.
+  minAvailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.name }}


### PR DESCRIPTION
## Summary

- `helm-charts/umami/templates/pdb.yaml` set `minAvailable: 0`, which gives
  the descheduler (and any other voluntary eviction) free rein to evict
  umami's sole replica at any time.
- Cluster events confirmed this happened twice within an hour on nuc-00
  (`HighNodeUtilization`), each time costing a real ~30s gap in availability
  while the replacement pod restarts and runs its DB/migration checks
  before passing readiness.
- Sets `minAvailable: 1` to match the existing single-replica pattern
  already used by `helm-charts/jung2bot/templates/pdb.yaml`.

## Test plan

- [x] `helm template umami helm-charts/umami` renders the PDB correctly
- [x] `make check-yaml lint-editorconfig` pass
- [x] `make validate-helm-charts` fails only on a pre-existing, unrelated
      `argocd` chart dependency-cache issue (confirmed present on master
      without this change)
- [ ] CI green