### PR TITLE
feat: onboard 7 more workloads to VPA

### DIFF
--- a/helm-charts/cloudflare-tunnel/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/cloudflare-tunnel/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: cloudflared
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 128Mi
+      - containerName: cloudflared
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 5m
+        maxAllowed:
+          cpu: 50m
+{{- end }}

--- a/helm-charts/cloudflare-tunnel/values.yaml
+++ b/helm-charts/cloudflare-tunnel/values.yaml
@@ -1,6 +1,11 @@
 name: cloudflare-tunnel
 namespace: cloudflare-tunnel
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d usage
+# consistently 17-45Mi against a 128Mi request, no incident history).
+vpa:
+  enabled: true
+
 image:
   repository: cloudflare/cloudflared
   tag: "2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"

--- a/helm-charts/home-assistant/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/home-assistant/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 128Mi
+        maxAllowed:
+          memory: 320Mi
+      - containerName: {{ .Values.name }}
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 10m
+        maxAllowed:
+          cpu: 100m
+{{- end }}

--- a/helm-charts/home-assistant/values.yaml
+++ b/helm-charts/home-assistant/values.yaml
@@ -1,6 +1,12 @@
 name: home-assistant
 namespace: home-assistant
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d avg/max
+# ~223/234Mi against no incident history) confirmed this is a good
+# candidate -- no periodic-spike shape, no OOM history.
+vpa:
+  enabled: true
+
 ip: 192.168.10.51
 
 deployment:

--- a/helm-charts/hydra/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/hydra/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: hydra
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 128Mi
+      - containerName: hydra
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 10m
+        maxAllowed:
+          cpu: 150m
+{{- end }}

--- a/helm-charts/hydra/values.yaml
+++ b/helm-charts/hydra/values.yaml
@@ -1,6 +1,14 @@
 name: hydra
 namespace: hydra
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d avg/max
+# ~56/60Mi against a 128Mi request, no incident history). Directly
+# addresses the "no live KRR history yet, revisit after 14 days" note on
+# the resources block below -- only targets the main hydra Deployment,
+# not hydra-maester.
+vpa:
+  enabled: true
+
 gateway:
   name: gateway
   namespace: gateway

--- a/helm-charts/openclaw/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/openclaw/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 384Mi
+        maxAllowed:
+          memory: 896Mi
+      - containerName: {{ .Values.name }}
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 200m
+        maxAllowed:
+          cpu: 1500m
+{{- end }}

--- a/helm-charts/openclaw/values.yaml
+++ b/helm-charts/openclaw/values.yaml
@@ -1,6 +1,13 @@
 name: openclaw
 namespace: openclaw
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d avg/max
+# ~489/623Mi against a 768Mi request, ratio ~1.27 -- more variance than the
+# other candidates but no incident history and no periodic-spike shape,
+# so kept a wider maxAllowed margin below).
+vpa:
+  enabled: true
+
 image:
   repository: ghcr.io/openclaw/openclaw
   tag: 2026.5.22@sha256:dcfd148777401d1bbdc63eab5c2f280bbfa912dfb1818566f9d66bb96ffb3f95

--- a/helm-charts/teslamate/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/teslamate/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 128Mi
+        maxAllowed:
+          memory: 320Mi
+      - containerName: {{ .Values.name }}
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 10m
+        maxAllowed:
+          cpu: 150m
+{{- end }}

--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -1,5 +1,13 @@
 name: teslamate
 namespace: teslamate
+
+# VPA 2026-07-30: onboarded the main teslamate app after a steady-state
+# usage check (7d avg/max ~223/230Mi against a 320Mi request, ratio ~1.03,
+# no incident history). Deliberately excludes teslamate-grafana, which has
+# a documented OOMKill history (128Mi -> 512Mi) and stays on manual KRR.
+vpa:
+  enabled: true
+
 database:
   host: teslamate-20260412-0619-rw.teslamate
   name: app

