### PR TITLE
fix(changedetection): complete deferred CPU upsize for browser sidecar

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -94,8 +94,12 @@ browser:
     # but needed 1199m; every other node was short on memory instead.
     # Reduced to 700m, which fits raspberrypi-03 with ~155m spare. Full
     # KRR target deferred to a later pass once cluster headroom improves.
+    # KRR 2026-07-30: completing the deferred upsize to the full 1189m
+    # target. The pod now runs on raspberrypi-00, which has CPU headroom
+    # (about 71 percent requested, no CPU limit set cluster-wide), so the
+    # full 489m bump fits without touching memory, which stays unchanged.
     requests:
-      cpu: 700m
+      cpu: 1189m
       memory: 1408Mi
       ephemeral-storage: 1Gi
     limits:


### PR DESCRIPTION
## Summary

- Completes a CPU upsize for the changedetection browser sidecar that was deferred on 2026-07-18 due to a lack of concurrent node headroom.
- The pod's current node now has enough free CPU (no CPU limit set repo-wide, so this is requests-only) to take the full KRR target (700m -> 1189m). Memory is unchanged.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm ArgoCD syncs the `changedetection` Application and the browser pod resizes without disruption (no CPU limit means this should apply live without a restart)

Part of the routine otaru self-healing right-sizing pass.