### PR TITLE
chore(skills): switch self-healing loop cadence from hourly to 30 minutes

### DIFF
--- a/.claude/skills/self-healing-loop/SKILL.md
+++ b/.claude/skills/self-healing-loop/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: "self-healing-loop"
 description: >-
-  Use when starting, renewing, or extending the session-only hourly self-healing
-  schedule to the platform max TTL (currently 7 days from this run). Not for
-  one-off cluster investigation or GitOps fixes (use /self-healing). Every
-  invoke: create a full-window /loop job, confirm, delete other matchers, run
-  /self-healing once when possible, report timing.
+  Use when starting, renewing, or extending the session-only 30-minute
+  self-healing schedule to the platform max TTL (currently 7 days from this
+  run). Not for one-off cluster investigation or GitOps fixes (use
+  /self-healing). Every invoke: create a full-window /loop job, confirm,
+  delete other matchers, run /self-healing once when possible, report timing.
 metadata:
-  short-description: "Bootstrap/renew hourly self-healing schedule to max TTL"
+  short-description: "Bootstrap/renew 30-minute self-healing schedule to max TTL"
 ---
 
 # Self-healing loop (orchestrator)
 
-**Role:** **every** invoke **bootstraps or renews** the hourly session loop to
+**Role:** **every** invoke **bootstraps or renews** the 30-minute session loop to
 the **platform maximum TTL** (currently **7 days from this run**), keeps a
 **single** matching job, then **delegates one** `/self-healing` after a
 successful renew (or skips when investigation already ran this round). Composes
@@ -42,7 +42,7 @@ Running `/self-healing-loop` **always** resets the schedule clock to
 - treat agent-written body timestamps alone as proof when platform metadata
   shows a shorter remaining TTL
 
-Always: **create a new** session-only hourly job with
+Always: **create a new** session-only 30-minute job with
 `created_local = now` and `expires_local = now + MAX_WINDOW`, **confirm**
 full-window success, **then** delete every other matcher so exactly one job
 remains with remaining **≥ MAX_WINDOW − 1 hour** at confirm. That is both
