### PR TITLE
fix(hydra): scope Maester cache to namespace

### DIFF
--- a/helm-charts/hydra/templates/mcp-test-client.yaml
+++ b/helm-charts/hydra/templates/mcp-test-client.yaml
@@ -10,8 +10,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   accessTokenStrategy: jwt
+  # Declare CRD defaults explicitly so Kubernetes defaulting does not leave
+  # Argo CD reporting this client as perpetually OutOfSync.
+  backChannelLogoutSessionRequired: false
   clientName: {{ .Values.mcpTestClient.name | quote }}
   deletionPolicy: delete
+  frontChannelLogoutSessionRequired: false
   grantTypes:
     - client_credentials
   responseTypes:
@@ -19,6 +23,8 @@ spec:
   scopeArray:
     - {{ .Values.mcpTestClient.scope | quote }}
   secretName: {{ .Values.mcpTestClient.secretName }}
+  skipConsent: false
+  skipLogoutConsent: false
   tokenEndpointAuthMethod: client_secret_basic
   tokenLifespans:
     client_credentials_grant_access_token_lifespan: 15m

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -176,6 +176,11 @@ hydra:
     image:
       tag: v0.0.42@sha256:0a7a2bfd0e7d4c730faec3d6fbd6184e8ed2aa9f88c0a88a8f5a35e18385d156
     deployment:
+      extraEnv:
+        # Maester v0.0.42 scopes its controller cache from this environment
+        # variable; the --namespace flag alone only filters reconciliation.
+        - name: NAMESPACE
+          value: "{{ .Release.Namespace }}"
       # Initial controller sizing: Maester reconciles one small client CR and
       # has no live metrics yet. Start small and revisit after KRR has history.
       resources:


### PR DESCRIPTION
## Summary
- scope the Hydra Maester controller-runtime cache to its deployment namespace
- declare OAuth2Client CRD defaults to avoid persistent Argo CD drift
- preserve namespace-only Secret RBAC

## Validation
- `make test`
- rendered Maester deployment includes `NAMESPACE=hydra`
- rendered OAuth2Client includes all defaulted boolean fields

Follow-up to #2952.