--- a/helm-charts/umami/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/umami/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 128Mi
+        maxAllowed:
+          memory: 384Mi
+      - containerName: {{ .Values.name }}
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 50m
+        maxAllowed:
+          cpu: 500m
+{{- end }}

--- a/helm-charts/umami/values.yaml
+++ b/helm-charts/umami/values.yaml
@@ -1,6 +1,11 @@
 name: umami
 namespace: umami
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d avg/max
+# ~221/250Mi against a 320Mi request, ratio ~1.13, no incident history).
+vpa:
+  enabled: true
+
 image:
   repository: ghcr.io/umami-software/umami
   tag: postgresql-latest@sha256:8edfe4beaef13f9d1300619fa264ef250a3688df9cc54d24ca830ca31cb475ec

--- a/helm-charts/unifi-mcp/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/unifi-mcp/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: network
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 64Mi
+        maxAllowed:
+          memory: 256Mi
+      - containerName: network
+        controlledResources: [cpu]
+        controlledValues: RequestsOnly  # this repo sets no cpu limits
+        minAllowed:
+          cpu: 10m
+        maxAllowed:
+          cpu: 150m
+{{- end }}

--- a/helm-charts/unifi-mcp/values.yaml
+++ b/helm-charts/unifi-mcp/values.yaml
@@ -1,6 +1,13 @@
 name: unifi-mcp
 namespace: unifi-mcp
 
+# VPA 2026-07-30: onboarded after a steady-state usage check (7d avg
+# 70-137Mi, max up to 191Mi across recent pod instances, no incident
+# history). Directly addresses the "revisit after real data" note on the
+# resources block below.
+vpa:
+  enabled: true
+
 gateway:
   name: gateway
   namespace: gateway


### PR DESCRIPTION
## Summary

Extends the existing VPA pattern (currently: descheduler, k8s-cleaner, kiali, kubernetes-mcp-server, onepassword-connect, reloader) to 7 more workloads, following the survey criteria: no incident history, no periodic-spike shape, no conflicting horizontal autoscaler (HPA/KEDA).

- `home-assistant`: 7d avg/max ~223/234Mi vs 320Mi request
- `teslamate` (main app only, not teslamate-grafana): 7d avg/max ~223/230Mi vs 320Mi request
- `umami`: 7d avg/max ~221/250Mi vs 320Mi request
- `unifi-mcp`: 7d avg 70-137Mi, max up to 191Mi vs 192Mi request -- resolves its own "revisit after real data" comment
- `cloudflare-tunnel`: 7d usage 17-45Mi vs 128Mi request
- `openclaw`: 7d avg/max ~489/623Mi vs 768Mi request (wider margin kept given more variance)
- `hydra` (main deployment only, not hydra-maester): 7d avg/max ~56/60Mi vs 128Mi request -- resolves its own "no KRR history yet" comment

**Deliberately excluded** from this batch:

- `teslamate-grafana` -- documented OOMKill history (128Mi -> 512Mi), stays on manual KRR, per explicit request.
- `jung2bot` -- has a KEDA `ScaledObject` scaling on CPU/memory Utilization. Adding VPA here without decoupling that trigger first would recreate the same conflict blocky's HPA had.
- `httpbin`, `cyberchef`, `excalidraw`, `jsoncrack` -- all have an HPA scaling on CPU/memory Utilization, same conflict class. Flagging separately rather than silently reworking their autoscalers in this batch.

Each new `VerticalPodAutoscaler` follows the existing reloader/blocky pattern: `updateMode: InPlaceOrRecreate`, memory split into its own `controlledResources: [memory]` policy (`RequestsAndLimits`), CPU into a separate `controlledResources: [cpu]` policy (`RequestsOnly`, since this repo sets no CPU limits). `minAllowed`/`maxAllowed` bounds are derived from real 7-day Prometheus measurements, not guesses.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm each Application syncs, the new VPA objects report `PROVIDED: true`, and watch the confidence-inflated first ~24h before recommendations settle (per the right-sizing skill's documented VPA onboarding behaviour)

Requested and reviewed with the user during a routine otaru self-healing round.