### PR TITLE
fix(changedetection): spoof Windows Chrome user-agent to fix watch 403s

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -14,7 +14,8 @@ deployment:
     LANG: C.UTF-8
     LC_ALL: C.UTF-8
     MINIMUM_SECONDS_RECHECK_TIME: "60"
-    PLAYWRIGHT_DRIVER_URL: ws://changedetection-browser.changedetection.svc.cluster.local:3000?--user-data-dir=/profile/chromium&headful=true
+    PLAYWRIGHT_DRIVER_URL: "ws://changedetection-browser.changedetection.svc.cluster.local:3000?--user-data-dir=/profile/chromium&headful=true&\
+      --user-agent=Mozilla/5.0%20%28Windows%20NT%2010.0%3B%20Win64%3B%20x64%29%20AppleWebKit/537.36%20%28KHTML%2C%20like%20Gecko%29%20Chrome/119.0.0.0%20Safari/537.36"
     TZ: Europe/London
     USE_X_SETTINGS: "true"
   image:


### PR DESCRIPTION
## Summary

- A browser-backed watch was returning 403 (Access denied) on every check.
- Direct CDP testing against the `changedetection-browser` sidecar isolated the cause to the User-Agent OS string alone (Linux desktop UAs blocked, Windows UAs allowed); `navigator.webdriver`, WebGL renderer, and `navigator.platform` were all unaffected and not the differentiator.
- Appends a `--user-agent` override (Windows 10 Chrome UA) to `PLAYWRIGHT_DRIVER_URL`, applied globally to all browser-backed watches.

## Test plan

- [x] `helm template helm-charts/changedetection` renders the expected env value
- [x] `make test` passes (EditorConfig line-length required a YAML escaped-line-continuation split)
- [ ] After merge and ArgoCD sync, re-trigger the previously-failing watch and confirm it returns 200 instead of 403