### PR TITLE
feat(jwks): publish MCP OAuth client public JWKS

### DIFF
--- a/jwks/README.md
+++ b/jwks/README.md
@@ -1,0 +1,7 @@
+# Public JWKS
+
+Public signing keys only. Never put private keys here.
+
+| File                        | Key id         |
+|-----------------------------|----------------|
+| `otaru-mcp-oauth.jwks.json` | `mcp-20260728` |

--- a/jwks/otaru-mcp-oauth.jwks.json
+++ b/jwks/otaru-mcp-oauth.jwks.json
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "crv": "P-256",
+      "use": "sig",
+      "alg": "ES256",
+      "kid": "mcp-20260728",
+      "x": "rjX02NIdhAKJQSAsw5Gpe90TXNTrMSSd--WTD03m0Hk",
+      "y": "2Jr7u5KKnKF3qc9WPXRIccJfn-7Ahikc1mk4n3Y8lv4"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a root `jwks/` catalogue for **public** OAuth client signing keys
- Publish the MCP OAuth client ES256 / P-256 JWKS (`kid`: `mcp-20260728`)
- Intended for Hydra `jwks_uri` / Maester and future federation; private keys stay in 1Password

## Test plan

- [x] `make test`
- [ ] Confirm raw URL resolves after merge:
  `https://raw.githubusercontent.com/siutsin/otaru/master/jwks/otaru-mcp-oauth.jwks.json`