### PR TITLE
fix(monitoring): enable PDB for prometheus-server

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -52,6 +52,17 @@ prometheus:
   server:
     deploymentAnnotations:
       secret.reloader.stakater.com/reload: blackbox-scrape-config
+    # 2026-07-25: no PDB existed, so the descheduler had free rein to evict
+    # the sole prometheus-server replica for HighNodeUtilization. Confirmed
+    # via events: evicted roughly every 5 minutes for over an hour on
+    # raspberrypi-03, never staying up long enough to finish loading its
+    # TSDB, causing live 503s. Same root cause and fix as umami (#2917),
+    # home-assistant (#2918), and the changedetection/openclaw/teslamate/
+    # unifi-mcp bundle (#2919) -- this subchart exposes the setting
+    # natively rather than needing a hand-written template.
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
     resources:
       # KRR 2026-07-05: live peak ~3.16Gi working set; prior 3Gi bump (#2309) was still ~40Mi short.
       # KRR 2026-07-22: CPU CRITICAL, 14d peak only ~155m against the 800m


### PR DESCRIPTION
## Summary

- No PodDisruptionBudget existed for `prometheus-server`, so the
  descheduler had free rein to evict its sole replica for
  `HighNodeUtilization` at any time.
- Cluster events confirmed this happening roughly every 5 minutes for
  over an hour on raspberrypi-03 -- the pod never stayed up long enough
  to finish loading its TSDB, causing live 503s on the Prometheus API
  (this is the same instance that showed up as a transient-looking
  `monitoring` Application blip in two earlier self-healing rounds
  today, which in hindsight was this same ongoing eviction storm, not
  two unrelated one-offs).
- Same root cause as umami (#2917), home-assistant (#2918), and the
  changedetection/openclaw/teslamate/unifi-mcp bundle (#2919) fixed
  earlier today. Unlike those, `prometheus-server` is a bundled
  subchart of `helm-charts/monitoring` (prometheus-community/prometheus
  29.17.0), and that chart exposes `server.podDisruptionBudget` as a
  native values option -- no hand-written PDB template needed.

## Test plan

- [x] `helm dependency build` + `helm template monitoring` renders a
      `PodDisruptionBudget` for `monitoring-prometheus-server` with
      `minAvailable: 1`
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green