### PR TITLE
feat(mcp): enforce EG SecurityPolicy JWT on HTTPRoutes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,11 @@ Ready on a wrong probe path). Use a peer chart (for example `httpbin`,
 - [ ] Ambient mesh: `AuthorizationPolicy` with `targetRefs` on the `Service` and
   `from.source.principals` allowing the gateway SA
   (`cluster.local/ns/gateway/sa/gateway`) for ingress-backed ports
+- [ ] JWT-protected MCP (or similar) ingress: Envoy Gateway `SecurityPolicy`
+  targeting the HTTPRoute (issuer/JWKS + deny-by-default authz). Mesh AuthZ is
+  not enough because EG can bypass Service waypoints via pod IPs. Add the
+  namespace to `requireSecurityPolicy.namespaces` in
+  `helm-charts/kyverno-policy/values.yaml`
 - [ ] Secrets: `ExternalSecret` → ClusterSecretStore `onepassword-secret-store`,
   plus Reloader (`reloader.stakater.com/auto: "true"`) when secret rotation
   should restart pods

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,11 +173,12 @@ Ready on a wrong probe path). Use a peer chart (for example `httpbin`,
 - [ ] Ambient mesh: `AuthorizationPolicy` with `targetRefs` on the `Service` and
   `from.source.principals` allowing the gateway SA
   (`cluster.local/ns/gateway/sa/gateway`) for ingress-backed ports
-- [ ] JWT-protected MCP (or similar) ingress: Envoy Gateway `SecurityPolicy`
-  targeting the HTTPRoute (issuer/JWKS + deny-by-default authz). Mesh AuthZ is
-  not enough because EG can bypass Service waypoints via pod IPs. Add the
-  namespace to `requireSecurityPolicy.namespaces` in
-  `helm-charts/kyverno-policy/values.yaml`
+- [ ] HTTPRoute JWT: Envoy Gateway `SecurityPolicy` targeting the route
+  (issuer/JWKS + deny-by-default authz). Mesh AuthZ is not enough because EG
+  can bypass Service waypoints via pod IPs. ClusterPolicy
+  `require-security-policy` enforces this for every new HTTPRoute; do not add
+  the route to `requireSecurityPolicy.excludedRoutes` unless deliberately
+  grandfathering without JWT
 - [ ] Secrets: `ExternalSecret` → ClusterSecretStore `onepassword-secret-store`,
   plus Reloader (`reloader.stakater.com/auto: "true"`) when secret rotation
   should restart pods

--- a/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/security-policy.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.name }}-authentication
+  namespace: {{ .Values.namespace }}
+spec:
+  # Envoy Gateway resolves backends to pod endpoints and can bypass a
+  # Service-attached ambient waypoint. Enforce JWTs on the HTTPRoute; Istio
+  # AuthorizationPolicy remains defence-in-depth for Service-addressed mesh calls.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.name }}-internal
+  jwt:
+    providers:
+      - name: hydra
+        issuer: {{ .Values.authentication.issuer | quote }}
+        remoteJWKS:
+          cacheDuration: 300s
+          uri: {{ .Values.authentication.jwksUri | quote }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-mcp-client
+        action: Allow
+        principal:
+          jwt:
+            provider: hydra
+            scopes:
+              {{- toYaml .Values.authentication.requiredScopes | nindent 14 }}
+            claims:
+              - name: sub
+                valueType: String
+                values:
+                  {{- toYaml .Values.authentication.allowedSubjects | nindent 18 }}
+{{- end }}

--- a/helm-charts/kubernetes-mcp-server/values.yaml
+++ b/helm-charts/kubernetes-mcp-server/values.yaml
@@ -6,8 +6,12 @@ vpa:
 
 authentication:
   enabled: true
+  issuer: https://auth.siutsin.com/
+  jwksUri: https://auth.siutsin.com/.well-known/jwks.json
   allowedSubjects:
     - otaru-mcp
+  requiredScopes:
+    - mcp
 
 kubernetes-mcp-server:
   image:

--- a/helm-charts/kyverno-policy/templates/require-security-policy-rbac.yaml
+++ b/helm-charts/kyverno-policy/templates/require-security-policy-rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.requireSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-require-security-policy-context
+rules:
+  - apiGroups:
+      - gateway.envoyproxy.io
+    resources:
+      - securitypolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-require-security-policy-context
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-require-security-policy-context
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: kyverno-background-controller
+    namespace: {{ .Values.namespace }}
+  - kind: ServiceAccount
+    name: kyverno-reports-controller
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/kyverno-policy/templates/require-security-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-security-policy.yaml
@@ -17,9 +17,16 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
+{{- with .Values.requireSecurityPolicy.excludedRoutes }}
+      exclude:
+        any:
+{{- range . }}
+          - resources:
               namespaces:
-{{- range .Values.requireSecurityPolicy.namespaces }}
-                - {{ . }}
+                - {{ .namespace }}
+              names:
+                - {{ .name }}
+{{- end }}
 {{- end }}
       context:
         - name: securityPolicyCount
@@ -37,12 +44,13 @@ spec:
         allowExistingViolations: true
         failureAction: {{ .Values.requireSecurityPolicy.failureAction }}
         message: >-
-          HTTPRoutes in JWT-protected namespaces must have a SecurityPolicy in
-          the same namespace with targetRefs pointing at that HTTPRoute, at
-          least one jwt.providers entry, and authorization.defaultAction Deny.
-          Envoy Gateway can resolve backends to pod IPs and bypass Service
-          waypoints, so mesh AuthorizationPolicy alone is not enough. Annotate
-          gateway.otaru.io/skip-security-policy=true only for deliberate opt-outs.
+          HTTPRoutes must have a SecurityPolicy in the same namespace with
+          targetRefs pointing at that HTTPRoute, at least one jwt.providers
+          entry, and authorization.defaultAction Deny. Envoy Gateway can
+          resolve backends to pod IPs and bypass Service waypoints, so mesh
+          AuthorizationPolicy alone is not enough. Pre-existing routes are
+          listed under requireSecurityPolicy.excludedRoutes; for a one-off
+          opt-out set gateway.otaru.io/skip-security-policy=true.
         deny:
           conditions:
             all:

--- a/helm-charts/kyverno-policy/templates/require-security-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-security-policy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.requireSecurityPolicy.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-security-policy
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+    - name: require-security-policy-for-httproutes
+      match:
+        any:
+          - resources:
+              kinds:
+                - HTTPRoute
+              operations:
+                - CREATE
+                - UPDATE
+              namespaces:
+{{- range .Values.requireSecurityPolicy.namespaces }}
+                - {{ . }}
+{{- end }}
+      context:
+        - name: securityPolicyCount
+          apiCall:
+            method: GET
+            urlPath: "/apis/gateway.envoyproxy.io/v1alpha1/namespaces/{{ `{{ request.namespace }}` }}/securitypolicies"
+            jmesPath: >-
+              items[?length((spec.targetRefs || `[]`)[?group == 'gateway.networking.k8s.io' &&
+              kind == 'HTTPRoute' && name == '{{ `{{ request.object.metadata.name }}` }}']) > `0` &&
+              length(spec.jwt.providers || `[]`) > `0` &&
+              spec.authorization.defaultAction == 'Deny'] | length(@)
+            default: 0
+      skipBackgroundRequests: true
+      validate:
+        allowExistingViolations: true
+        failureAction: {{ .Values.requireSecurityPolicy.failureAction }}
+        message: >-
+          HTTPRoutes in JWT-protected namespaces must have a SecurityPolicy in
+          the same namespace with targetRefs pointing at that HTTPRoute, at
+          least one jwt.providers entry, and authorization.defaultAction Deny.
+          Envoy Gateway can resolve backends to pod IPs and bypass Service
+          waypoints, so mesh AuthorizationPolicy alone is not enough. Annotate
+          gateway.otaru.io/skip-security-policy=true only for deliberate opt-outs.
+        deny:
+          conditions:
+            all:
+              - key: "{{ `{{ securityPolicyCount }}` }}"
+                operator: Equals
+                value: 0
+              - key: {{ printf "{{ request.object.metadata.annotations.\"gateway.otaru.io/skip-security-policy\" || '' }}" | quote }}
+                operator: NotEquals
+                value: "true"
+  validationFailureAction: {{ .Values.requireSecurityPolicy.failureAction }}
+{{- end }}

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -65,16 +65,58 @@ meshAuthorizationPolicy:
     matchLabels:
       istio.io/dataplane-mode: ambient
 
-# Envoy Gateway can hit pod IPs and bypass Service waypoints, so MCP
-# HTTPRoutes need a SecurityPolicy (JWT + deny-by-default) in addition to
-# mesh AuthorizationPolicy. Keep this list aligned with charts that ship
-# security-policy.yaml (kubernetes-mcp-server, unifi-mcp).
+# Cluster-wide: every HTTPRoute needs a companion Envoy Gateway
+# SecurityPolicy (JWT + deny-by-default). EG can hit pod IPs and bypass
+# Service waypoints, so mesh AuthorizationPolicy alone is not enough.
+# excludedRoutes lists pre-existing routes grandfathered without JWT;
+# remove entries only when that route gains a real SecurityPolicy.
+# k8s-mcp-internal and unifi-mcp-internal are intentionally not listed.
 requireSecurityPolicy:
   enabled: true
   failureAction: Enforce
-  namespaces:
-    - kubernetes-mcp-server
-    - unifi-mcp
+  excludedRoutes:
+    - namespace: argocd
+      name: argocd-internal
+    - namespace: argocd
+      name: argocd-public
+    - namespace: blocky
+      name: blocky-internal-doh
+    - namespace: changedetection
+      name: changedetection-internal
+    - namespace: cyberchef
+      name: cyberchef-internal
+    - namespace: excalidraw
+      name: excalidraw-internal
+    - namespace: gateway
+      name: kiali-internal
+    - namespace: home-assistant
+      name: home-assistant-internal
+    - namespace: httpbin
+      name: httpbin-public
+    - namespace: hydra
+      name: hydra-internal
+    - namespace: jsoncrack
+      name: jsoncrack-internal
+    - namespace: jung2bot
+      name: jung2bot-public
+    - namespace: longhorn-system
+      name: longhorn-internal
+    - namespace: monitoring
+      name: monitoring-grafana-internal
+    - namespace: monitoring
+      name: monitoring-loki-internal
+    - namespace: monitoring
+      name: monitoring-prometheus-internal
+    - namespace: openclaw
+      name: openclaw-internal
+    - namespace: teslamate
+      name: teslamate-grafana-internal
+    - namespace: teslamate
+      name: teslamate-internal
+    - namespace: umami
+      name: umami-collect
+    - namespace: umami
+      name: umami-internal
 
 barmanObjectStorePolicy:
   enabled: true

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -65,6 +65,17 @@ meshAuthorizationPolicy:
     matchLabels:
       istio.io/dataplane-mode: ambient
 
+# Envoy Gateway can hit pod IPs and bypass Service waypoints, so MCP
+# HTTPRoutes need a SecurityPolicy (JWT + deny-by-default) in addition to
+# mesh AuthorizationPolicy. Keep this list aligned with charts that ship
+# security-policy.yaml (kubernetes-mcp-server, unifi-mcp).
+requireSecurityPolicy:
+  enabled: true
+  failureAction: Enforce
+  namespaces:
+    - kubernetes-mcp-server
+    - unifi-mcp
+
 barmanObjectStorePolicy:
   enabled: true
   allowedNamespaces:

--- a/helm-charts/unifi-mcp/templates/security-policy.yaml
+++ b/helm-charts/unifi-mcp/templates/security-policy.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.name }}-authentication
+  namespace: {{ .Values.namespace }}
+spec:
+  # Envoy Gateway resolves backends to pod endpoints and can bypass a
+  # Service-attached ambient waypoint. Enforce JWTs on the HTTPRoute; Istio
+  # AuthorizationPolicy remains defence-in-depth for Service-addressed mesh calls.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.name }}-internal
+  jwt:
+    providers:
+      - name: hydra
+        issuer: {{ .Values.authentication.issuer | quote }}
+        remoteJWKS:
+          cacheDuration: 300s
+          uri: {{ .Values.authentication.jwksUri | quote }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-mcp-client
+        action: Allow
+        principal:
+          jwt:
+            provider: hydra
+            scopes:
+              {{- toYaml .Values.authentication.requiredScopes | nindent 14 }}
+            claims:
+              - name: sub
+                valueType: String
+                values:
+                  {{- toYaml .Values.authentication.allowedSubjects | nindent 18 }}
+{{- end }}

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -7,8 +7,12 @@ gateway:
 
 authentication:
   enabled: true
+  issuer: https://auth.siutsin.com/
+  jwksUri: https://auth.siutsin.com/.well-known/jwks.json
   allowedSubjects:
     - otaru-mcp
+  requiredScopes:
+    - mcp
 
 externalSecret:
   refreshInterval: 1h


### PR DESCRIPTION
## Summary

- Restore Envoy Gateway `SecurityPolicy` on the k8s-mcp and unifi-mcp internal `HTTPRoute`s (Hydra issuer/JWKS, `sub=otaru-mcp`, scope `mcp`, deny-by-default).
- Add Kyverno ClusterPolicy `require-security-policy` for **every** HTTPRoute: JWT SecurityPolicy required unless the route is listed in `excludedRoutes` or annotated `gateway.otaru.io/skip-security-policy=true`.
- Grandfather all pre-existing non-MCP HTTPRoutes in `excludedRoutes`; MCP routes are intentionally not listed so they stay enforced.
- Document the checklist item in `AGENTS.md`.

## Why

Mesh AuthorizationPolicy only covers Service-addressed traffic. Envoy Gateway can resolve backends to pod endpoints and skip the waypoint, so anonymous ingress was still possible without a route-scoped SecurityPolicy. Cluster-wide enforcement stops new routes from shipping without JWT by default.

## Test plan

- [x] `make test`
- [ ] After merge/sync: SecurityPolicy Accepted on both MCP routes
- [ ] Anonymous request to `k8s-mcp.internal.siutsin.com` and `unifi-mcp.internal.siutsin.com` returns 401/403
- [ ] Minted JWT with `sub=otaru-mcp` and scope `mcp` succeeds
- [ ] Kyverno policy `require-security-policy` Ready; RBAC for securitypolicies present
- [ ] Creating a new non-excluded HTTPRoute without SecurityPolicy is denied