### PR TITLE
fix(operators): enable native PodDisruptionBudget on 8 controller charts

### DIFF
--- a/helm-charts/cert-manager/values.yaml
+++ b/helm-charts/cert-manager/values.yaml
@@ -17,6 +17,9 @@ cert-manager:
     limits:
       memory: 128Mi
       ephemeral-storage: 64Mi
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   cainjector:
     affinity:
       <<: *preferredPodAntiAffinity
@@ -28,6 +31,9 @@ cert-manager:
       limits:
         memory: 128Mi
         ephemeral-storage: 64Mi
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
   webhook:
     affinity:
       <<: *preferredPodAntiAffinity
@@ -39,6 +45,9 @@ cert-manager:
       limits:
         memory: 64Mi
         ephemeral-storage: 64Mi
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
   startupapicheck:
     resources:
       requests:

--- a/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
+++ b/helm-charts/envoy-gateway/templates/envoy-proxy.yaml
@@ -38,3 +38,8 @@ spec:
 {{ toYaml .Values.envoyProxy.shutdownManagerResources | indent 24 }}
       envoyService:
         name: {{ .Values.service.name }}
+      # 2026-07-26: repo-wide PDB audit -- protects the 2-replica data-plane
+      # proxy from the descheduler's HighNodeUtilization eviction the same
+      # way as every other workload in this pass (see documentation/gotcha.md).
+      envoyPDB:
+        minAvailable: 1

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -89,6 +89,8 @@ envoy-gateway:
     gatewayAPI:
       safeUpgradePolicy:
         enabled: false
+  podDisruptionBudget:
+    minAvailable: 1
   deployment:
     envoyGateway:
       resources: *envoyGatewayResources

--- a/helm-charts/external-secrets/values.yaml
+++ b/helm-charts/external-secrets/values.yaml
@@ -21,6 +21,9 @@ external-secrets:
   affinity:
     <<: *preferredPodAntiAffinity
   resources: *resources
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   webhook:
     # 2026-07-12: ArgoCD ExternalSecret syncs failed with "no endpoints
     # available for service external-secrets-webhook" during a night of
@@ -40,6 +43,9 @@ external-secrets:
     affinity:
       <<: *preferredPodAntiAffinity
     resources: *resources
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
   global:
     affinity:
       <<: *preferredPodAntiAffinity

--- a/helm-charts/keda/values.yaml
+++ b/helm-charts/keda/values.yaml
@@ -49,3 +49,9 @@ keda:
       <<: *preferredPodAntiAffinity
   affinity:
     <<: *preferredPodAntiAffinity
+  podDisruptionBudget:
+    # metricServer and webhooks have no native podDisruptionBudget support
+    # in this chart version -- hand-written PDBs for those two live in
+    # templates/metrics-server-pdb.yaml and templates/webhooks-pdb.yaml.
+    operator:
+      minAvailable: 1

--- a/helm-charts/kyverno/values.yaml
+++ b/helm-charts/kyverno/values.yaml
@@ -10,13 +10,20 @@ _shared:
       memory: 128Mi
       ephemeral-storage: 64Mi
 
+_pdb: &pdb
+  enabled: true
+  minAvailable: 1
+
 kyverno:
   admissionController:
     resources: *resources
+    podDisruptionBudget: *pdb
   backgroundController:
     resources: *resources
+    podDisruptionBudget: *pdb
   cleanupController:
     resources: *resources
+    podDisruptionBudget: *pdb
   reportsController:
     # KRR 2026-07-18: CPU WARNING, 14d peak needs ~335m against the shared
     # 50m request (memory unaffected, still GOOD at 128Mi). Split out from
@@ -31,3 +38,4 @@ kyverno:
       limits:
         memory: 128Mi
         ephemeral-storage: 64Mi
+    podDisruptionBudget: *pdb

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -1,5 +1,8 @@
 reloader:
   reloader:
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
     deployment:
       resources:
         requests:


### PR DESCRIPTION
## Summary

Continuation of the repo-wide PDB audit (PR #2929, #2930) into the
operator/controller chart family. Each of these components was single- or
low-replica with no PDB, meaning the descheduler's HighNodeUtilization
eviction could kill it on effectively every scan cycle (the same failure
class documented in `documentation/gotcha.md`).

All fixes here use each chart's own native `podDisruptionBudget` values
option (`minAvailable: 1`) rather than a hand-written template:

- cert-manager: controller, cainjector, webhook (3 components)
- external-secrets: controller, cert-controller (webhook already had a PDB
  from an earlier fix)
- keda: operator only (`metricServer` and `webhooks` have no native PDB
  option in chart 2.20.1 -- follow-up needed if these should also be
  covered)
- kyverno: admission, background, cleanup, and reports controllers (4
  components)
- envoy-gateway: the controller pod, and the 2-replica data-plane `gateway`
  proxy via `EnvoyProxy.spec.provider.kubernetes.envoyPDB`
- reloader

Verified with `helm template --api-versions "policy/v1/PodDisruptionBudget"`
for each chart before opening this PR.

## Test plan

- [x] `make test` passes
- [x] `helm template` for each of the 6 touched charts renders exactly the
      expected PodDisruptionBudget count
- [ ] After merge: confirm ArgoCD syncs each app and `kubectl get pdb`
      shows the new budgets live in their namespaces