### PR TITLE
fix(mcp): declare JWKS cache default

### DIFF
--- a/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
@@ -17,6 +17,8 @@ spec:
       - name: hydra
         issuer: {{ .Values.authentication.issuer | quote }}
         remoteJWKS:
+          # Match the Envoy Gateway CRD default explicitly to avoid Argo drift.
+          cacheDuration: 300s
           uri: {{ .Values.authentication.jwksUri | quote }}
   authorization:
     defaultAction: Deny

--- a/helm-charts/unifi-mcp/templates/security-policy.yaml
+++ b/helm-charts/unifi-mcp/templates/security-policy.yaml
@@ -17,6 +17,8 @@ spec:
       - name: hydra
         issuer: {{ .Values.authentication.issuer | quote }}
         remoteJWKS:
+          # Match the Envoy Gateway CRD default explicitly to avoid Argo drift.
+          cacheDuration: 300s
           uri: {{ .Values.authentication.jwksUri | quote }}
   authorization:
     defaultAction: Deny


### PR DESCRIPTION
## Summary
- declare Envoy Gateway’s `remoteJWKS.cacheDuration` default explicitly on both MCP security policies
- eliminate post-admission Argo CD drift without changing runtime behavior

## Validation
- `make test`
- live policies are accepted and enforce missing/invalid/valid JWT as `401/401/200` on both MCP routes