### PR TITLE
docs: add VPA to README and right-sizing/self-healing runbooks

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -3,10 +3,12 @@ name: "right-sizing"
 description: >-
   Right-size otaru workloads via KRR (CPU/memory) and Prometheus ephemeral-storage
   metrics. Read incident comments as guardrails, apply downsizes and upsizes in one
-  GitOps PR, verify rollout. Invoke as /right-sizing from /self-healing when
-  healthy (including scheduled fires from /self-healing-loop), or manually.
+  GitOps PR, verify rollout. Also covers VPA (helm-charts/vpa), a complementary
+  automated path for steady-state workloads with no spike pattern. Invoke as
+  /right-sizing from /self-healing when healthy (including scheduled fires from
+  /self-healing-loop), or manually.
 metadata:
-  short-description: "KRR and ephemeral-storage right-sizing for otaru"
+  short-description: "KRR, ephemeral-storage, and VPA right-sizing for otaru"
 ---
 
 # Otaru workload right-sizing
@@ -60,8 +62,13 @@ krr simple -p <prometheus-url-via-ingress> -f json -q > /tmp/krr-otaru-$(date +%
 
 ### Build the change set
 
-For each candidate workload in `helm-charts/**/values.yaml` (and chart templates
-when resources live there):
+Before editing any workload, check `kubectl get vpa -A` — skip anything with an
+existing `VerticalPodAutoscaler` object (see **VPA-managed workloads** below).
+KRR and VPA fighting over the same Deployment produces confusing drift, not a
+better answer.
+
+For each remaining candidate workload in `helm-charts/**/values.yaml` (and chart
+templates when resources live there):
 
 1. Read inline resource comments for past incidents (OOM, probe failures, scheduling pressure). **Do not downsize past those guardrails.**
 2. **Downsize** when KRR peak is well below the request and no incident comment blocks it.
@@ -167,6 +174,52 @@ Open a follow-up PR immediately if rollout breaks a workload:
   and workload (for example changedetection OOMKill exit 137 at 256Mi → 1Gi).
 - **Init/exec format error on nuc-00** — arm64-only images on amd64; pin
   `nodeSelector: kubernetes.io/arch: arm64` when charts use arm64-only digests.
+
+## VPA-managed workloads
+
+`helm-charts/vpa/` deploys Kubernetes VPA (recommender, updater,
+admission-controller). It is a **second, complementary** resource-management
+path, not a replacement for KRR passes above — the two suit different shapes
+of workload.
+
+### Why VPA does not replace KRR here
+
+VPA's memory algorithm targets the 95th percentile of **daily peak** usage
+over an 8-day window, not typical/steady-state usage. That is the right
+behaviour for a workload with roughly constant usage, but for a workload that
+spikes briefly then idles (blocky's ~4h denylist refresh, changedetection's
+hourly page-render), it recommends a request near the peak — undoing the
+manual "steady-state request, higher limit" overcommit tuning already applied
+to those charts. **Never add a `VerticalPodAutoscaler` for a guarded workload**
+(the same list as the KRR guardrails above) unless it is scoped to
+`controlledResources: [cpu]` only, since VPA's CPU algorithm is
+percentile-based, not peak-based, and does not have this problem.
+
+### Good VPA candidates
+
+Workloads with no incident-history comment in their chart and no
+periodic-spike shape — most single-purpose controllers and sidecars. `reloader`
+and `k8s-cleaner` are the initial trial (`helm-charts/reloader/values.yaml`,
+`helm-charts/k8s-cleaner/values.yaml`, both `vpa.enabled: true`).
+
+### Onboarding a new workload to VPA
+
+1. Add `vpa.enabled: true` to the chart's `values.yaml`.
+2. Add `templates/verticalpodautoscaler.yaml` gated by that flag, following
+    the pattern in `helm-charts/reloader/templates/verticalpodautoscaler.yaml`:
+    `targetRef` at the Deployment, `minAllowed`/`maxAllowed` bounds derived
+    from real Prometheus usage (not a guess), `controlledResources` scoped to
+    what is safe for that workload's usage shape.
+3. Start `updateMode: Initial` while validating the recommendation against
+    real usage; a fresh VPA has near-zero history and its confidence-interval
+    math inflates recommendations toward `maxAllowed` for the first ~24 hours,
+    settling toward the real value over roughly a week (8-day histogram
+    window). Do not trust or hand-tune bounds around an `Initial`-mode
+    recommendation less than a day old.
+4. Switch to `updateMode: InPlaceOrRecreate` once the recommendation has
+    settled and looks sane. This cluster's k3s v1.36.2 supports in-place pod
+    resize (GA since Kubernetes 1.35) and VPA 1.7+ needs no feature-gate flag
+    for this mode, so most resizes apply live with no pod restart.
 
 ## Journal
 

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -97,6 +97,17 @@
   - This is now a recurring-enough pattern to spot-check on any
     `Progressing` finding, not just wait for a report.
 
+- **VPA-driven resource changes are expected, not an incident.**
+  `helm-charts/vpa/` runs a live admission-controller and updater for a
+  growing set of workloads (`kubectl get vpa -A` lists them). A pod whose
+  `resources.requests`/`limits` differ from its chart's declared values, or
+  that shows a restart with no other explanation, may simply be VPA applying
+  a recommendation (`InPlaceOrRecreate` resizes live with no restart when the
+  kubelet supports it; it falls back to a normal pod recreate otherwise).
+  Check `kubectl get vpa -n <namespace>` before treating this as drift or an
+  issue. See `.claude/skills/right-sizing/SKILL.md` **VPA-managed workloads**
+  for how these are configured and vetted.
+
 ## Known data-durability gotchas
 
 - **changedetection watch list wipe:** pinning

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Current cluster layout:
 | `ucg-ultra`       | [UniFi Cloud Gateway Ultra][ucg-ultra]                         | Router/Gateway | -                                      |
 | `usw-lite-8-poe`  | UniFi Switch Lite 8 PoE                                        | PoE switch     | -                                      |
 | `usw-ultra`       | [UniFi Switch Ultra][usw-ultra]                                | PoE switch     | -                                      |
-| `u7-pro-front`    | UniFi U7 Pro                                                    | Access point   | -                                      |
-| `u7-pro-back`     | UniFi U7 Pro                                                    | Access point   | -                                      |
+| `u7-pro-front`    | UniFi U7 Pro                                                   | Access point   | -                                      |
+| `u7-pro-back`     | UniFi U7 Pro                                                   | Access point   | -                                      |
 | `rackmate-t1`     | [GeeekPi DeskPi RackMate T1][rackmate-t1]                      | Rack enclosure | -                                      |
 | `rack-mount`      | [GeeekPi 10" 2U Rack Mount][rack-mount]                        | Pi rack mount  | -                                      |
 <!-- markdownlint-enable MD060 -->
@@ -58,16 +58,16 @@ The UniFi gateway routes eight managed networks. Detailed firewall behavior and
 verification steps are documented in
 [Infrastructure operations](documentation/infrastructure.md#current-unifi-access-policy).
 
-| VLAN | Network       | Subnet              | Purpose                                      |
-|------|---------------|---------------------|----------------------------------------------|
-| 1    | Default       | `192.168.1.0/24`    | Untagged and VLAN-unaware IoT devices        |
-| 3    | Guest         | `192.168.3.0/24`    | Visitor devices                              |
-| 4    | Client        | `192.168.4.0/24`    | Trusted personal clients and media receivers |
-| 5    | IoT Public    | `192.168.5.0/24`    | Internet-connected IoT devices               |
-| 6    | IoT Private   | `192.168.6.0/24`    | IoT devices that must remain offline         |
-| 7    | Work          | `192.168.7.0/24`    | Work devices                                 |
-| 8    | Unrestricted  | `192.168.8.0/24`    | Unrestricted trusted devices                 |
-| 10   | Server        | `192.168.10.0/24`   | Cluster nodes and service VIPs               |
+| VLAN | Network      | Subnet            | Purpose                                      |
+|------|--------------|-------------------|----------------------------------------------|
+| 1    | Default      | `192.168.1.0/24`  | Untagged and VLAN-unaware IoT devices        |
+| 3    | Guest        | `192.168.3.0/24`  | Visitor devices                              |
+| 4    | Client       | `192.168.4.0/24`  | Trusted personal clients and media receivers |
+| 5    | IoT Public   | `192.168.5.0/24`  | Internet-connected IoT devices               |
+| 6    | IoT Private  | `192.168.6.0/24`  | IoT devices that must remain offline         |
+| 7    | Work         | `192.168.7.0/24`  | Work devices                                 |
+| 8    | Unrestricted | `192.168.8.0/24`  | Unrestricted trusted devices                 |
+| 10   | Server       | `192.168.10.0/24` | Cluster nodes and service VIPs               |
 
 Key addresses on the Server network:
 
@@ -128,10 +128,11 @@ Key addresses on the Server network:
 | Monitoring   | [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server)                      | Scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines                                                                  |
 | Monitoring   | [Loki](helm-charts/monitoring)                                                                      | Log aggregation and query backend                                                                                                                                       |
 | Monitoring   | [Prometheus](helm-charts/monitoring)                                                                | Metrics collection and query backend                                                                                                                                    |
-| Scheduling   | [Descheduler](https://github.com/kubernetes-sigs/descheduler)                                       | Evicts pods for optimal cluster node utilisation; runs a `HighNodeUtilization` profile to consolidate the least-loaded node's pods elsewhere                           |
+| Scheduling   | [Descheduler](https://github.com/kubernetes-sigs/descheduler)                                       | Evicts pods for optimal cluster node utilisation; runs a `HighNodeUtilization` profile to consolidate the least-loaded node's pods elsewhere                            |
 | Scheduling   | [k8s-cleaner](https://github.com/gianlucam76/k8s-cleaner)                                           | Automated failed pod cleanup and periodic workload repaving                                                                                                             |
 | Scheduling   | [KEDA](https://keda.sh/)                                                                            | Event Driven Autoscaler                                                                                                                                                 |
 | Scheduling   | [Reloader](https://github.com/stakater/Reloader)                                                    | Watch changes in ConfigMap and Secret and do rolling upgrades                                                                                                           |
+| Scheduling   | [VPA](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)                 | Vertical Pod Autoscaler for automatic CPU/memory right-sizing                                                                                                           |
 | Security     | [1Password Connect](https://github.com/1Password/connect)                                           | Proxy service for 1Password; acts as a secret provider                                                                                                                  |
 | Security     | [amazon-eks-pod-identity-webhook](https://github.com/aws/amazon-eks-pod-identity-webhook)           | Amazon EKS Pod Identity Webhook for IRSA in bare metal Kubernetes clusters                                                                                              |
 | Security     | [cert-manager](https://github.com/cert-manager/cert-manager)                                        | Manages TLS certificates via Let's Encrypt and ACME protocol                                                                                                            |


### PR DESCRIPTION
## Summary

Documentation follow-up to the VPA trial (#2938, #2939) -- no functional
changes.

- `README.md`: registered VPA in the Cluster Components table (Scheduling
  category).
- `.claude/skills/right-sizing/SKILL.md`: new **VPA-managed workloads**
  section explaining why VPA's peak-based memory algorithm is a poor fit
  for spike-then-idle workloads (blocky, changedetection) but a good fit
  for steady-state ones, plus the onboarding steps used for the
  `reloader`/`k8s-cleaner` trial. Also added a note to check
  `kubectl get vpa -A` before hand-editing a workload's resources during
  a KRR pass, so the two systems do not fight each other.
- `.claude/skills/self-healing/runbooks/workloads.md`: new gotcha entry
  so a future investigation recognises a VPA-driven resize/restart as
  expected behaviour rather than drift or an incident.

## Test plan

- [x] `make test` passes (markdown lint, editorconfig)