### PR TITLE
fix(home-assistant): add PDB to stop descheduler eviction loop

### DIFF
--- a/helm-charts/home-assistant/templates/pdb.yaml
+++ b/helm-charts/home-assistant/templates/pdb.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-24: no PDB existed at all, so the descheduler had free rein to
+  # evict the sole home-assistant replica for HighNodeUtilization. Confirmed
+  # via events: evicted four times in 25 minutes on nuc-00 (12:20, 12:25,
+  # 12:30, 12:45 UTC), each restart's startup probe still failing when the
+  # next eviction hit -- a real ~25min outage. Same fix and pattern as
+  # helm-charts/umami/templates/pdb.yaml and the single-replica case in
+  # helm-charts/jung2bot/templates/pdb.yaml.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}


### PR DESCRIPTION
## Summary

- `helm-charts/home-assistant/` had no PodDisruptionBudget at all, so the
  descheduler had free rein to evict the sole home-assistant replica
  whenever nuc-00 crossed the `HighNodeUtilization` threshold.
- Cluster events confirmed this happened four times in 25 minutes
  (12:20, 12:25, 12:30, 12:45 UTC): each restart's startup probe was
  still failing (app not yet listening on 8123) when the next eviction
  hit, so home-assistant was effectively unreachable for the whole
  window -- matches the reported "home assistant alert" timing.
- Adds `helm-charts/home-assistant/templates/pdb.yaml` with
  `minAvailable: 1`, matching the existing single-replica PDB pattern
  already used by `jung2bot` and `umami` (the latter fixed for the same
  root cause earlier today in #2917).

## Test plan

- [x] `helm template home-assistant helm-charts/home-assistant` renders
      the new PDB correctly
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green