### PR TITLE
fix(changedetection,teslamate): add PDB for browser and grafana

### DIFF
--- a/helm-charts/changedetection/templates/browser-pdb.yaml
+++ b/helm-charts/changedetection/templates/browser-pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.browser.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-25: found during a repo-wide PDB audit after the missing-PDB
+  # eviction-storm pattern caused real outages for umami, home-assistant,
+  # and prometheus-server the same day (see documentation/gotcha.md).
+  # The main changedetection Deployment already has a PDB
+  # (templates/pdb.yaml); this sidecar browser Deployment did not.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.browser.name }}

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -58,6 +58,11 @@ grafana:
   testFramework:
     # Helm test hooks are not run under Argo CD and leave orphaned resources that degrade app health.
     enabled: false
+  # 2026-07-25: no PDB existed, found during a repo-wide audit after the
+  # same gap caused real outages for umami, home-assistant, and
+  # prometheus-server the same day (see documentation/gotcha.md).
+  podDisruptionBudget:
+    minAvailable: 1
   resources:
     # Keep memory at 512Mi: TeslaMate dashboard usage pushed Grafana against the 128Mi limit and caused OOMKills.
     requests:


### PR DESCRIPTION
## Summary

Found during a repo-wide PDB audit prompted by todays prometheus-server
outage (#2922). Same missing-PDB eviction-storm root cause as umami,
home-assistant, and prometheus-server (see documentation/gotcha.md):

- `changedetection-browser` (the Playwright sidecar Deployment) had no
  PDB even though the main `changedetection` Deployment already did --
  adds a matching hand-written template.
- `teslamate-grafana` (bundled grafana subchart) had no PDB -- enables
  the charts native `podDisruptionBudget` values option, same pattern
  used for prometheus-server.

## Test plan

- [x] `helm template` renders both PDBs correctly (grafana one verified
      resolves to `policy/v1`, not `v1beta1`, via `--api-versions
      policy/v1/PodDisruptionBudget` to simulate the live cluster)
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green