### PR TITLE
feat(vpa): expand trial to kiali, descheduler, kubernetes-mcp-server, onepassword-connect

### DIFF
--- a/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: descheduler
+  namespace: descheduler
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: descheduler
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 16Mi
+        maxAllowed:
+          memory: 128Mi
+{{- end }}

--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -1,3 +1,6 @@
+vpa:
+  enabled: true
+
 descheduler:
   kind: Deployment
   resources:

--- a/helm-charts/kiali/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/kiali/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 256Mi
+{{- end }}

--- a/helm-charts/kiali/values.yaml
+++ b/helm-charts/kiali/values.yaml
@@ -1,6 +1,9 @@
 name: kiali
 namespace: kiali
 
+vpa:
+  enabled: true
+
 kiali-server:
   auth:
     strategy: anonymous

--- a/helm-charts/kubernetes-mcp-server/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kubernetes-mcp-server
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kubernetes-mcp-server
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 16Mi
+        maxAllowed:
+          memory: 128Mi
+{{- end }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -1,6 +1,9 @@
 name: k8s-mcp
 namespace: kubernetes-mcp-server
 
+vpa:
+  enabled: true
+
 kubernetes-mcp-server:
   image:
     registry: quay.io

--- a/helm-charts/onepassword-connect/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/onepassword-connect/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.vpa.enabled }}
+{{- $namespace := .Release.Namespace | default "onepassword" -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: onepassword-connect
+  namespace: {{ $namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: onepassword-connect
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+      - containerName: connect-api
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 16Mi
+        maxAllowed:
+          memory: 64Mi
+      - containerName: connect-sync
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 16Mi
+        maxAllowed:
+          memory: 64Mi
+{{- end }}

--- a/helm-charts/onepassword-connect/values.yaml
+++ b/helm-charts/onepassword-connect/values.yaml
@@ -1,3 +1,6 @@
+vpa:
+  enabled: true
+
 _shared:
   resources: &resources
     requests:


### PR DESCRIPTION
## Summary

Expands the VPA trial (previously just `reloader`/`k8s-cleaner`) to four
more low-risk candidates -- no incident-history comment in any of their
charts, no periodic-spike usage shape.

Bounds this time are derived from real 14-day Prometheus usage
(`quantile_over_time` p50/p95/p99), not a guess like the original
`32Mi`-`256Mi` for the first two:

| Workload                  | p50  | p99   | 14d max | Bounds set  |
|----------------------------|------|-------|---------|-------------|
| kiali                      | 71Mi | 134Mi | 143Mi   | 32Mi-256Mi  |
| descheduler                 | 26Mi | 74Mi  | 75Mi    | 16Mi-128Mi  |
| kubernetes-mcp-server       | 28Mi | 71Mi  | 78Mi    | 16Mi-128Mi  |
| onepassword-connect (api)   | 26Mi | 34Mi  | --      | 16Mi-64Mi   |
| onepassword-connect (sync)  | 19Mi | 23Mi  | --      | 16Mi-64Mi   |

All four start in `updateMode: Initial`, not `InPlaceOrRecreate`. The
`reloader`/`k8s-cleaner` trial showed a brand-new VPA object's first
recommendation is confidence-inflated for roughly 24 hours -- applying
that live immediately just pushed both up to a worse number than they
started with (64Mi -> 250Mi). Letting each settle first this time before
switching to live automation.

## Test plan

- [x] `make test` passes
- [x] `helm template` for all four charts renders the VPA object with the
      correct target name/namespace and per-container bounds
- [ ] After merge: confirm `kubectl get vpa -A` shows all four, and check
      back in ~24h that recommendations have settled toward the real
      usage numbers above rather than sitting near each `maxAllowed`