### PR TITLE
fix(monitoring): complete deferred prometheus-server memory upsize

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -78,12 +78,17 @@ prometheus:
       # memory-request headroom improves (same pattern as
       # changedetection-browser's deferred CPU target -- see that entry
       # above this chart's history for a comparable case).
+      # KRR 2026-07-31: completing the deferred upsize. 14d peak is now
+      # ~3730Mi; the pod relocated off nuc-00 to raspberrypi-00 (which had
+      # 867Mi free requested-memory capacity, well above the 466Mi needed)
+      # after a series of overcommit/VPA changes freed real headroom
+      # cluster-wide over the past day. Bumped to 3730Mi.
       requests:
         cpu: 200m
-        memory: 3264Mi
+        memory: 3730Mi
         ephemeral-storage: 256Mi
       limits:
-        memory: 3264Mi
+        memory: 3730Mi
         ephemeral-storage: 256Mi
     persistentVolume:
       size: 100Gi


### PR DESCRIPTION
## Summary

- Completes the prometheus-server memory upsize deferred on 2026-07-22, when no node had the ~466Mi of free requested-memory capacity it needed at once (attempting it caused `FailedScheduling` and took prometheus down).
- The pod has since relocated to `raspberrypi-00`, which now has 867Mi free after yesterday's overcommit (changedetection-browser, argocd-application-controller) and VPA rollout (18 workloads) freed real headroom cluster-wide.
- Bumps memory 3264Mi -> 3730Mi, matching the current 14-day peak KRR recommendation.

## Test plan

- [x] `make test` passes
- [ ] After merge: confirm ArgoCD syncs, the pod resizes without a scheduling failure this time, and no OOM

Part of the routine otaru self-healing right-sizing pass.