### PR TITLE
feat(hydra): register MCP OAuth client with private_key_jwt

### DIFF
--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -23,8 +23,7 @@ spec:
               - "4444"
 ---
 # Hydra's administrative API can create clients, keys, and trust relationships.
-# Keep it reachable only through explicit future service-level policy changes;
-# it must never inherit the public issuer's gateway access.
+# Keep it closed to the ingress gateway; only the client controller may call it.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -36,4 +35,16 @@ spec:
     - group: ""
       kind: Service
       name: hydra-admin
+  {{- if .Values.clientController.enabled }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/{{ .Values.clientController.serviceAccountName }}
+      to:
+        - operation:
+            ports:
+              - "4445"
+  {{- else }}
   rules: []
+  {{- end }}

--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -22,8 +22,6 @@ spec:
             ports:
               - "4444"
 ---
-# Hydra's administrative API can create clients, keys, and trust relationships.
-# Keep it closed to the ingress gateway; only the client controller may call it.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/helm-charts/hydra/templates/oauth-client-secret.yaml
+++ b/helm-charts/hydra/templates/oauth-client-secret.yaml
@@ -1,15 +1,35 @@
 {{- if .Values.oauthClient.enabled }}
-# Nominal client credentials for Maester only. Token endpoint authentication
-# uses private_key_jwt; this secret must not be treated as a real password.
-apiVersion: v1
-kind: Secret
+# Nominal client credentials for Maester. Token endpoint auth is private_key_jwt;
+# the password field is still sourced from 1Password so rotation is operator-owned.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: {{ .Values.oauthClient.secretName }}
   namespace: {{ .Values.namespace }}
   annotations:
+    # Ready before OAuth2Client (wave 2) so Maester sees CLIENT_ID/CLIENT_SECRET.
     argocd.argoproj.io/sync-wave: "1"
-type: Opaque
-stringData:
-  CLIENT_ID: {{ .Values.oauthClient.id | quote }}
-  CLIENT_SECRET: unused-private-key-jwt
+spec:
+  refreshInterval: {{ .Values.oauthClient.externalSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.oauthClient.externalSecret.secretStoreRef.kind }}
+    name: {{ .Values.oauthClient.externalSecret.secretStoreRef.name }}
+  target:
+    name: {{ .Values.oauthClient.secretName }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        CLIENT_ID: {{ .Values.oauthClient.id | quote }}
+        CLIENT_SECRET: "{{ `{{ .password }}` }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        nullBytePolicy: Ignore
+        key: {{ .Values.oauthClient.externalSecret.remoteRef.key | quote }}
+        metadataPolicy: None
+        property: {{ .Values.oauthClient.externalSecret.remoteRef.property | quote }}
 {{- end }}

--- a/helm-charts/hydra/templates/oauth-client-secret.yaml
+++ b/helm-charts/hydra/templates/oauth-client-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.oauthClient.enabled }}
+# Nominal client credentials for Maester only. Token endpoint authentication
+# uses private_key_jwt; this secret must not be treated as a real password.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.oauthClient.secretName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+type: Opaque
+stringData:
+  CLIENT_ID: {{ .Values.oauthClient.id | quote }}
+  CLIENT_SECRET: unused-private-key-jwt
+{{- end }}

--- a/helm-charts/hydra/templates/oauth-client-secret.yaml
+++ b/helm-charts/hydra/templates/oauth-client-secret.yaml
@@ -1,13 +1,10 @@
 {{- if .Values.oauthClient.enabled }}
-# Nominal client credentials for Maester. Token endpoint auth is private_key_jwt;
-# the password field is still sourced from 1Password so rotation is operator-owned.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.oauthClient.secretName }}
   namespace: {{ .Values.namespace }}
   annotations:
-    # Ready before OAuth2Client (wave 2) so Maester sees CLIENT_ID/CLIENT_SECRET.
     argocd.argoproj.io/sync-wave: "1"
 spec:
   refreshInterval: {{ .Values.oauthClient.externalSecret.refreshInterval }}

--- a/helm-charts/hydra/templates/oauth-client.yaml
+++ b/helm-charts/hydra/templates/oauth-client.yaml
@@ -5,12 +5,10 @@ metadata:
   name: {{ .Values.oauthClient.id }}
   namespace: {{ .Values.namespace }}
   annotations:
-    # Secret with CLIENT_ID must exist before Maester reconciles this CR.
     argocd.argoproj.io/sync-wave: "2"
 spec:
   accessTokenStrategy: jwt
-  # Declare CRD defaults explicitly so Kubernetes defaulting does not leave
-  # Argo CD reporting this client as perpetually OutOfSync.
+  # Explicit CRD defaults so Kubernetes defaulting does not leave Argo CD OutOfSync.
   backChannelLogoutSessionRequired: false
   clientName: {{ .Values.oauthClient.name | quote }}
   deletionPolicy: delete
@@ -24,7 +22,6 @@ spec:
     {{- range .Values.oauthClient.scopes }}
     - {{ . | quote }}
     {{- end }}
-  # Maester always requires a Secret; token auth uses private_key_jwt only.
   secretName: {{ .Values.oauthClient.secretName }}
   skipConsent: false
   skipLogoutConsent: false

