### PR TITLE
fix(mcp): enforce JWTs at ingress gateway

### DIFF
--- a/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.name }}-authentication
+  namespace: {{ .Values.namespace }}
+spec:
+  # Envoy Gateway resolves backends directly to pod endpoints, so ingress can
+  # bypass a Service-attached ambient waypoint. Enforce JWTs on the HTTPRoute;
+  # the Istio policy remains defense-in-depth for Service-addressed mesh calls.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.name }}-internal
+  jwt:
+    providers:
+      - name: hydra
+        issuer: {{ .Values.authentication.issuer | quote }}
+        remoteJWKS:
+          uri: {{ .Values.authentication.jwksUri | quote }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-mcp-client
+        action: Allow
+        principal:
+          jwt:
+            provider: hydra
+            scopes:
+              {{- toYaml .Values.authentication.requiredScopes | nindent 14 }}
+            claims:
+              - name: sub
+                valueType: String
+                values:
+                  {{- toYaml .Values.authentication.allowedSubjects | nindent 18 }}
+{{- end }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -10,6 +10,8 @@ authentication:
   jwksUri: https://auth.siutsin.com/.well-known/jwks.json
   allowedSubjects:
     - mcp-test-client
+  requiredScopes:
+    - mcp
 
 kubernetes-mcp-server:
   image:

--- a/helm-charts/unifi-mcp/templates/security-policy.yaml
+++ b/helm-charts/unifi-mcp/templates/security-policy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.name }}-authentication
+  namespace: {{ .Values.namespace }}
+spec:
+  # Envoy Gateway resolves backends directly to pod endpoints, so ingress can
+  # bypass a Service-attached ambient waypoint. Enforce JWTs on the HTTPRoute;
+  # the Istio policy remains defense-in-depth for Service-addressed mesh calls.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.name }}-internal
+  jwt:
+    providers:
+      - name: hydra
+        issuer: {{ .Values.authentication.issuer | quote }}
+        remoteJWKS:
+          uri: {{ .Values.authentication.jwksUri | quote }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-mcp-client
+        action: Allow
+        principal:
+          jwt:
+            provider: hydra
+            scopes:
+              {{- toYaml .Values.authentication.requiredScopes | nindent 14 }}
+            claims:
+              - name: sub
+                valueType: String
+                values:
+                  {{- toYaml .Values.authentication.allowedSubjects | nindent 18 }}
+{{- end }}

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -11,6 +11,8 @@ authentication:
   jwksUri: https://auth.siutsin.com/.well-known/jwks.json
   allowedSubjects:
     - mcp-test-client
+  requiredScopes:
+    - mcp
 
 externalSecret:
   refreshInterval: 1h


### PR DESCRIPTION
## Summary
- enforce Hydra JWT authentication on both MCP `HTTPRoute` resources with Envoy Gateway `SecurityPolicy`
- require the `mcp-test-client` subject and `mcp` scope
- retain Istio waypoint policies as defense-in-depth for Service-addressed mesh traffic

Envoy Gateway resolves route backends to pod endpoints, so ingress bypasses the Service-attached ambient waypoint even though the waypoint policy is accepted and rendered. Route-level policy closes that gap.

## Validation
- `make test`
- both rendered `SecurityPolicy` resources pass `kubectl apply --dry-run=server`
- Hydra client is `Ready=True` and issues a signed 15-minute JWT with `sub=mcp-test-client` and `scp=[mcp]`