### PR TITLE
fix(changedetection): overcommit browser sidecar memory like blocky

### DIFF
--- a/helm-charts/changedetection/values.yaml
+++ b/helm-charts/changedetection/values.yaml
@@ -98,12 +98,27 @@ browser:
     # target. The pod now runs on raspberrypi-00, which has CPU headroom
     # (about 71 percent requested, no CPU limit set cluster-wide), so the
     # full 489m bump fits without touching memory, which stays unchanged.
+    #
+    # 2026-07-30 (overcommit): same technique as blocky's exception to the
+    # repo's "memory request equal to limit" convention. Measured 7-day
+    # working-set across five recent pod instances: steady-state averages
+    # 47-270Mi, but real recurring peaks of 764-1365Mi during Amazon watch
+    # / screenshot-stitching bursts (matching the "Playwright browser
+    # peaked at ~1.08Gi" note above) -- no OOMKill history at 1408Mi, but
+    # only ~3 percent headroom over the highest observed peak. Lowered
+    # request to 350Mi (comfortably above steady-state, well under any
+    # observed peak) and raised the limit to 1536Mi for real headroom
+    # above the measured 1365Mi peak. Frees ~1058Mi of previously
+    # reserved-but-idle memory per replica -- this pod's node
+    # (raspberrypi-00) was at 99 percent memory requested, contributing to
+    # cluster-wide scheduling pressure (see the 2026-07-30 PITR verify
+    # scheduling failure in .scratchpad/SELF_HEALING.md).
     requests:
       cpu: 1189m
-      memory: 1408Mi
+      memory: 350Mi
       ephemeral-storage: 1Gi
     limits:
-      memory: 1408Mi
+      memory: 1536Mi
       ephemeral-storage: 1Gi
 
 service:


### PR DESCRIPTION
## Summary

- Applies the same memory overcommit technique already used for `blocky` to the `changedetection-browser` sidecar.
- 7-day measurement across five recent pod instances shows a spike-then-idle shape: steady-state working set of 47-270Mi, with recurring peaks of 764-1365Mi during Amazon watch / screenshot-stitching bursts. No OOMKill history at the current 1408Mi limit.
- Lowers the memory request 1408Mi -> 350Mi (comfortably above steady-state) and raises the limit 1408Mi -> 1536Mi (real headroom above the measured 1365Mi peak). No HPA on this workload, so no decoupling concern like blocky's memory-percentage HPA target.
- Frees ~1058Mi of previously reserved-but-idle memory per replica on raspberrypi-00, which was at 99 percent memory requested and contributed to a same-day PITR verification job failing to schedule cluster-wide.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm ArgoCD syncs, pod reaches Ready with the new resources, and watch for any OOM over the next few days' Amazon-watch cycles

Requested by the user as a follow-up to the blocky overcommit pattern, during a routine otaru self-healing round.