### PR TITLE
fix(hydra): run database as single instance

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/values.yaml
+++ b/helm-charts/cloudnative-pg-clusters/values.yaml
@@ -119,12 +119,16 @@ clusters:
     namespace: hydra
     affinity:
       podAntiAffinityType: required
-    instances: 2
-    minSyncReplicas: 1
-    maxSyncReplicas: 1
+    # 2026-07-27: the replica join stayed Pending because required anti-affinity
+    # excludes the primary node and every other node lacks the requested memory.
+    # Run one instance while 3-hourly backups and continuous WAL archiving provide
+    # PITR; restore 2/1/1 after reserving at least 1Gi on another node.
+    instances: 1
+    minSyncReplicas: 0
+    maxSyncReplicas: 0
     # Initial sizing: Hydra stores low-volume OAuth metadata and has no live
     # database metrics yet. This matches the established lightweight database
-    # envelope while retaining failover and vacuum headroom; revisit with KRR.
+    # envelope while retaining vacuum headroom; revisit with KRR.
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Summary

- run the Hydra CloudNativePG cluster as one instance while the nodes lack scheduling headroom
- disable synchronous replica requirements for the single-instance topology
- keep required pod anti-affinity and document the condition for restoring HA

## Recovery safeguards

- scheduled online backup completes every three hours
- continuous WAL archiving is healthy
- Barman reports a first recoverability point and 30-day retention

## Verification

- make test
- live backup hydra-20260726-0001-scheduled-backup-20260727000000 is completed
- CNPG reports ContinuousArchivingSuccess and LastBackupSucceeded

PITR is configured and healthy; a restore drill has not yet been performed for this new database.