### PR TITLE
refactor(vpa): parameterize target name/namespace, trial InPlaceOrRecreate

### DIFF
--- a/helm-charts/k8s-cleaner/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/k8s-cleaner/templates/verticalpodautoscaler.yaml
@@ -2,15 +2,15 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: k8s-cleaner
+  name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: k8s-cleaner
+    name: {{ .Values.name }}
   updatePolicy:
-    updateMode: Initial  # trial: only applies at pod (re)creation, never evicts
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: '*'

--- a/helm-charts/k8s-cleaner/values.yaml
+++ b/helm-charts/k8s-cleaner/values.yaml
@@ -1,3 +1,4 @@
+name: k8s-cleaner
 namespace: k8s-cleaner
 
 vpa:

--- a/helm-charts/reloader/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/reloader/templates/verticalpodautoscaler.yaml
@@ -2,15 +2,15 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: reloader-reloader
-  namespace: reloader
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: reloader-reloader
+    name: {{ .Values.name }}
   updatePolicy:
-    updateMode: Initial  # trial: only applies at pod (re)creation, never evicts
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: '*'

--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -1,3 +1,6 @@
+name: reloader-reloader
+namespace: reloader
+
 vpa:
   enabled: true
 


### PR DESCRIPTION
## Summary

- Parameterize the hardcoded Deployment name/namespace in both trial
  `VerticalPodAutoscaler` objects (`reloader`, `k8s-cleaner`) via
  `.Values.name`/`.Values.namespace`, matching the convention already
  used elsewhere in these charts.
- Switch `updateMode` from `Initial` to `InPlaceOrRecreate` for both, now
  that the trial workloads are confirmed low-risk with no incident
  history. VPA 1.7.1 (already deployed by #2938) needs no feature-gate
  flag for this -- it became standard behavior in 1.7.0.

## Test plan

- [x] `make test` passes
- [x] `helm template` for both charts renders the same live resource
      names (`reloader-reloader`, `k8s-cleaner`) via the new values
- [ ] After merge: watch both pods for a live in-place resize (or a
      recreate fallback) once VPA has enough history to recommend a
      change