--- a/helm-charts/hydra/templates/oauth-client.yaml
+++ b/helm-charts/hydra/templates/oauth-client.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.oauthClient.enabled }}
+apiVersion: hydra.ory.sh/v1alpha1
+kind: OAuth2Client
+metadata:
+  name: {{ .Values.oauthClient.id }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    # Secret with CLIENT_ID must exist before Maester reconciles this CR.
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  accessTokenStrategy: jwt
+  # Declare CRD defaults explicitly so Kubernetes defaulting does not leave
+  # Argo CD reporting this client as perpetually OutOfSync.
+  backChannelLogoutSessionRequired: false
+  clientName: {{ .Values.oauthClient.name | quote }}
+  deletionPolicy: delete
+  frontChannelLogoutSessionRequired: false
+  grantTypes:
+    - client_credentials
+  jwksUri: {{ .Values.oauthClient.jwksUri | quote }}
+  responseTypes:
+    - token
+  scopeArray:
+    {{- range .Values.oauthClient.scopes }}
+    - {{ . | quote }}
+    {{- end }}
+  # Maester always requires a Secret; token auth uses private_key_jwt only.
+  secretName: {{ .Values.oauthClient.secretName }}
+  skipConsent: false
+  skipLogoutConsent: false
+  tokenEndpointAuthMethod: private_key_jwt
+  tokenEndpointAuthSigningAlg: {{ .Values.oauthClient.tokenEndpointAuthSigningAlg | quote }}
+  tokenLifespans:
+    client_credentials_grant_access_token_lifespan: {{ .Values.oauthClient.accessTokenLifespan | quote }}
+{{- end }}

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -22,6 +22,23 @@ database:
   secretName: hydra-20260726-0001
   caSecretName: hydra-20260726-0001-ca
 
+# Allow Maester to call Hydra admin; keep the gateway off that API.
+clientController:
+  enabled: true
+  serviceAccountName: hydra-maester-account
+
+# Machine OAuth client for MCP (private_key_jwt + public JWKS in the repo).
+oauthClient:
+  enabled: true
+  id: otaru-mcp
+  name: Otaru MCP machine client
+  secretName: otaru-mcp
+  scopes:
+    - mcp
+  tokenEndpointAuthSigningAlg: ES256
+  accessTokenLifespan: 15m
+  jwksUri: https://raw.githubusercontent.com/siutsin/otaru/master/jwks/otaru-mcp-oauth.jwks.json
+
 hydra:
   fullnameOverride: hydra
   replicaCount: 2
@@ -152,9 +169,33 @@ hydra:
       minAvailable: 1
 
   maester:
-    # Client onboarding is paused; avoid running a controller and CRDs until
-    # there is an OAuth2Client for it to manage.
-    enabled: false
+    enabled: true
+
+  hydra-maester:
+    fullnameOverride: hydra-maester
+    singleNamespaceMode: true
+    image:
+      tag: v0.0.42@sha256:0a7a2bfd0e7d4c730faec3d6fbd6184e8ed2aa9f88c0a88a8f5a35e18385d156
+    deployment:
+      extraEnv:
+        # Maester v0.0.42 scopes its controller cache from this environment
+        # variable; the --namespace flag alone only filters reconciliation.
+        - name: NAMESPACE
+          value: "{{ .Release.Namespace }}"
+      # Initial controller sizing: Maester reconciles one small client CR and
+      # has no live metrics yet. Start small and revisit after KRR has history.
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+          ephemeral-storage: 64Mi
+        limits:
+          memory: 64Mi
+          ephemeral-storage: 64Mi
+    pdb:
+      enabled: true
+      spec:
+        minAvailable: 1
 
   test:
     busybox:

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -38,6 +38,15 @@ oauthClient:
   tokenEndpointAuthSigningAlg: ES256
   accessTokenLifespan: 15m
   jwksUri: https://raw.githubusercontent.com/siutsin/otaru/master/jwks/otaru-mcp-oauth.jwks.json
+  # Nominal CLIENT_SECRET for Maester only (1Password item title otaru-mcp).
+  externalSecret:
+    refreshInterval: 24h
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: onepassword-secret-store
+    remoteRef:
+      key: otaru-mcp
+      property: password
 
 hydra:
   fullnameOverride: hydra

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -22,12 +22,10 @@ database:
   secretName: hydra-20260726-0001
   caSecretName: hydra-20260726-0001-ca
 
-# Allow Maester to call Hydra admin; keep the gateway off that API.
 clientController:
   enabled: true
   serviceAccountName: hydra-maester-account
 
-# Machine OAuth client for MCP (private_key_jwt + public JWKS in the repo).
 oauthClient:
   enabled: true
   id: otaru-mcp
@@ -38,7 +36,6 @@ oauthClient:
   tokenEndpointAuthSigningAlg: ES256
   accessTokenLifespan: 15m
   jwksUri: https://raw.githubusercontent.com/siutsin/otaru/master/jwks/otaru-mcp-oauth.jwks.json
-  # Nominal CLIENT_SECRET for Maester only (1Password item title otaru-mcp).
   externalSecret:
     refreshInterval: 24h
     secretStoreRef:

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -25,6 +25,7 @@ clusterSecretStorePolicy:
     hydra:
       - b2-secret-cloudnative-pg
       - Ory
+      - otaru-mcp
     umami:
       - Umami
       - b2-secret-cloudnative-pg


### PR DESCRIPTION
## Summary

- Re-enable Hydra Maester for GitOps OAuth client management
- Register `otaru-mcp` with `client_credentials` + `private_key_jwt` (`ES256`)
- Point `jwksUri` at the public repo JWKS (`kid` `mcp-20260728`)
- Allow Hydra admin only from `hydra-maester-account`; gateway stays blocked
- Maester still requires a Secret; it holds a non-auth dummy `CLIENT_SECRET`

## Test plan

- [x] `make test`
- [x] Cluster can fetch `https://raw.githubusercontent.com/siutsin/otaru/master/jwks/otaru-mcp-oauth.jwks.json`
- [ ] After sync: Maester Ready, `OAuth2Client/otaru-mcp` Ready
- [ ] Mint token with local private key assertion against `auth.siutsin.com`