### PR TITLE
docs(changedetection): document Amazon Restock watch script convention

### DIFF
--- a/helm-charts/changedetection/AGENTS.md
+++ b/helm-charts/changedetection/AGENTS.md
@@ -21,6 +21,12 @@ diagnostics or recovery, then backport the chart change.
   model configuration. A request may complete after the client sees a timeout.
 - For variant-specific product watches, make extraction target the exact
   variant. Generic product metadata often points at a default variant.
+- Amazon Restock watches: use one shared `webdriver_js_execute_code` on every
+  Amazon Restock watch (featured buy-box price → inject Product JSON-LD;
+  used-only / "See All Buying Options" / no featured offer → inject
+  "no featured offers available" into the stock-script scan band). Keep all
+  Amazon watches on the same script so stock and price semantics stay
+  consistent. Datastore-only; not in the chart.
 - For workload-only changes, restart the workload or let Argo CD reconcile. Do
   not reboot nodes for this app.
 - Validate focused changes with `helm template`, then run `make test`.


### PR DESCRIPTION
## Summary

- Records the shared `webdriver_js_execute_code` convention already in use across Amazon Restock watches, so it stays consistent going forward: inject Product JSON-LD when a featured buy-box price exists, otherwise mark "no featured offers available" for used-only/no-offer pages.
- Datastore-only setting (the watch's own JS execute field), not tracked in the chart — doc-only change, no chart/values.yaml edit.

## Test plan

- [x] `markdownlint-cli2` clean
- [x] `make test` passes