### PR TITLE
feat: onboard VPA for 5 workloads with existing HPA/KEDA

### DIFF
--- a/helm-charts/cyberchef/templates/hpa.yaml
+++ b/helm-charts/cyberchef/templates/hpa.yaml
@@ -15,9 +15,13 @@ spec:
       type: Resource
     - resource:
         name: memory
+        # 2026-07-30: switched from Utilization (% of request) to a fixed
+        # AverageValue so the memory-only VPA added alongside this HPA can
+        # adjust the request without moving this trigger point. 70Mi keeps
+        # the same absolute trigger as the previous 70%-of-100Mi target.
         target:
-          averageUtilization: 70
-          type: Utilization
+          type: AverageValue
+          averageValue: 70Mi
       type: Resource
   minReplicas: 2
   scaleTargetRef:

--- a/helm-charts/cyberchef/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/cyberchef/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 100Mi
+{{- end }}

--- a/helm-charts/cyberchef/values.yaml
+++ b/helm-charts/cyberchef/values.yaml
@@ -1,6 +1,14 @@
 name: cyberchef
 namespace: cyberchef
 
+# VPA 2026-07-30: onboarded memory-only after a steady-state usage check
+# (7d usage only 7-9Mi against a 100Mi request, no incident history). CPU
+# is left to the existing HPA. The HPA's memory trigger was switched from
+# Utilization to AverageValue (see templates/hpa.yaml) to decouple it from
+# the request this VPA adjusts -- same fix blocky's HPA needed.
+vpa:
+  enabled: true
+
 deployment:
   image:
     repository: ghcr.io/gchq/cyberchef

--- a/helm-charts/excalidraw/templates/hpa.yaml
+++ b/helm-charts/excalidraw/templates/hpa.yaml
@@ -15,9 +15,14 @@ spec:
       type: Resource
     - resource:
         name: memory
+        # 2026-07-30: switched from Utilization (% of request) to a fixed
+        # AverageValue so the memory-only VPA added alongside this HPA can
+        # adjust the request without moving this trigger point. 90Mi keeps
+        # roughly the same absolute trigger as the previous 70%-of-128Mi
+        # (~90Mi) target.
         target:
-          averageUtilization: 70
-          type: Utilization
+          type: AverageValue
+          averageValue: 90Mi
       type: Resource
   minReplicas: 2
   scaleTargetRef:

--- a/helm-charts/excalidraw/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/excalidraw/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 128Mi
+{{- end }}

--- a/helm-charts/excalidraw/values.yaml
+++ b/helm-charts/excalidraw/values.yaml
@@ -1,6 +1,14 @@
 name: excalidraw
 namespace: excalidraw
 
+# VPA 2026-07-30: onboarded memory-only after a steady-state usage check
+# (7d usage only 7-8Mi against a 128Mi request, no incident history). CPU
+# is left to the existing HPA. The HPA's memory trigger was switched from
+# Utilization to AverageValue (see templates/hpa.yaml) to decouple it from
+# the request this VPA adjusts -- same fix blocky's HPA needed.
+vpa:
+  enabled: true
+
 deployment:
   image:
     repository: docker.io/excalidraw/excalidraw

--- a/helm-charts/httpbin/templates/hpa.yaml
+++ b/helm-charts/httpbin/templates/hpa.yaml
@@ -20,6 +20,10 @@ spec:
     - type: Resource
       resource:
         name: memory
+        # 2026-07-30: switched from Utilization (% of request) to a fixed
+        # AverageValue so the memory-only VPA added alongside this HPA can
+        # adjust the request without moving this trigger point. 60Mi keeps
+        # the same absolute trigger as the previous 60%-of-100Mi target.
         target:
-          type: Utilization
-          averageUtilization: 60
+          type: AverageValue
+          averageValue: 60Mi

--- a/helm-charts/httpbin/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/httpbin/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 128Mi
+{{- end }}

--- a/helm-charts/httpbin/values.yaml
+++ b/helm-charts/httpbin/values.yaml
@@ -1,6 +1,14 @@
 name: httpbin
 namespace: httpbin
 
+# VPA 2026-07-30: onboarded memory-only after a steady-state usage check
+# (7d avg/max ~62/63Mi against a 100Mi request, no incident history). CPU
+# is left to the existing HPA. The HPA's memory trigger was switched from
+# Utilization to AverageValue (see templates/hpa.yaml) to decouple it from
+# the request this VPA adjusts -- same fix blocky's HPA needed.
+vpa:
+  enabled: true
+
 app:
   image:
     repository: kong/httpbin

--- a/helm-charts/jsoncrack/templates/hpa.yaml
+++ b/helm-charts/jsoncrack/templates/hpa.yaml
@@ -15,9 +15,14 @@ spec:
       type: Resource
     - resource:
         name: memory
