### PR TITLE
fix(argocd): overcommit application-controller memory request

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -7,12 +7,30 @@ argo-cd:
     addPrometheusAnnotations: true
   _shared:
     controllerResources: &controllerResources
-      # Keep memory at 2Gi: sync spikes can queue many repo comparisons at once,
-      # and Argo CD tends to concentrate that work in a single controller pod, so
-      # extra replicas do not materially reduce peak memory on the active pod.
+      # Keep the limit at 2Gi: sync spikes can queue many repo comparisons at
+      # once, and Argo CD tends to concentrate that work in a single
+      # controller pod, so extra replicas do not materially reduce peak
+      # memory on the active pod.
+      #
+      # 2026-07-30 (overcommit): same request-vs-limit split already used
+      # for blocky and changedetection-browser. 7d and 14d working-set both
+      # topped out around 909Mi (14d max: 909.3Mi), well under the 2Gi
+      # request/limit that had been reserved since day one. Lowered the
+      # request to 1280Mi -- about 40 percent above the highest measured
+      # peak, wider margin than the other overcommit changes because this
+      # pod runs `replicas: 1` with no redundancy: an eviction here stalls
+      # GitOps reconciliation for all Applications until it reschedules and
+      # rebuilds its full watch cache, not just one workload's blip. The
+      # limit stays at 2Gi unchanged, so hard OOM-kill protection for a
+      # genuine sync-spike is identical to before -- that is governed by
+      # the limit, not the request. Note this pod is already `Burstable`
+      # QoS (no CPU limit is set, per this repo's convention), so this
+      # change does not newly expose it to eviction ranking; it only
+      # narrows the margin during the rare case of a real sync-spike
+      # coinciding with node memory pressure.
       requests:
         cpu: 250m
-        memory: 2Gi
+        memory: 1280Mi
         ephemeral-storage: 256Mi
       limits:
         memory: 2Gi


### PR DESCRIPTION
## Summary

- Applies the same memory overcommit technique already used for `blocky` and `changedetection-browser` to `argocd-application-controller`.
- 7-day and 14-day working-set both topped out around 909Mi, well under the 2Gi request/limit reserved since day one.
- Lowers the request 2Gi -> 1280Mi (about 40 percent above the highest measured peak). Keeps the limit at 2Gi unchanged, so OOM protection for a genuine sync-spike (the reason the original comment gives for keeping this at 2Gi) is identical to today -- that's governed by the limit, not the request.
- Wider margin than the other two overcommit changes on purpose: this pod runs `replicas: 1` with no redundancy, so an eviction here stalls GitOps reconciliation for every Application, not just one workload's blip. It's also already `Burstable` QoS (no CPU limit set, per this repo's convention), so this change doesn't newly expose it to eviction ranking -- it only narrows the margin during the rare case of a real sync-spike coinciding with node memory pressure.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm ArgoCD syncs itself, the controller pod restarts cleanly with the new request, and watch for any OOM or reconciliation delay over the next few days

Discussed and explicitly approved by the user during a routine otaru self-healing round, given this component's higher blast radius than the other overcommit candidates.