### PR TITLE
fix(envoy-gateway): right-size the shutdown-manager sidecar

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1679,3 +1679,41 @@ Verified live for all seven workloads listed above: `disruptionsAllowed:
 observed after rollout.
 
 ---
+
+## `krr` can hang silently for hours with near-zero CPU
+
+**Problem:** a `krr simple` run for the right-sizing pass sat for over
+two hours producing no output and no error, blocking two consecutive
+hourly self-healing fires (each one saw a prior right-sizing run "still
+in progress" and skipped its own investigation).
+
+**Why it happens:** unknown -- Prometheus itself was healthy throughout
+(`/-/healthy` responded in under 50ms, the prometheus-server pod showed
+normal CPU/memory and 0 restarts), and the stuck `krr` process held
+several established TCP connections with almost no CPU time consumed
+(4 seconds of CPU across 2 hours), consistent with a client-side stall
+rather than a slow query or an overloaded cluster. A second run against
+the same Prometheus, same cluster state, completed normally in about a
+minute.
+
+### Symptoms: KRR Silent Hang
+
+- `krr simple -p <prometheus-url> -f json -q > out.json` produces an
+  empty `out.json` well past the few-minutes duration of a normal pass.
+- `ps aux | grep krr` shows the process alive with very low accumulated
+  CPU time (not spinning, not obviously crashed).
+- Downstream: the self-healing loop's own "is a prior right-sizing run
+  still running" check (`.claude/skills/self-healing-loop`) correctly
+  defers to it, so the hang silently consumes multiple scheduled fires
+  before anyone notices no KRR output ever landed.
+
+### Resolution: Kill and Retry Once
+
+- If a `krr` process has been running much longer than a normal pass
+  (check the journal for a typical duration) with an empty output file
+  and low CPU time, kill it (`kill <pid>` -- a local CLI subprocess, not
+  a cluster mutation) and retry once.
+- If the retry also hangs, treat it as a real issue and escalate rather
+  than retrying indefinitely.
+
+---

--- a/helm-charts/envoy-gateway/values.yaml
+++ b/helm-charts/envoy-gateway/values.yaml
@@ -15,20 +15,18 @@ _shared:
     limits:
       memory: 256Mi
       ephemeral-storage: 128Mi
-  # Kyverno require-workload-resources (background scan) flagged the
-  # shutdown-manager sidecar in the gateway Deployment as missing memory
-  # and ephemeral-storage requests/limits (only a CPU request is applied
-  # by envoy-gateway's own hardcoded default). No KRR data yet for this
-  # container, so reuse its existing 10m CPU request and pair it with a
-  # memory/ephemeral-storage size similar to envoyGatewayResources above,
-  # since both are lightweight Go control-plane sidecars.
+  # KRR 2026-07-26: the original 10m CPU request (an arbitrary guess made
+  # when this container had no KRR data yet, see git history) was WARNING
+  # against a 14d peak of ~296m -- almost 30x under-provisioned. Memory was
+  # already GOOD at 32Mi/32Mi, but the same pass reported a ~100Mi peak, so
+  # bumped both together now that real data exists.
   shutdownManagerResources: &shutdownManagerResources
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 300m
+      memory: 100Mi
       ephemeral-storage: 32Mi
     limits:
-      memory: 32Mi
+      memory: 100Mi
       ephemeral-storage: 32Mi
 
 name: gateway


### PR DESCRIPTION
## Summary

Scheduled right-sizing pass (2026-07-26). One actionable finding out of 21
WARNING/CRITICAL KRR results -- the rest were guarded workloads (blocky,
changedetection, jellyfin, the argocd family), system-managed Longhorn
components out of scope for this repo, prometheus-server (recurring, held
again -- its current node has no memory headroom for the recommended
bump), or trivial few-MB deltas / inherited CPU limits from vendored chart
defaults not worth touching.

- **envoy-gateway shutdown-manager:** CPU request was WARNING at 10m
  against a 14-day peak of ~296m (~30x under-provisioned). This was an
  arbitrary placeholder set before any KRR data existed for this
  container (only added to satisfy the Kyverno
  `require-workload-resources` policy). Bumped CPU and memory to match
  the now-available real data.

Also includes an unrelated docs commit: captured a `krr` gotcha
encountered during this same pass (a `krr simple` run hung silently for
over two hours with near-zero CPU while Prometheus itself stayed
healthy -- killing and retrying resolved it in about a minute).

## Test plan

- [x] `make test` passes
- [x] `helm template` confirms the new resources render on the
      shutdown-manager container
- [ ] After merge: confirm ArgoCD syncs and the new gateway pods roll out
      without scheduling issues