### PR TITLE
feat(mcp): add OAuth end-to-end test client

### DIFF
--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -36,4 +36,18 @@ spec:
     - group: ""
       kind: Service
       name: hydra-admin
+  {{- if .Values.clientController.enabled }}
+  rules:
+    # Maester is the only workload allowed to reconcile OAuth clients through
+    # Hydra's administrative API; the ingress gateway remains excluded.
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/{{ .Values.clientController.serviceAccountName }}
+      to:
+        - operation:
+            ports:
+              - "4445"
+  {{- else }}
   rules: []
+  {{- end }}

--- a/helm-charts/hydra/templates/mcp-test-client-secret.yaml
+++ b/helm-charts/hydra/templates/mcp-test-client-secret.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.mcpTestClient.enabled }}
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: {{ .Values.mcpTestClient.secretName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  length: {{ .Values.mcpTestClient.password.length }}
+  digits: {{ .Values.mcpTestClient.password.digits }}
+  symbols: {{ .Values.mcpTestClient.password.symbols }}
+  symbolCharacters: {{ .Values.mcpTestClient.password.symbolCharacters | quote }}
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.mcpTestClient.secretName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    # Wait for the Password generator, then let Argo verify this Secret is Ready
+    # before creating the OAuth2Client in the next sync wave.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshPolicy: CreatedOnce
+  target:
+    name: {{ .Values.mcpTestClient.secretName }}
+    creationPolicy: Owner
+    immutable: true
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        CLIENT_ID: {{ .Values.mcpTestClient.id | quote }}
+        CLIENT_SECRET: "{{ `{{ .password }}` }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: {{ .Values.mcpTestClient.secretName }}
+{{- end }}

--- a/helm-charts/hydra/templates/mcp-test-client.yaml
+++ b/helm-charts/hydra/templates/mcp-test-client.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.mcpTestClient.enabled }}
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: {{ .Values.mcpTestClient.id }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    # The previous wave guarantees Maester reads the deterministic client ID
+    # and generated secret instead of racing to generate different credentials.
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  accessTokenStrategy: jwt
+  clientName: {{ .Values.mcpTestClient.name | quote }}
+  deletionPolicy: delete
+  grantTypes:
+    - client_credentials
+  responseTypes:
+    - token
+  scopeArray:
+    - {{ .Values.mcpTestClient.scope | quote }}
+  secretName: {{ .Values.mcpTestClient.secretName }}
+  tokenEndpointAuthMethod: client_secret_basic
+  tokenLifespans:
+    client_credentials_grant_access_token_lifespan: 15m
+{{- end }}

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -22,6 +22,22 @@ database:
   secretName: hydra-20260726-0001
   caSecretName: hydra-20260726-0001-ca
 
+clientController:
+  enabled: true
+  serviceAccountName: hydra-maester-account
+
+mcpTestClient:
+  enabled: true
+  id: mcp-test-client
+  name: MCP end-to-end test client
+  scope: mcp
+  secretName: mcp-test-client
+  password:
+    length: 48
+    digits: 8
+    symbols: 8
+    symbolCharacters: "!&*+"
+
 hydra:
   fullnameOverride: hydra
   replicaCount: 2
@@ -152,9 +168,28 @@ hydra:
       minAvailable: 1
 
   maester:
-    # Client onboarding comes later; avoid running a controller and CRDs until
-    # there is an OAuth2Client for it to manage.
-    enabled: false
+    enabled: true
+
+  hydra-maester:
+    fullnameOverride: hydra-maester
+    singleNamespaceMode: true
+    image:
+      tag: v0.0.42@sha256:0a7a2bfd0e7d4c730faec3d6fbd6184e8ed2aa9f88c0a88a8f5a35e18385d156
+    deployment:
+      # Initial controller sizing: Maester reconciles one small client CR and
+      # has no live metrics yet. Start small and revisit after KRR has history.
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+          ephemeral-storage: 64Mi
+        limits:
+          memory: 64Mi
+          ephemeral-storage: 64Mi
+    pdb:
+      enabled: true
+      spec:
+        minAvailable: 1
 
   test:
     busybox:

--- a/helm-charts/kubernetes-mcp-server/templates/authorization-policy.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/authorization-policy.yaml
@@ -17,7 +17,15 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+            # RequestAuthentication validates the issuer; this additionally
+            # requires a signed JWT rather than accepting anonymous ingress.
+            requestPrincipals:
+              - "*"
       to:
         - operation:
             ports:
               - {{ index .Values "kubernetes-mcp-server" "service" "port" | quote }}
+      when:
+        - key: request.auth.claims[sub]
+          values:
+            {{- toYaml .Values.authentication.allowedSubjects | nindent 12 }}

--- a/helm-charts/kubernetes-mcp-server/templates/request-authentication.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/request-authentication.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ index .Values "kubernetes-mcp-server" "fullnameOverride" }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # Ambient waypoints require targetRefs; a selector would be ignored.
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ index .Values "kubernetes-mcp-server" "fullnameOverride" }}
+  jwtRules:
+    - issuer: {{ .Values.authentication.issuer | quote }}
+      jwksUri: {{ .Values.authentication.jwksUri | quote }}
+{{- end }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -4,6 +4,13 @@ namespace: kubernetes-mcp-server
 vpa:
   enabled: true
 
+authentication:
+  enabled: true
+  issuer: https://auth.siutsin.com/
+  jwksUri: https://auth.siutsin.com/.well-known/jwks.json
+  allowedSubjects:
+    - mcp-test-client
+
 kubernetes-mcp-server:
   image:
     registry: quay.io
@@ -48,4 +55,3 @@ kubernetes-mcp-server:
         - weight: 100
           podAffinityTerm:
             topologyKey: kubernetes.io/hostname
-

--- a/helm-charts/unifi-mcp/templates/authorization-policy.yaml
+++ b/helm-charts/unifi-mcp/templates/authorization-policy.yaml
@@ -17,6 +17,10 @@ spec:
         - source:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+            # RequestAuthentication validates the issuer; this additionally
+            # requires a signed JWT rather than accepting anonymous ingress.
+            requestPrincipals:
+              - "*"
       to:
         - operation:
             ports:
@@ -25,3 +29,7 @@ spec:
               - {{ $c.port | quote }}
               {{- end }}
               {{- end }}
+      when:
+        - key: request.auth.claims[sub]
+          values:
+            {{- toYaml .Values.authentication.allowedSubjects | nindent 12 }}

--- a/helm-charts/unifi-mcp/templates/request-authentication.yaml
+++ b/helm-charts/unifi-mcp/templates/request-authentication.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  # Ambient waypoints require targetRefs; a selector would be ignored.
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Values.name }}
+  jwtRules:
+    - issuer: {{ .Values.authentication.issuer | quote }}
+      jwksUri: {{ .Values.authentication.jwksUri | quote }}
+{{- end }}

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -5,6 +5,13 @@ gateway:
   name: gateway
   namespace: gateway
 
+authentication:
+  enabled: true
+  issuer: https://auth.siutsin.com/
+  jwksUri: https://auth.siutsin.com/.well-known/jwks.json
+  allowedSubjects:
+    - mcp-test-client
+
 externalSecret:
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
## Summary

- enable the bundled Hydra Maester controller in single-namespace mode
- reconcile a deterministic client-credentials test client with a generated Kubernetes-only secret
- validate Hydra JWTs at the Kubernetes and UniFi MCP services
- require the `mcp-test-client` subject in addition to the ingress gateway workload identity

## Security

- Hydra admin remains private and only permits the Maester service account
- the client secret is generated once, immutable, and never stored in Git or 1Password
- tokens are signed JWTs with a 15-minute lifetime
- anonymous, malformed, expired, and wrong-subject tokens are denied

## Verification

- `make test`
- server-side dry-run of both Istio RequestAuthentication and AuthorizationPolicy resources
- Helm rendering confirms the Maester image is digest-pinned and resources meet repository policy

After merge, live verification will request a client-credentials token and exercise both MCP initialize endpoints with no token, an invalid token, and the valid Hydra token.