### PR TITLE
fix(operators): add hand-written PDBs for charts with no native option

### DIFF
--- a/helm-charts/istiod/templates/poddisruptionbudget.yaml
+++ b/helm-charts/istiod/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: istiod
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # istio-release/istiod chart only creates its own PDB when replicas > 1
+  # (a workaround for https://github.com/kubernetes/kubernetes/issues/93476
+  # -- a single-replica PDB with 0 allowed disruptions can deadlock a node
+  # drain). That does not apply here: the LUKS reboot playbook
+  # (ansible/playbooks/maintenance/000-packages.yaml) already drains with
+  # `--disable-eviction`, bypassing the Eviction API and therefore this PDB
+  # entirely, so a hand-written PDB is safe for our single-replica istiod.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      istio: pilot

--- a/helm-charts/k8s-cleaner/templates/poddisruptionbudget.yaml
+++ b/helm-charts/k8s-cleaner/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: k8s-cleaner
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # gianlucam76/k8s-cleaner chart has no native podDisruptionBudget option.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-cleaner
+      app.kubernetes.io/instance: k8s-cleaner

--- a/helm-charts/keda/templates/metrics-server-pdb.yaml
+++ b/helm-charts/keda/templates/metrics-server-pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-operator-metrics-apiserver
+  namespace: keda
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # kedacore/keda chart's native podDisruptionBudget option only covers the
+  # operator component in this chart version -- metricServer has no native
+  # PDB option, so this is hand-written in the parent chart.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: keda-operator-metrics-apiserver

--- a/helm-charts/keda/templates/webhooks-pdb.yaml
+++ b/helm-charts/keda/templates/webhooks-pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-admission-webhooks
+  namespace: keda
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # kedacore/keda chart's native podDisruptionBudget option only covers the
+  # operator component in this chart version -- webhooks has no native PDB
+  # option, so this is hand-written in the parent chart.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: keda-admission-webhooks

--- a/helm-charts/kiali/templates/poddisruptionbudget.yaml
+++ b/helm-charts/kiali/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # kiali-server chart has no native podDisruptionBudget option.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ .Values.name }}

--- a/helm-charts/onepassword-connect/templates/poddisruptionbudget.yaml
+++ b/helm-charts/onepassword-connect/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- $namespace := .Release.Namespace | default "onepassword" -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: onepassword-connect
+  namespace: {{ $namespace }}
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The vendored
+  # 1password/connect chart has no native podDisruptionBudget option.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: onepassword-connect


### PR DESCRIPTION
## Summary

Second batch of the operator/controller PDB audit (follow-up to #2931). Each
of these single-replica components has no native `podDisruptionBudget`
option in its vendored chart, so the PDB is hand-written in the parent
chart's own `templates/`, matching the pattern already used for loki in
`helm-charts/monitoring` (#2930):

- **istiod** -- the vendored chart's own PDB template only fires when
  `replicaCount > 1`, guarding against
  [kubernetes/kubernetes#93476](https://github.com/kubernetes/kubernetes/issues/93476)
  (a single-replica PDB with 0 allowed disruptions can deadlock a node
  drain). That guard does not apply on this cluster: the LUKS reboot
  playbook already drains with `--disable-eviction`, which bypasses the
  Eviction API (and therefore any PDB) entirely for planned maintenance.
  The only thing a PDB blocks here is the descheduler's own eviction.
- **kiali, onepassword-connect, k8s-cleaner** -- no native PDB option at
  all in these charts.
- **keda metricServer / webhooks** -- the operator component already got
  native PDB support in #2931; these two components have no native option
  in chart 2.20.1.

## Test plan

- [x] `make test` passes
- [x] `helm template --api-versions "policy/v1/PodDisruptionBudget"` for
      each chart renders exactly one new PodDisruptionBudget with the
      correct selector matching the live pod labels
- [ ] After merge: confirm ArgoCD syncs each app and `kubectl get pdb`
      shows the new budgets live in their namespaces