### PR TITLE
feat(monitoring): add a Kyverno policy metrics dashboard

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -139,6 +139,7 @@ local _ignoreDifferences = {
 local _grafanaDashboards = [
   'dashboards/blocky.yaml',
   'dashboards/container-log-dashboard.yaml',
+  'dashboards/kyverno-policy-metrics.yaml',
   'dashboards/onzack-cluster-monitoring.yaml',
   'dashboards/prometheus-stats.yaml',
 ];

--- a/helm-charts/kyverno/values.yaml
+++ b/helm-charts/kyverno/values.yaml
@@ -14,16 +14,28 @@ _pdb: &pdb
   enabled: true
   minAvailable: 1
 
+# Scrape annotations for each controller's metrics Service (port 8000).
+# The Prometheus AuthorizationPolicy for this port already existed
+# (templates/authorization-policy.yaml) but nothing set these annotations,
+# so the kubernetes-service-endpoints job never picked the services up.
+_metricsScrape: &metricsScrape
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
+
 kyverno:
   admissionController:
     resources: *resources
     podDisruptionBudget: *pdb
+    metricsService: *metricsScrape
   backgroundController:
     resources: *resources
     podDisruptionBudget: *pdb
+    metricsService: *metricsScrape
   cleanupController:
     resources: *resources
     podDisruptionBudget: *pdb
+    metricsService: *metricsScrape
   reportsController:
     # KRR 2026-07-18: CPU WARNING, 14d peak needs ~335m against the shared
     # 50m request (memory unaffected, still GOOD at 128Mi). Split out from
@@ -39,3 +51,4 @@ kyverno:
         memory: 128Mi
         ephemeral-storage: 64Mi
     podDisruptionBudget: *pdb
+    metricsService: *metricsScrape

--- a/helm-charts/monitoring/AGENTS.md
+++ b/helm-charts/monitoring/AGENTS.md
@@ -8,12 +8,13 @@ diagnostics, then backport.
 
 Path: `dashboards/*.yaml` (Grafana helm `grafana.dashboards.default` embeds).
 
-| Key | Grafana title | Notes |
-| --- | --- | --- |
-| `blocky` | Blocky | Custom SRE layout; v0.28 metric names |
-| `onzack-cluster-monitoring` | Standard Cluster Monitoring | ONZACK 17404 + recording rules + otaru sections |
-| `prometheus-stats` | Prometheus Stats | Prometheus process stats |
-| `container-log-dashboard` | (gnet 16966) | Loki logs; `gnetId`+`revision` download |
+| Key                         | Grafana title               | Notes                                                                                      |
+|-----------------------------|-----------------------------|--------------------------------------------------------------------------------------------|
+| `blocky`                    | Blocky                      | Custom SRE layout; v0.28 metric names                                                      |
+| `kyverno-policy-metrics`    | Kyverno Policy Metrics      | Custom layout; requires `helm-charts/kyverno`'s `metricsService.annotations` scrape config |
+| `onzack-cluster-monitoring` | Standard Cluster Monitoring | ONZACK 17404 + recording rules + otaru sections                                            |
+| `prometheus-stats`          | Prometheus Stats            | Prometheus process stats                                                                   |
+| `container-log-dashboard`   | (gnet 16966)                | Loki logs; `gnetId`+`revision` download                                                    |
 
 **Dashboards are vendored GitOps artifacts**, not live upstream sync (except
 `container-log-dashboard`, which pins a Grafana.com revision). Editing UI is
@@ -76,25 +77,25 @@ When re-vendoring 17404, re-apply:
    whose titles end with `(cAdvisor)` or `(KRR)`, plus variables
    `cadvisor_instance` and `namespace`. Details:
 
-   | Collapsed row title | Source (retired board) | Contents |
-   | --- | --- | --- |
-   | Workload usage by namespace (cAdvisor) | gnet 15282 / k3s-cluster-monitoring | CPU + memory by namespace |
-   | Pods resource usage (cAdvisor) | gnet 15282 | Pod CPU, memory, network I/O |
-   | Containers resource usage (cAdvisor) | gnet 15282 | Container CPU/memory, network I/O |
-   | Resource requests vs usage (KRR) | resource-requests-vs-usage | Request vs 6h usage tables (CPU/mem), cluster requested vs used, ephemeral-storage top 20 |
+| Collapsed row title                    | Source (retired board)              | Contents                                                                                  |
+|----------------------------------------|-------------------------------------|-------------------------------------------------------------------------------------------|
+| Workload usage by namespace (cAdvisor) | gnet 15282 / k3s-cluster-monitoring | CPU + memory by namespace                                                                 |
+| Pods resource usage (cAdvisor)         | gnet 15282                          | Pod CPU, memory, network I/O                                                              |
+| Containers resource usage (cAdvisor)   | gnet 15282                          | Container CPU/memory, network I/O                                                         |
+| Resource requests vs usage (KRR)       | resource-requests-vs-usage          | Request vs 6h usage tables (CPU/mem), cluster requested vs used, ephemeral-storage top 20 |
 
    Section rules when re-applying:
 
-   - Datasource UID must be `${datasource}` (not hardcoded Prometheus UID).
-   - cAdvisor workload queries filter with
+- Datasource UID must be `${datasource}` (not hardcoded Prometheus UID).
+- cAdvisor workload queries filter with
      `instance=~"$cadvisor_instance"` and `namespace=~"$namespace"`
      (variables: All = `.*`, multi-select).
-   - Prefer `$__rate_interval` for live rates (scrape is 1m). Keep the KRR
+- Prefer `$__rate_interval` for live rates (scrape is 1m). Keep the KRR
      tables’ fixed `6h` / `avg_over_time(...[6h])` windows — those are
      intentional right-sizing horizons.
-   - Skip re-adding host-level “All processes” charts from old k3s; node
+- Skip re-adding host-level “All processes” charts from old k3s; node
      views already live in ONZACK CPU/Memory/Network rows.
-   - Do **not** reintroduce standalone
+- Do **not** reintroduce standalone
      `k3s-cluster-monitoring.yaml` or `resource-requests-vs-usage.yaml`.
 
 ### Upgrading the dashboard

--- a/helm-charts/monitoring/dashboards/kyverno-policy-metrics.yaml
+++ b/helm-charts/monitoring/dashboards/kyverno-policy-metrics.yaml
@@ -1,0 +1,1311 @@
+grafana:
+  dashboards:
+    default:
+      kyverno-policy-metrics:
+        json: |
+          {
+            "annotations": {
+              "list": [
+                {
+                  "builtIn": 1,
+                  "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                  },
+                  "enable": true,
+                  "hide": true,
+                  "iconColor": "rgba(0, 211, 255, 1)",
+                  "name": "Annotations & Alerts",
+                  "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                  },
+                  "type": "dashboard"
+                }
+              ]
+            },
+            "editable": true,
+            "fiscalYearStartMonth": 0,
+            "graphTooltip": 1,
+            "links": [
+              {
+                "icon": "external link",
+                "tags": [],
+                "title": "Kyverno @ GitHub",
+                "tooltip": "open GitHub repo",
+                "type": "link",
+                "url": "https://github.com/kyverno/kyverno"
+              }
+            ],
+            "liveNow": false,
+            "panels": [
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 0
+                },
+                "id": 1,
+                "panels": [],
+                "title": "Overview",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Distinct Kyverno metrics targets currently reporting (admission, background, cleanup, reports controllers)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 1
+                        },
+                        {
+                          "color": "green",
+                          "value": 4
+                        }
+                      ]
+                    },
+                    "unit": "none"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 0,
+                  "y": 1
+                },
+                "id": 2,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(count by (job, __name__) (kyverno_info))",
+                    "legendFormat": "",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Controllers reporting",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Distinct ready Kyverno policies currently loaded in the cluster",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "none"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 6,
+                  "y": 1
+                },
+                "id": 3,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(count by (policy_name) (kyverno_policy_rule_info_total{status_ready=\"true\"}))",
+                    "legendFormat": "",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Policies loaded",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Admission requests handled across all Kyverno webhooks (rate over the last 5 minutes)",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 1
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 12,
+                  "y": 1
+                },
+                "id": 4,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(kyverno_admission_requests_total[5m])) * 60",
+                    "legendFormat": "",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Admission requests/min",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Policy rule evaluations that failed (rule_result=\"fail\") across all policies (rate over the last 5 minutes) -- the key signal for whether a policy is actively blocking something",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 0.1
+                        },
+                        {
+                          "color": "red",
+                          "value": 1
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 1
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 18,
+                  "y": 1
+                },
+                "id": 5,
+                "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "percentChangeColorMode": "standard",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showPercentChange": false,
+                  "textMode": "auto",
+                  "wideLayout": true
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(kyverno_policy_results_total{rule_result=\"fail\"}[5m])) * 60",
+                    "legendFormat": "",
+                    "range": false,
+                    "refId": "A",
+                    "instant": true
+                  }
+                ],
+                "title": "Rule failures/min",
+                "transparent": true,
+                "type": "stat"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 5
+                },
+                "id": 6,
+                "panels": [],
+                "title": "Policy Results",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Rule evaluation rate broken down by result (pass/fail/warn/error/skip), across every policy and rule",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 60,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 6
+                },
+                "id": 7,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (rule_result) (rate(kyverno_policy_results_total{policy_name=~\"$policy_name\"}[$__rate_interval])) * 60",
+                    "legendFormat": "{{rule_result}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Rule results by outcome",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Policies and rules with the most fail or error results in the last 24 hours -- investigate these first",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "inspect": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 6
+                },
+                "id": 8,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "Value"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(10, sum by (policy_name, rule_name, resource_kind) (increase(kyverno_policy_results_total{rule_result=~\"fail|error\", policy_name=~\"$policy_name\"}[24h])))",
+                    "format": "table",
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Top policies by fail/error (24h)",
+                "transparent": true,
+                "type": "table"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 14
+                },
+                "id": 9,
+                "panels": [],
+                "title": "Admission Control",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Admission requests per minute, split by whether Kyverno allowed or denied the request",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 60,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 15
+                },
+                "id": 10,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (request_allowed) (rate(kyverno_admission_requests_total[$__rate_interval])) * 60",
+                    "legendFormat": "allowed={{request_allowed}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Admission requests: allowed vs denied",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "End-to-end admission review latency -- how long Kyverno takes to evaluate all matching policies for one incoming request",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 20,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 15
+                },
+                "id": 11,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.50, sum(rate(kyverno_admission_review_duration_seconds_bucket[$__rate_interval])) by (le))",
+                    "legendFormat": "p50",
+                    "range": true,
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.95, sum(rate(kyverno_admission_review_duration_seconds_bucket[$__rate_interval])) by (le))",
+                    "legendFormat": "p95",
+                    "range": true,
+                    "refId": "B"
+                  },
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.99, sum(rate(kyverno_admission_review_duration_seconds_bucket[$__rate_interval])) by (le))",
+                    "legendFormat": "p99",
+                    "range": true,
+                    "refId": "C"
+                  }
+                ],
+                "title": "Admission review latency (p50/p95/p99)",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Which Kubernetes resource kinds generate the most admission review traffic through Kyverno",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 20,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 23
+                },
+                "id": 12,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(10, sum by (resource_kind) (rate(kyverno_admission_requests_total[$__rate_interval]))) * 60",
+                    "legendFormat": "{{resource_kind}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Admission requests by resource kind (top 10)",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 31
+                },
+                "id": 13,
+                "panels": [],
+                "title": "Policy Health",
+                "type": "row"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "The 10 policies with the slowest rule execution at the 95th percentile -- a slow policy adds latency to every matching admission request",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 20,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 32
+                },
+                "id": 14,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(10, histogram_quantile(0.95, sum by (policy_name, le) (rate(kyverno_policy_execution_duration_seconds_bucket{policy_name=~\"$policy_name\"}[$__rate_interval]))))",
+                    "legendFormat": "{{policy_name}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Rule execution latency p95 by policy (top 10)",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Policy create/update/delete events -- spikes here line up with GitOps deploys touching Kyverno policies",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "none",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 60,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "normal"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 32
+                },
+                "id": 15,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (policy_change_type) (increase(kyverno_policy_changes_total[$__rate_interval]))",
+                    "legendFormat": "{{policy_change_type}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Policy changes",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Kyverno's internal circuit breakers -- sustained non-zero rates indicate Kyverno is throttling itself, usually under API-server or admission-report load",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short",
+                    "decimals": 2,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 20,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 40
+                },
+                "id": 16,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (circuit_name) (rate(kyverno_breaker_total[$__rate_interval])) * 60",
+                    "legendFormat": "{{circuit_name}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Circuit breaker invocations",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Policy rules Kyverno currently reports as not ready (status_ready=\"false\") -- these are not being enforced",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "inspect": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 40
+                },
+                "id": 17,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "Value"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "kyverno_policy_rule_info_total{status_ready=\"false\"}",
+                    "format": "table",
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Rules not ready",
+                "transparent": true,
+                "type": "table"
+              }
+            ],
+            "refresh": "auto",
+            "schemaVersion": 39,
+            "tags": [
+              "kyverno",
+              "policy",
+              "otaru"
+            ],
+            "templating": {
+              "list": [
+                {
+                  "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                  },
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                  },
+                  "definition": "label_values(kyverno_policy_rule_info_total,policy_name)",
+                  "hide": 0,
+                  "includeAll": true,
+                  "label": "policy_name",
+                  "multi": true,
+                  "name": "policy_name",
+                  "options": [],
+                  "query": {
+                    "qryType": 1,
+                    "query": "label_values(kyverno_policy_rule_info_total,policy_name)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                  },
+                  "refresh": 2,
+                  "regex": "",
+                  "skipUrlSync": false,
+                  "sort": 1,
+                  "type": "query"
+                }
+              ]
+            },
+            "time": {
+              "from": "now-6h",
+              "to": "now"
+            },
+            "timepicker": {
+              "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+              ]
+            },
+            "timezone": "browser",
+            "title": "Kyverno Policy Metrics",
+            "uid": "kyverno-policy-metrics",
+            "version": 1,
+            "weekStart": ""
+          }


