### PR TITLE
fix(monitoring): add PDB for all 9 unprotected subchart components

### DIFF
--- a/helm-charts/monitoring/templates/k8s-ephemeral-storage-metrics-pdb.yaml
+++ b/helm-charts/monitoring/templates/k8s-ephemeral-storage-metrics-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-k8s-ephemeral-storage-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  # 2026-07-25: the vendored k8s-ephemeral-storage-metrics chart has no
+  # native podDisruptionBudget support -- found during a repo-wide
+  # audit after the same missing-PDB gap caused real outages for umami,
+  # home-assistant, and prometheus-server the same day (see
+  # documentation/gotcha.md). Added here in the parent chart since the
+  # subchart itself cannot be patched without being overwritten on the
+  # next `helm dependency build`.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+      app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-charts/monitoring/templates/loki-gateway-pdb.yaml
+++ b/helm-charts/monitoring/templates/loki-gateway-pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-loki-gateway
+  namespace: {{ .Release.Namespace }}
+spec:
+  # See templates/loki-pdb.yaml for why this lives in the parent chart.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: gateway

--- a/helm-charts/monitoring/templates/loki-pdb.yaml
+++ b/helm-charts/monitoring/templates/loki-pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
+spec:
+  # 2026-07-25: the vendored loki chart (grafana/loki) has no native
+  # podDisruptionBudget support for any of its components -- found
+  # during a repo-wide audit after the same missing-PDB gap caused real
+  # outages for umami, home-assistant, and prometheus-server the same
+  # day (see documentation/gotcha.md). Added here in the parent chart
+  # since the subchart itself cannot be patched without being
+  # overwritten on the next `helm dependency build`.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: single-binary

--- a/helm-charts/monitoring/templates/loki-results-cache-pdb.yaml
+++ b/helm-charts/monitoring/templates/loki-results-cache-pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-loki-results-cache
+  namespace: {{ .Release.Namespace }}
+spec:
+  # See templates/loki-pdb.yaml for why this lives in the parent chart.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: memcached-results-cache

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -100,6 +100,11 @@ prometheus:
         readOnly: true
   alertmanager:
     enabled: true
+    # 2026-07-25: no PDB existed, found during a repo-wide audit after
+    # the same gap caused real outages for umami, home-assistant, and
+    # prometheus-server the same day (see documentation/gotcha.md).
+    podDisruptionBudget:
+      minAvailable: 1
     resources: *smallResources
     persistence:
       enabled: true
@@ -122,10 +127,20 @@ prometheus:
         mountPath: /etc/alertmanager/templates
         readOnly: true
   kube-state-metrics:
+    # 2026-07-25: no PDB existed, found during a repo-wide audit after
+    # the same gap caused real outages for umami, home-assistant, and
+    # prometheus-server the same day (see documentation/gotcha.md).
+    podDisruptionBudget:
+      minAvailable: 1
     resources: *smallResources
   prometheus-node-exporter:
     resources: *smallResources
   prometheus-pushgateway:
+    # 2026-07-25: no PDB existed, found during a repo-wide audit after
+    # the same gap caused real outages for umami, home-assistant, and
+    # prometheus-server the same day (see documentation/gotcha.md).
+    podDisruptionBudget:
+      minAvailable: 1
     resources: *smallResources
   serverFiles:
     recording_rules.yml:
@@ -361,6 +376,11 @@ prometheus:
 
 prometheus-blackbox-exporter:
   fullnameOverride: blackbox
+  # 2026-07-25: no PDB existed, found during a repo-wide audit after
+  # the same gap caused real outages for umami, home-assistant, and
+  # prometheus-server the same day (see documentation/gotcha.md).
+  podDisruptionBudget:
+    minAvailable: 1
   resources: *smallResources
 
 k8s-ephemeral-storage-metrics:
@@ -387,6 +407,11 @@ k8s-ephemeral-storage-metrics:
       ephemeral-storage: 64Mi
 
 grafana:
+  # 2026-07-25: no PDB existed, found during a repo-wide audit after
+  # the same gap caused real outages for umami, home-assistant, and
+  # prometheus-server the same day (see documentation/gotcha.md).
+  podDisruptionBudget:
+    minAvailable: 1
   resources:
     # Keep memory at 512Mi: dashboard usage pushed Grafana against the 128Mi limit and caused probe failures.
     # ephemeral-storage 2026-07-06: 14d peak ~50Mi against a 64Mi limit (80.6% via ephemeral_storage_container_limit_percentage) — bump to 128Mi for headroom.


### PR DESCRIPTION
## Summary

Found during the repo-wide PDB audit prompted by the prometheus-server
outage (#2922). Same missing-PDB eviction-storm root cause, applied
across every remaining unprotected component in the `monitoring` chart:

**Native `podDisruptionBudget` values option enabled** (chart already
supports it):
- `grafana`, `prometheus-blackbox-exporter`, `prometheus.alertmanager`,
  `prometheus.kube-state-metrics`, `prometheus.prometheus-pushgateway`

**Hand-written PDB templates added to the parent chart** (no native
support in the vendored subchart, so it cannot be patched without
being overwritten on the next `helm dependency build`):
- `loki` (single-binary), `loki-gateway`, `loki-results-cache`
  (memcached), `k8s-ephemeral-storage-metrics`

`prometheus-node-exporter` is a DaemonSet (one pod per node) and does
not need a PDB in the same sense; left untouched.

## Test plan

- [x] `helm template monitoring` (with `--api-versions
      policy/v1/PodDisruptionBudget` to simulate the live cluster)
      renders all 9 PDBs with `minAvailable: 1` and selectors matching
      live pod labels
- [x] `make check-yaml lint-editorconfig` pass
- [ ] CI green