### PR TITLE
feat(vpa): deploy Kubernetes VPA, trial on reloader and k8s-cleaner

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -271,6 +271,7 @@ local scheduling = [
   { wave: '02', name: 'k8s-cleaner', namespace: 'k8s-cleaner', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.scheduling['k8s-cleaner'] },
   { wave: '02', name: 'keda', namespace: 'keda' },
   { wave: '02', name: 'reloader', namespace: 'reloader', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.scheduling.reloader },
+  { wave: '05', name: 'vpa', namespace: 'vpa' },  // after cert-manager (wave 02)
 ];
 
 local security = [

--- a/helm-charts/k8s-cleaner/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/k8s-cleaner/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: k8s-cleaner
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: k8s-cleaner
+  updatePolicy:
+    updateMode: Initial  # trial: only applies at pod (re)creation, never evicts
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: [memory]  # cpu stays as declared in values.yaml
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 256Mi
+{{- end }}

--- a/helm-charts/k8s-cleaner/values.yaml
+++ b/helm-charts/k8s-cleaner/values.yaml
@@ -1,5 +1,8 @@
 namespace: k8s-cleaner
 
+vpa:
+  enabled: true
+
 excludeNamespaces: &excludeNamespaces
   - envoy-gateway-system
   - gateway

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -41,3 +41,4 @@ namespaces:
   - name: teslamate
   - name: umami
   - name: unifi-mcp
+  - name: vpa

--- a/helm-charts/reloader/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/reloader/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: reloader-reloader
+  namespace: reloader
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: reloader-reloader
+  updatePolicy:
+    updateMode: Initial  # trial: only applies at pod (re)creation, never evicts
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: [memory]  # cpu stays as declared in values.yaml
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 256Mi
+{{- end }}

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -1,3 +1,6 @@
+vpa:
+  enabled: true
+
 reloader:
   reloader:
     podDisruptionBudget:

--- a/helm-charts/vpa/Chart.lock
+++ b/helm-charts/vpa/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: vertical-pod-autoscaler
+  repository: https://kubernetes.github.io/autoscaler
+  version: 0.11.0
+digest: sha256:d3e20c7d2c68ba7815660ce47beb07312bf044c904a17287e0ecda73e7182a18
+generated: "2026-07-26T23:21:52.186434+01:00"

--- a/helm-charts/vpa/Chart.yaml
+++ b/helm-charts/vpa/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: vpa
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
+dependencies:
+- name: vertical-pod-autoscaler
+  version: 0.11.0
+  repository: https://kubernetes.github.io/autoscaler

--- a/helm-charts/vpa/templates/authorization-policy.yaml
+++ b/helm-charts/vpa/templates/authorization-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: vpa-webhook
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: vpa-webhook
+  rules:
+    - to:  # kube-apiserver calls this directly, no mesh identity to scope to (same as kyverno-svc)
+        - operation:
+            ports:
+              - "443"

--- a/helm-charts/vpa/values.yaml
+++ b/helm-charts/vpa/values.yaml
@@ -1,0 +1,49 @@
+namespace: vpa
+
+vertical-pod-autoscaler:
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+  admissionController:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 100Mi
+        ephemeral-storage: 64Mi
+    mutatingWebhookConfiguration:
+      failurePolicy: Ignore  # explicit chart default: never block pod creation
+    certGen:
+      enabled: false
+    registerWebhook: false
+    tls:
+      create: false
+    certManager:
+      enabled: true
+      createSelfSignedIssuer:
+        enabled: true
+  recommender:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 128Mi
+        ephemeral-storage: 64Mi
+  updater:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+        ephemeral-storage: 64Mi
+      limits:
+        memory: 100Mi
+        ephemeral-storage: 64Mi


### PR DESCRIPTION
## Summary

Deploys Kubernetes VPA (`kubernetes/autoscaler`'s official Helm chart) as
a trial, following up on the right-sizing/overcommit discussion this
session. This is a new cluster-wide component (a mutating admission
webhook), so scoping and safety details below.

### What's deployed

- `helm-charts/vpa/`: recommender, updater, admission-controller. Each
  single-replica with a native PodDisruptionBudget (`minAvailable: 1`,
  consistent with the repo-wide PDB audit earlier this session).
- Webhook TLS via a cert-manager self-signed Issuer (matches the
  `cnpg-system/selfsigned-issuer` pattern already used in this repo,
  since there is no shared cluster-wide ClusterIssuer).
- `mutatingWebhookConfiguration.failurePolicy: Ignore` (explicit,
  matches the chart default) -- if the admission-controller is ever
  down, pod creation cluster-wide must never block on it.
- An `AuthorizationPolicy` allowing any source on port 443 to the
  `vpa-webhook` Service, since `kube-apiserver` calls webhooks directly
  and is not itself a mesh workload -- same pattern as
  `helm-charts/kyverno/templates/authorization-policy.yaml`.

### Why no ArgoCD `ignoreDifferences` is needed

VPA's admission-controller mutates individual `Pod` objects at admission
time, never the owning `Deployment`/`StatefulSet`. ArgoCD's diff compares
the Deployment (rendered from Git) against the live Deployment, which
VPA never touches -- so there is no drift for `selfHeal` to fight.

### Trial scope

Only two workloads, both simple, non-guarded, no incident history:
- `reloader` (`helm-charts/reloader/templates/verticalpodautoscaler.yaml`)
- `k8s-cleaner` (`helm-charts/k8s-cleaner/templates/verticalpodautoscaler.yaml`)

Both use `updateMode: Initial` (applies only at pod (re)creation, never
forces an eviction) and `controlledResources: [memory]` with
`minAllowed`/`maxAllowed` bounds, leaving CPU as declared in each
chart's own `values.yaml`.

Deliberately **not** starting with `blocky`, `changedetection`, or the
`argocd` family -- all three have documented resource-tuning incidents
(OOMKilled, `FailedScheduling`) that VPA's recommender has no visibility
into.

## Test plan

- [x] `make test` passes
- [x] `helm template` for `vpa`, `reloader`, and `k8s-cleaner` renders
      cleanly with `--include-crds`
- [ ] After merge: confirm ArgoCD syncs `vpa`, all three VPA pods reach
      Ready, the webhook `Certificate`/`Issuer` pair goes Ready, and
      `kubectl get vpa -A` shows recommendations forming for the two
      trial workloads
- [ ] Watch `reloader`/`k8s-cleaner` pods do not crash-loop under the
      new `readOnlyRootFilesystem: true` container hardening