### PR DESCRIPTION
## Summary

- Kyverno already exports Prometheus-format metrics on port 8000 for each
  of its 4 controllers, and the `AuthorizationPolicy` allowing Prometheus
  to reach that port already existed (`helm-charts/kyverno/templates/
  authorization-policy.yaml`), but nothing set the `prometheus.io/scrape`
  annotation on the metrics Services -- so the `kubernetes-service-
  endpoints` job never picked them up. Fixed by setting
  `metricsService.annotations` on all four controllers.
- New Grafana dashboard, "Kyverno Policy Metrics", covering:
  - Overview: controllers reporting, policies loaded, admission
    requests/min, rule failures/min
  - Rule results by outcome (pass/fail/warn/error/skip), top failing
    policies over the last 24h
  - Admission allow/deny rate, review latency (p50/p95/p99), traffic by
    resource kind
  - Rule execution latency by policy, policy change events, circuit
    breaker activity, rules currently not ready

## Test plan

- [x] `make test` passes (includes `validate-grafana-dashboards.py`)
- [x] `helm template` for both `kyverno` and `monitoring` charts renders
      cleanly with the new values
- [ ] After merge: confirm ArgoCD syncs, `kubectl get pdb`-style check --
      `curl` each `kyverno-*-metrics` Service and confirm Prometheus
      target is `up`, then open the new dashboard in Grafana and confirm
      panels populate