@@ -127,7 +127,7 @@ fields and `n/a` where unknown. Set **Round end** only when the run stops
 (after Step 5 investigate/skip/**failure**, or on earlier fail-closed).
 
 | Field                | Meaning                                                                 |
-| -------------------- | ----------------------------------------------------------------------- |
+|----------------------|-------------------------------------------------------------------------|
 | Round start          | Skill entry (local)                                                     |
 | Round end            | When this run stops (local)                                             |
 | Keeper job_id        | Confirmed new keeper, or `n/a`                                          |
@@ -164,12 +164,13 @@ expire/remaining if present, and
 match already exists — renew requires a new full-window job.
 
 **Step 2. Create the new schedule first (max window from now).** Prefer Claude
-native `/loop` with a **fixed hourly** interval (not bare maintenance `/loop`,
-not dynamic-only). Prefer cadence off wall-clock `:00` / `:30` when the
-platform lets you pin cron; otherwise `/loop 1h`. Example shape:
+native `/loop` with a **fixed 30-minute** interval (not bare maintenance
+`/loop`, not dynamic-only). Prefer cadence off wall-clock `:00` / `:30` when
+the platform lets you pin cron (for example minutes `4` and `34`); otherwise
+`/loop 30m`. Example shape:
 
 ```text
-/loop 1h
+/loop 30m
 otaru-self-healing-loop-fire
 job_id: pending
 created_local: <now>
@@ -206,7 +207,7 @@ at create (both `/loop` and CronCreate).
 ```text
 recurring: true
 durable:   false   # session-only; do not omit
-cron:      37 * * * *   # hourly; any fixed minute except :00/:30 if 37 taken
+cron:      4,34 * * * *   # every 30 minutes; any two minutes 30 apart, avoiding :00/:30
 prompt:    <verbatim fire template with absolute timestamps>
 ```
 

--- a/.claude/skills/self-healing/SKILL.md
+++ b/.claude/skills/self-healing/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   reconciliation, workloads, storage, data plane, platform, ingress/mesh,
   policy, and CI health; fix safe issues via GitOps PRs; escalate destructive
   or database work. Invoke as /self-healing for manual or scheduled
-  investigation runs. To start or renew the hourly session schedule, use
+  investigation runs. To start or renew the 30-minute session schedule, use
   /self-healing-loop.
 metadata:
   short-description: "otaru cluster self-healing investigation and fixes"
@@ -19,7 +19,7 @@ metadata:
 
 **Role:** one-off investigation and safe fixes — one pass of cluster checks,
 GitOps PRs, journal, merge-policy, and optional `/right-sizing` when healthy.
-**Not this skill:** creating or renewing the hourly schedule (`/loop`, job
+**Not this skill:** creating or renewing the 30-minute schedule (`/loop`, job
 TTL, single-job cleanup). That is `.claude/skills/self-healing-loop`
 (`/self-healing-loop`).
 
@@ -29,7 +29,7 @@ a CI runner or a remote devserver). Investigate the otaru home-lab `k3s`
 cluster, fix safe issues, and journal findings. Usable as a manual one-shot
 or as the body of each scheduled fire from `/self-healing-loop`.
 
-Invoke as `/self-healing`. To start or renew the hourly schedule, use
+Invoke as `/self-healing`. To start or renew the 30-minute schedule, use
 `/self-healing-loop`.
 
 ## Scope
@@ -273,5 +273,5 @@ content edit, not a restructure. Schedule/bootstrap changes belong in
 - `runbooks/` — one file per investigation category, plus merge policy,
   branch cleanup, and unused-resource detection.
 - `.claude/skills/self-healing-loop` (`/self-healing-loop`) — bootstrap/renew
-  the hourly schedule.
+  the 30-minute schedule.
 - `documentation/gotcha.md` — known issues and workarounds.

--- a/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
+++ b/.claude/skills/self-healing/runbooks/gitops-reconciliation.md
@@ -13,9 +13,9 @@ category and its place in the investigation order do not need to change.
 ## Triage
 
 - `Degraded` or `Unknown` → P0; diagnose then GitOps-fix or escalate.
-- `OutOfSync` for more than one hourly loop cycle with no in-flight PR →
-  investigate drift; GitOps-fix when the live diff is wrong, otherwise
-  escalate if sync needs prune/force.
+- `OutOfSync` for more than one loop cycle (currently 30 minutes) with no
+  in-flight PR → investigate drift; GitOps-fix when the live diff is wrong,
+  otherwise escalate if sync needs prune/force.
 - **`Progressing`:** do not treat "the current pod reached Ready" as proof
   the issue is resolved. A single point-in-time check cannot tell a
   one-off restart apart from a workload that is being repeatedly killed

--- a/.claude/skills/self-healing/runbooks/merge-policy.md
+++ b/.claude/skills/self-healing/runbooks/merge-policy.md
@@ -14,7 +14,8 @@ After branch, commit, push, and PR open:
   `gh pr checks <number> --watch --fail-fast` (see `AGENTS.md`). In
   **unattended/loop** mode bound the wait (for example stop after ~15
   minutes, journal `result: open` with the PR URL, and re-check next cycle).
-  Do not park the whole hourly fire on an unbounded watch.
+  Do not park the whole fire (currently a 30-minute cycle) on an unbounded
+  watch.
 2. Address review feedback if any.
 3. Then apply the class below.
 

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -14,7 +14,7 @@
   URL resolution as `right-sizing`'s KRR step) — any `firing` alerts. A
   pod stuck `CrashLoopBackOff` still reports phase `Running` and can look
   fine at a glance if this step is skipped, especially on an abbreviated
-  hourly check; run it every pass, not just on a full sweep.
+  scheduled check; run it every pass, not just on a full sweep.
 
 ## Triage
 


### PR DESCRIPTION
## Summary

- Changes the `/self-healing-loop` schedule cadence from hourly to every
  30 minutes: native `/loop 30m`, the `CronCreate` fallback example
  (`4,34 * * * *`), and the frontmatter/description text.
- Updates every cross-reference to the loop's cadence in
  `/self-healing`'s `SKILL.md` and its `gitops-reconciliation.md`,
  `merge-policy.md`, and `workloads.md` runbooks so nothing says
  "hourly" while meaning something else.
- Leaves the legacy `hourly` fire matcher untouched -- it exists to clean
  up pre-token jobs from before this schedule existed, not to describe
  the current cadence.

## Test plan

- [x] `make test` passes
- [ ] Next `/self-healing-loop` renew creates a 30-minute job and reports
      correctly