### PR TITLE
fix(monitoring): aggregate the VPA objects-tracked panel query

### DIFF
--- a/helm-charts/monitoring/dashboards/vpa.yaml
+++ b/helm-charts/monitoring/dashboards/vpa.yaml
@@ -111,7 +111,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "vpa_recommender_vpa_objects_count",
+                    "expr": "sum(vpa_recommender_vpa_objects_count{matches_pods=\"true\", has_recommendation=\"true\", unsupported_config=\"false\"})",
                     "legendFormat": "",
                     "range": false,
                     "refId": "A",


### PR DESCRIPTION
## Summary

Follow-up to #2943 (merged just now) -- caught this while manually verifying
the new dashboard's queries against live Prometheus data.
`vpa_recommender_vpa_objects_count` carries `api`/`has_recommendation`/
`matches_pods`/`unsupported_config`/`update_mode` labels, so the bare
metric name in the "VPA objects tracked" panel returns dozens of series
(mostly zero) instead of a single number. Scoped it to the one
combination that means "a real, matched VPA object with a recommendation"
and summed it -- confirmed live it now returns exactly `2` for the
`reloader`/`k8s-cleaner` trial.

## Test plan

- [x] `make test` passes
- [x] Confirmed the corrected query against live Prometheus returns a
      single clean value (`2`)