### PR TITLE
fix(kyverno): grandfather jellyfin and jung2bot-dev HTTPRoutes

### DIFF
--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -95,9 +95,15 @@ requireSecurityPolicy:
       name: httpbin-public
     - namespace: hydra
       name: hydra-internal
+    - namespace: jellyfin
+      name: jellyfin-internal
+    - namespace: jellyfin
+      name: jellyfin-sftpgo-internal-http
     - namespace: jsoncrack
       name: jsoncrack-internal
     - namespace: jung2bot
+      name: jung2bot-public
+    - namespace: jung2bot-dev
       name: jung2bot-public
     - namespace: longhorn-system
       name: longhorn-internal


### PR DESCRIPTION
## Summary

- Add live HTTPRoutes that were missing from `requireSecurityPolicy.excludedRoutes`: `jellyfin/jellyfin-internal`, `jellyfin/jellyfin-sftpgo-internal-http`, `jung2bot-dev/jung2bot-public`.

## Why

Cluster-wide SecurityPolicy enforcement should grandfather every pre-existing route. These three exist in the cluster (jellyfin from private chart) but were not in the chart-derived exclusion list.

## Test plan

- [x] Diff matches live `kubectl get httproute -A` minus MCP routes
- [ ] After merge: kyverno-policy syncs; no PolicyReport noise for jellyfin/jung2bot-dev