### PR TITLE
feat(hydra): deploy OAuth issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Key addresses on the Server network:
 | Security     | [External Secrets Operator](https://github.com/external-secrets/external-secrets)                   | Extracts secrets from a secret provider                                                                                                                                 |
 | Security     | [Kyverno](https://github.com/kyverno/kyverno)                                                       | Kubernetes policy engine                                                                                                                                                |
 | Security     | [oidc-provider](helm-charts/oidc-provider)                                                          | Kubernetes OIDC provider and JWKS endpoint                                                                                                                              |
+| Security     | [Ory Hydra](https://www.ory.com/hydra)                                                               | OAuth 2.0 and OpenID Connect provider for machine identities                                                                                                           |
 | Storage      | [Longhorn](https://github.com/longhorn/longhorn)                                                    | Distributed block storage system; backup and restore from/to remote destinations                                                                                        |
 <!-- markdownlint-enable MD060 -->
 

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -177,6 +177,7 @@ local application = [
   { wave: '10', name: 'cyberchef', namespace: 'cyberchef' },
   { wave: '10', name: 'excalidraw', namespace: 'excalidraw' },
   { wave: '10', name: 'home-assistant-volume', namespace: 'home-assistant', helm: homeAssistantVolumeHelm },
+  { wave: '10', name: 'hydra', namespace: 'hydra' },
   { wave: '10', name: 'jsoncrack', namespace: 'jsoncrack' },
   { wave: '10', name: 'kubernetes-mcp-server', namespace: 'kubernetes-mcp-server' },
   { wave: '10', name: 'openclaw-volume', namespace: 'openclaw' },

--- a/documentation/secrets.md
+++ b/documentation/secrets.md
@@ -197,6 +197,19 @@ otaru_luks_password: "replace-me"
 
 This file is not required for normal cluster bootstrap.
 
+## Ory
+
+The `Ory` Password item in the `github-otaru` vault provides two independent,
+stable Hydra fields: `hydraSecretsSystem` and `hydraSecretsCookie`. The
+component prefix keeps room for other Ory services in the same item. Hydra uses
+them to encrypt persisted data and protect browser state. Do not rotate either
+field as a normal password rotation: Hydra secret rotation requires an overlap
+period with both the old and new values configured.
+
+OAuth client signing keys are separate from these server secrets. Keep client
+private keys outside Git and Kubernetes; register only their public JWKs when a
+client is onboarded.
+
 ## Check
 
 Run this before bootstrap:

--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -114,6 +114,50 @@ clusters:
   # Avoid reusing the same ObjectStore configuration for both backup and recovery in the same cluster. If you must, ensure that each cluster uses a unique serverName
   # to prevent accidental overwrites of backup data.
 
+  hydra:
+    clusterName: hydra-20260726-0001
+    namespace: hydra
+    affinity:
+      podAntiAffinityType: required
+    instances: 2
+    minSyncReplicas: 1
+    maxSyncReplicas: 1
+    # Initial sizing: Hydra stores low-volume OAuth metadata and has no live
+    # database metrics yet. This matches the established lightweight database
+    # envelope while retaining failover and vacuum headroom; revisit with KRR.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+        ephemeral-storage: 512Mi
+      limits:
+        memory: 256Mi
+        ephemeral-storage: 512Mi
+    storage:
+      size: 2Gi
+      storageClass: longhorn-crypto-global
+    postgresql:
+      <<: *postgresql
+      pg_hba:
+        - hostssl all all 0.0.0.0/0 scram-sha-256
+        - hostssl all all ::0/0 scram-sha-256
+    enableSuperuserAccess: false
+    managed:
+      roles:
+        - name: app
+          ensure: present
+          login: true
+          connectionLimit: -1
+    bootstrap:
+      initdb:
+        database: hydra
+        owner: app
+        secret:
+          name: hydra-20260726-0001
+    test:
+      enabled: true
+      query: SELECT 1;
+
   teslamate:
     clusterName: teslamate-20260412-0619
     storage:

--- a/helm-charts/envoy-gateway/templates/gateway.yaml
+++ b/helm-charts/envoy-gateway/templates/gateway.yaml
@@ -36,6 +36,7 @@ spec:
                   - gateway
                   - home-assistant
                   - httpbin
+                  - hydra
                   - istio-system
                   - jellyfin
                   - jsoncrack

--- a/helm-charts/hydra/.helmignore
+++ b/helm-charts/hydra/.helmignore
@@ -1,0 +1,12 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/hydra/Chart.lock
+++ b/helm-charts/hydra/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: hydra
+  repository: https://k8s.ory.com/helm/charts
+  version: 0.62.1
+digest: sha256:c25b957d81c07a5f69262dce059810fe6ab930542133433e8dfe980d9e8dae29
+generated: "2026-07-26T23:43:30.688911+01:00"

--- a/helm-charts/hydra/Chart.yaml
+++ b/helm-charts/hydra/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: hydra
+description: OAuth 2.0 and OpenID Connect provider for machine identities
+type: application
+version: 0.1.0
+icon: https://raw.githubusercontent.com/ory/docs/master/docs/static/img/logo-hydra.svg
+dependencies:
+  - name: hydra
+    version: 0.62.1
+    repository: https://k8s.ory.com/helm/charts

--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -1,0 +1,39 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: hydra-public
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: hydra-public
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+      to:
+        - operation:
+            ports:
+              - "4444"
+---
+# Hydra's administrative API can create clients, keys, and trust relationships.
+# Keep it reachable only through explicit future service-level policy changes;
+# it must never inherit the public issuer's gateway access.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: hydra-admin
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: hydra-admin
+  rules: []

--- a/helm-charts/hydra/templates/external-secret.yaml
+++ b/helm-charts/hydra/templates/external-secret.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.systemSecret.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.systemSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.systemSecret.secretStoreRef.kind }}
+    name: {{ .Values.systemSecret.secretStoreRef.name }}
+  target:
+    name: {{ .Values.systemSecret.name }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  data:
+    - secretKey: secretsSystem
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.systemSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: hydraSecretsSystem
+    - secretKey: secretsCookie
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.systemSecret.remoteRef.key }}
+        metadataPolicy: None
+        property: hydraSecretsCookie

--- a/helm-charts/hydra/templates/route-internal.yaml
+++ b/helm-charts/hydra/templates/route-internal.yaml
@@ -1,0 +1,27 @@
+{{- $gateway := .Values.gateway | default dict -}}
+{{- $gatewayName := $gateway.name | default "gateway" -}}
+{{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.name }}-internal
+  namespace: {{ .Values.namespace }}
+spec:
+  hostnames:
+    - {{ .Values.route.hostname }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $gatewayName }}
+      namespace: {{ $gatewayNamespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: hydra-public
+          port: 4444
+          weight: 1

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -1,0 +1,160 @@
+name: hydra
+namespace: hydra
+
+gateway:
+  name: gateway
+  namespace: gateway
+
+route:
+  hostname: hydra.internal.siutsin.com
+
+systemSecret:
+  name: hydra-system
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-secret-store
+  remoteRef:
+    key: Ory
+
+database:
+  secretName: hydra-20260726-0001
+  caSecretName: hydra-20260726-0001-ca
+
+hydra:
+  fullnameOverride: hydra
+  replicaCount: 2
+
+  image:
+    tag: v26.2.0@sha256:ff67c7fb5f95074fa53374d41151713554960504b340cd3f95b09e65deaea2a9
+
+  hydra:
+    config:
+      urls:
+        self:
+          issuer: https://hydra.internal.siutsin.com/
+        # Browser grants are intentionally unavailable. Hydra requires these
+        # URLs syntactically, but client_credentials never calls them.
+        login: https://not-configured.invalid/login
+        consent: https://not-configured.invalid/consent
+        logout: https://not-configured.invalid/logout
+      strategies:
+        # Short-lived JWTs let Envoy validate MCP credentials locally using
+        # Hydra's public JWKS; revocation is bounded by the 15-minute TTL.
+        access_token: jwt
+      ttl:
+        access_token: 15m
+      log:
+        format: json
+        level: info
+    automigration:
+      enabled: true
+      type: job
+
+  secret:
+    enabled: false
+    nameOverride: hydra-system
+
+  deployment:
+    annotations:
+      reloader.stakater.com/auto: "true"
+    customLivenessProbe:
+      httpGet:
+        path: /health/alive
+        port: 4445
+        httpHeaders:
+          - name: Host
+            value: 127.0.0.1
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+    customReadinessProbe:
+      httpGet:
+        path: /health/ready
+        port: 4445
+        httpHeaders:
+          - name: Host
+            value: 127.0.0.1
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 5
+    customStartupProbe:
+      httpGet:
+        path: /health/ready
+        port: 4445
+        httpHeaders:
+          - name: Host
+            value: 127.0.0.1
+      periodSeconds: 2
+      timeoutSeconds: 2
+      failureThreshold: 30
+    extraEnv:
+      - name: DSN
+        valueFrom:
+          secretKeyRef:
+            name: hydra-20260726-0001
+            key: DATABASE_URL
+    extraVolumes:
+      - name: database-ca
+        secret:
+          secretName: hydra-20260726-0001-ca
+    extraVolumeMounts:
+      - name: database-ca
+        mountPath: /etc/secrets/ca
+        readOnly: true
+    # Initial sizing: Hydra is a small Go control-plane service with no live
+    # KRR history yet. Keep enough headroom for key generation and migrations,
+    # then revisit after 14 days of production metrics.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 128Mi
+      limits:
+        memory: 128Mi
+        ephemeral-storage: 128Mi
+
+  job:
+    automountServiceAccountToken: false
+    extraEnv:
+      - name: DSN
+        valueFrom:
+          secretKeyRef:
+            name: hydra-20260726-0001
+            key: DATABASE_URL
+    # Migration uses the same binary and database schema as the server; match
+    # the initial server memory envelope until live job metrics say otherwise.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 128Mi
+      limits:
+        memory: 128Mi
+        ephemeral-storage: 128Mi
+
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: hydra
+            topologyKey: kubernetes.io/hostname
+
+  pdb:
+    enabled: true
+    spec:
+      minAvailable: 1
+
+  maester:
+    # Client onboarding comes later; avoid running a controller and CRDs until
+    # there is an OAuth2Client for it to manage.
+    enabled: false
+
+  test:
+    busybox:
+      tag: stable@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -22,6 +22,9 @@ clusterSecretStorePolicy:
     gateway:
       - cloudflare-acme-verification-secret
       - heartbeats
+    hydra:
+      - b2-secret-cloudnative-pg
+      - Ory
     umami:
       - Umami
       - b2-secret-cloudnative-pg
@@ -64,6 +67,11 @@ meshAuthorizationPolicy:
 barmanObjectStorePolicy:
   enabled: true
   allowedNamespaces:
+    hydra:
+      objectStores:
+        - b2-backup
+      credentialSecrets:
+        - b2-backup-credentials
     teslamate:
       objectStores:
         - b2-backup

--- a/helm-charts/namespaces/values.yaml
+++ b/helm-charts/namespaces/values.yaml
@@ -20,6 +20,7 @@ namespaces:
   - name: external-secrets
   - name: home-assistant
   - name: httpbin
+  - name: hydra
   - name: istio-system
     ambient: false
   - name: jellyfin


### PR DESCRIPTION
## Summary

- deploy Ory Hydra as the internal OAuth 2.0/OIDC issuer
- add a two-instance backed-up CloudNativePG database
- source Hydra server secrets from the shared `Ory` 1Password item
- restrict the public service to the gateway and deny direct access to the admin service
- register the namespace, route, policies, and Argo CD application

## Validation

- `make test`
- `gitleaks git --redact --log-opts=origin/master..HEAD --no-banner`
- verified both 1Password fields are present, distinct, non-placeholder, and at least 32 characters without exposing their values