### PR TITLE
feat(kyverno-policy): add audit-only require-pod-disruption-budget policy

### DIFF
--- a/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.requirePodDisruptionBudgetPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-pod-disruption-budget
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-pdb-for-deployment
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+{{- with .Values.requirePodDisruptionBudgetPolicy.excludedNamespaces }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+{{- range . }}
+                - {{ . }}
+{{- end }}
+{{- end }}
+      context:
+        - name: matchingPdbCount
+          apiCall:
+            urlPath: "/apis/policy/v1/namespaces/{{ "{{" }} request.namespace {{ "}}" }}/poddisruptionbudgets"
+            jmesPath: >-
+              items[?spec.selector.matchLabels."app.kubernetes.io/name" ==
+              '{{ "{{" }} request.object.spec.template.metadata.labels."app.kubernetes.io/name" {{ "}}" }}']
+              | length(@)
+      validate:
+        allowExistingViolations: true
+        failureAction: Audit
+        message: >-
+          No PodDisruptionBudget found selecting this workload by its
+          app.kubernetes.io/name label. A single-replica workload with no
+          PDB has zero protection against descheduler eviction and can be
+          killed on effectively every scan cycle -- see
+          documentation/gotcha.md ("Descheduler Eviction Storms Look Like
+          Self-Resolving Blips, One Check At A Time") for the incident
+          this policy is meant to catch earlier next time.
+        deny:
+          conditions:
+            any:
+              - key: "{{ "{{" }} matchingPdbCount {{ "}}" }}"
+                operator: Equals
+                value: 0
+  validationFailureAction: Audit
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-rbac.yaml
+++ b/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-rbac.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.requirePodDisruptionBudgetPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-read-poddisruptionbudgets
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-read-poddisruptionbudgets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-read-poddisruptionbudgets
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: kyverno-background-controller
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -90,3 +90,22 @@ requireContainerHardeningPolicy:
     - istio-system
     - metallb-system
     - kube-system
+
+# 2026-07-25: audit-only policy added after the missing-PDB
+# eviction-storm pattern caused real outages for umami, home-assistant,
+# and prometheus-server on the same day (see documentation/gotcha.md).
+# Excluded namespaces are the same system-managed/dynamic components
+# already established as out of scope for hand-written PDB fixes
+# (helm-charts/*/templates -- Longhorn CSI/UI/driver-deployer are
+# created directly by longhorn-manager, not by any chart here).
+# Audit mode first: this reports violations without blocking anything,
+# so the initial run against ~30+ pre-existing gaps does not need every
+# exclusion tuned up front.
+requirePodDisruptionBudgetPolicy:
+  enabled: true
+  excludedNamespaces:
+    - longhorn-system
+    - kube-system
+    - kube-node-lease
+    - kube-public
+    - kyverno


### PR DESCRIPTION
## Summary

After the missing-PDB eviction-storm pattern caused real outages for
umami, home-assistant, and prometheus-server on the same day (see
`documentation/gotcha.md`), this adds a Kyverno policy that flags any
Deployment/StatefulSet with no PodDisruptionBudget selecting it by
`app.kubernetes.io/name`.

- **Audit mode only** (`validationFailureAction: Audit`,
  `allowExistingViolations: true`) -- reports without blocking, per
  your request to start in audit mode.
- Excludes the same system-managed/dynamic namespaces already
  established as out of scope for hand-written PDB fixes today
  (Longhorn CSI/UI/driver-deployer are created directly by
  longhorn-manager, not by any chart in this repo) plus core system
  namespaces (`kube-system`, `kube-node-lease`, `kube-public`,
  `kyverno`).
- Adds RBAC (`get`/`list`/`watch` on `policy/poddisruptionbudgets`) for
  the `context.apiCall` this rule depends on, bound to both the
  admission and background controller service accounts.

A live audit run against this cluster today would flag roughly 30
pre-existing gaps across app charts, monitoring subcharts, and
third-party operator charts -- that follow-up work is tracked
separately and not blocked on this PR merging.

## Why not trivial / not auto-merged

This is a new cluster-wide ClusterPolicy plus new RBAC grants, which
this repo's merge policy calls out as non-trivial even though the
enforcement mode is audit-only. Left for your review rather than
auto-merged.

## Test plan

- [x] `helm lint` / `helm template` render the policy and RBAC
      correctly, JMESPath/Kyverno `{{ }}` variables preserved
      (not consumed by Helm templating)
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green
- [ ] Manual review: confirm audit findings look right after sync,
      before ever considering `Enforce`