+        # 2026-07-30: switched from Utilization (% of request) to a fixed
+        # AverageValue so the memory-only VPA added alongside this HPA can
+        # adjust the request without moving this trigger point. 90Mi keeps
+        # roughly the same absolute trigger as the previous 70%-of-128Mi
+        # (~90Mi) target.
         target:
-          averageUtilization: 70
-          type: Utilization
+          type: AverageValue
+          averageValue: 90Mi
       type: Resource
   minReplicas: {{ .Values.autoscaling.min }}
   scaleTargetRef:

--- a/helm-charts/jsoncrack/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/jsoncrack/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 32Mi
+        maxAllowed:
+          memory: 128Mi
+{{- end }}

--- a/helm-charts/jsoncrack/values.yaml
+++ b/helm-charts/jsoncrack/values.yaml
@@ -1,6 +1,15 @@
 name: jsoncrack
 namespace: jsoncrack
 
+# VPA 2026-07-30: onboarded memory-only after a steady-state usage check
+# (7d usage only 5-9Mi against a 128Mi request, no incident history). CPU
+# is left to the existing HPA (though min/max are both 1, so it never
+# actually scales horizontally). The HPA's memory trigger was switched
+# from Utilization to AverageValue (see templates/hpa.yaml) to decouple it
+# from the request this VPA adjusts -- same fix blocky's HPA needed.
+vpa:
+  enabled: true
+
 deployment:
   image:
     repository: ghcr.io/siutsin/images/jsoncrack

--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -16,9 +16,14 @@ spec:
       metadata:
         value: "75"
     - type: memory
-      metricType: Utilization
+      # 2026-07-30: switched from Utilization (% of request) to a fixed
+      # AverageValue so the memory-only VPA added alongside this
+      # ScaledObject can adjust the request without moving this trigger
+      # point. 144Mi keeps the same absolute trigger as the previous
+      # 75%-of-192Mi target.
+      metricType: AverageValue
       metadata:
-        value: "75"
+        value: "144Mi"
     - type: cron
       metadata:
         timezone: "Asia/Hong_Kong"

--- a/helm-charts/jung2bot/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/jung2bot/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+  resourcePolicy:
+    containerPolicies:
+      - containerName: {{ .Values.name }}
+        controlledResources: [memory]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          memory: 64Mi
+        maxAllowed:
+          memory: 192Mi
+{{- end }}

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -1,6 +1,16 @@
 name: jung2bot
 namespace: jung2bot
 
+# VPA 2026-07-30: onboarded memory-only after a steady-state usage check
+# (7d avg/max ~95Mi against a 192Mi request, ratio ~1.0, no incident
+# history). CPU is left to the existing KEDA ScaledObject. The
+# ScaledObject's memory trigger was switched from Utilization to
+# AverageValue (see templates/scaled-object.yaml) to decouple it from the
+# request this VPA adjusts -- same fix blocky's HPA needed. Applies to
+# both jung2bot and jung2bot-dev (same chart, dev values file override).
+vpa:
+  enabled: true
+
 secret:
   remoteRef:
     key: jung2bot


### PR DESCRIPTION
## Summary

Onboards `httpbin`, `cyberchef`, `excalidraw`, `jsoncrack`, and `jung2bot` to VPA -- the 5 workloads flagged in #2994 as having an existing horizontal autoscaler (HPA or KEDA ScaledObject) scaling on CPU/memory Utilization.

Goes with option 1 from the discussion: VPA scoped to **memory only** on each (`controlledResources: [memory]`, no CPU policy), leaving CPU scaling to the existing horizontal autoscaler untouched. Each autoscaler's memory trigger is switched from `Utilization` (percentage of request) to a fixed `AverageValue`, preserving its previous absolute trigger point but decoupling it from the request VPA now adjusts -- the same fix `blocky`'s HPA needed (see `helm-charts/blocky/templates/hpa.yaml`).

| Workload | Old trigger | New fixed trigger | 7d measured usage | Current request |
|---|---|---|---|---|
| httpbin | 60% of request | 60Mi | avg/max ~62/63Mi | 100Mi |
| cyberchef | 70% of request | 70Mi | 7-9Mi | 100Mi |
| excalidraw | 70% of request | 90Mi | 7-8Mi | 128Mi |
| jsoncrack | 70% of request | 90Mi | 5-9Mi | 128Mi |
| jung2bot (KEDA) | 75% of request | 144Mi | avg/max ~95Mi | 192Mi |

No incident history on any of the 5. `jsoncrack`'s HPA has min=max=1 replicas so it never scales horizontally regardless -- fixed for consistency anyway.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm each Application syncs, each new `VerticalPodAutoscaler` reports `PROVIDED: true`, and specifically verify KEDA's `AverageValue` memory trigger parses correctly for jung2bot (its exact value-string convention for the memory scaler wasn't confirmed from docs alone) by inspecting the HPA object KEDA generates and checking `keda-operator` logs for parse errors

Follow-up to #2994, requested and reviewed with the user during a routine otaru self-healing round.