### PR TITLE
feat(vpa): switch the 4 newest trial workloads to InPlaceOrRecreate

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -210,16 +210,20 @@ and `k8s-cleaner` are the initial trial (`helm-charts/reloader/values.yaml`,
     `targetRef` at the Deployment, `minAllowed`/`maxAllowed` bounds derived
     from real Prometheus usage (not a guess), `controlledResources` scoped to
     what is safe for that workload's usage shape.
-3. Start `updateMode: Initial` while validating the recommendation against
-    real usage; a fresh VPA has near-zero history and its confidence-interval
-    math inflates recommendations toward `maxAllowed` for the first ~24 hours,
-    settling toward the real value over roughly a week (8-day histogram
-    window). Do not trust or hand-tune bounds around an `Initial`-mode
-    recommendation less than a day old.
-4. Switch to `updateMode: InPlaceOrRecreate` once the recommendation has
-    settled and looks sane. This cluster's k3s v1.36.2 supports in-place pod
-    resize (GA since Kubernetes 1.35) and VPA 1.7+ needs no feature-gate flag
-    for this mode, so most resizes apply live with no pod restart.
+3. Use `updateMode: InPlaceOrRecreate` from the start. This cluster's k3s
+    v1.36.2 supports in-place pod resize (GA since Kubernetes 1.35) and
+    VPA 1.7+ needs no feature-gate flag for this mode, so most resizes
+    apply live with no pod restart and the updater keeps re-applying as
+    the recommendation moves.
+4. Expect a fresh VPA's first recommendation to be confidence-inflated
+    toward `maxAllowed` for roughly the first 24 hours (near-zero history),
+    settling toward the real value over about a week (8-day histogram
+    window) -- `InPlaceOrRecreate` will apply that inflated number
+    immediately, then correct it down again as real history accumulates.
+    `Initial` mode avoids the temporary overshoot but only ever applies a
+    recommendation when the pod is next recreated for an unrelated reason,
+    which may never happen for a long-lived Deployment -- not a real
+    alternative for actually getting the fix applied.
 
 ## Journal
 

--- a/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
@@ -10,7 +10,7 @@ spec:
     kind: Deployment
     name: descheduler
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: '*'

--- a/helm-charts/kiali/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/kiali/templates/verticalpodautoscaler.yaml
@@ -10,7 +10,7 @@ spec:
     kind: Deployment
     name: {{ .Values.name }}
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: '*'

--- a/helm-charts/kubernetes-mcp-server/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/verticalpodautoscaler.yaml
@@ -10,7 +10,7 @@ spec:
     kind: Deployment
     name: kubernetes-mcp-server
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: '*'

--- a/helm-charts/onepassword-connect/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/onepassword-connect/templates/verticalpodautoscaler.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: onepassword-connect
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: connect-api


### PR DESCRIPTION
## Summary

Follow-up to #2946 (merged). Switches `kiali`, `descheduler`,
`kubernetes-mcp-server`, and `onepassword-connect` from `updateMode:
Initial` to `InPlaceOrRecreate`.

`Initial` only applies a recommendation the next time a pod is recreated
for an unrelated reason -- for a long-lived Deployment that may not
happen for weeks, so it doesn't actually guarantee the right-sizing lands.
`InPlaceOrRecreate` re-evaluates continuously: yes, it applies a
temporarily-inflated early recommendation live (same confidence-interval
behaviour already observed with `reloader`/`k8s-cleaner`), but it also
corrects that back down again as real usage history accumulates, which
`Initial` mode cannot do on its own.

Also updates `.claude/skills/right-sizing/SKILL.md`'s onboarding
guidance to recommend `InPlaceOrRecreate` from the start rather than an
`Initial`-first staging step.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm `kubectl get vpa -A` shows all four in
      `InPlaceOrRecreate` mode and watch for a live resize on each