### PR TITLE
fix(cloudnative-pg): add PDB for the single-replica operator

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/operator-poddisruptionbudget.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/operator-poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudnative-pg
+  namespace: {{ .Values.namespace }}
+spec:
+  # 2026-07-26: repo-wide PDB audit (documentation/gotcha.md). The
+  # cloudnative-pg operator (single replica) has no native
+  # podDisruptionBudget option in its upstream chart, and that chart is
+  # applied directly from https://cloudnative-pg.io/charts/ via ArgoCD
+  # (see argocd/manifest.jsonnet) rather than vendored under helm-charts/,
+  # so there is no local template to patch. This chart already targets the
+  # same cnpg-system namespace and syncs after the operator (wave 06 vs
+  # wave 03), so the PDB lives here instead of a new single-purpose chart.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+      app.kubernetes.io/instance: cloudnative-pg


### PR DESCRIPTION
## Summary

Final component of the operator/controller PDB audit (follow-up to #2931,
#2933). The cloudnative-pg operator has no native `podDisruptionBudget`
option in its upstream chart, and unlike every other chart in this audit it
is applied directly from `https://cloudnative-pg.io/charts/` via ArgoCD's
inline `source.helm` (see `argocd/manifest.jsonnet`) rather than vendored
under `helm-charts/` -- so there is no local chart to add a native option or
patch a template on.

Added the PDB to `cloudnative-pg-clusters` instead: it already targets the
same `cnpg-system` namespace and syncs after the operator (wave 06 vs wave
03), so by the time it applies, the operator's pods already exist and match
the selector.

## Test plan

- [x] `make test` passes
- [x] `helm template cloudnative-pg-clusters --api-versions
      "policy/v1/PodDisruptionBudget"` renders the PDB with a selector
      matching the live operator pod labels
- [ ] After merge: confirm ArgoCD syncs and `kubectl get pdb -n cnpg-system`
      shows it live