### PR TITLE
fix(changedetection,openclaw,teslamate,unifi-mcp): add PDB for sole replica

### DIFF
--- a/helm-charts/changedetection/templates/pdb.yaml
+++ b/helm-charts/changedetection/templates/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-24: no PDB existed, so the descheduler had free rein to evict
+  # the sole replica for HighNodeUtilization -- found while auditing all
+  # single-replica app charts after the same gap caused real outages for
+  # umami (#2917) and home-assistant (#2918) on the same day. Matches the
+  # existing single-replica PDB pattern already used by those charts.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/openclaw/templates/pdb.yaml
+++ b/helm-charts/openclaw/templates/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-24: no PDB existed, so the descheduler had free rein to evict
+  # the sole replica for HighNodeUtilization -- found while auditing all
+  # single-replica app charts after the same gap caused real outages for
+  # umami (#2917) and home-assistant (#2918) on the same day. Matches the
+  # existing single-replica PDB pattern already used by those charts.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/teslamate/templates/pdb.yaml
+++ b/helm-charts/teslamate/templates/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-24: no PDB existed, so the descheduler had free rein to evict
+  # the sole replica for HighNodeUtilization -- found while auditing all
+  # single-replica app charts after the same gap caused real outages for
+  # umami (#2917) and home-assistant (#2918) on the same day. Matches the
+  # existing single-replica PDB pattern already used by those charts.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-charts/unifi-mcp/templates/pdb.yaml
+++ b/helm-charts/unifi-mcp/templates/pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-24: no PDB existed, so the descheduler had free rein to evict
+  # the sole replica for HighNodeUtilization -- found while auditing all
+  # single-replica app charts after the same gap caused real outages for
+  # umami (#2917) and home-assistant (#2918) on the same day. Matches the
+  # existing single-replica PDB pattern already used by those charts.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}


### PR DESCRIPTION
## Summary

- None of these four charts had a PodDisruptionBudget, so the descheduler
  had free rein to evict each single replica for `HighNodeUtilization` at
  any time -- the same root cause that caused real outages for umami
  (#2917) and home-assistant (#2918) earlier today.
- Found via a repo-wide audit of every chart with a Deployment, checking
  for missing or ineffective PDB coverage.
- Adds `minAvailable: 1` to each, matching the existing pattern already
  used by `jung2bot`, `umami`, and `home-assistant`.

## Not included

Three other single-replica charts have the same gap but are vendored/
generated operator manifests (helmify-style, hardcoded labels, no
`.Values.name` convention) with a different structure and higher blast
radius:

- `heartbeats` (operator controller manager)
- `k3s-apiserver-loadbalancer` (operator controller manager)
- `cloudnative-pg-plugin-barman-cloud` (serves live CNPG backup traffic
  cluster-wide -- an eviction mid-backup is a different risk profile)

Left for a follow-up decision rather than patched in this PR.

## Test plan

- [x] `helm template` renders the new PDB correctly for all four charts
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green