### PR TITLE
feat(skills): auto-unlock LUKS Pi nodes on the confirmed initramfs signature

### DIFF
--- a/.claude/skills/self-healing/references/escalation.md
+++ b/.claude/skills/self-healing/references/escalation.md
@@ -27,8 +27,13 @@ merge).
   **resize or delete** on DB volumes, operator topology changes.
 - **Storage** — volume delete, restore, recurring-job backup target changes,
   crypto secret rotation, stuck-volume webhook work.
-- **Disk encryption / nodes** — unlock (`make unlock`), hardware replace,
-  stale node-password cleanup, plain reboot of LUKS-root nodes.
+- **Disk encryption / nodes** — hardware replace, stale node-password
+  cleanup, plain reboot of LUKS-root nodes. **Unlock** (`make unlock`) is
+  the one exception: auto-fix directly when the documented
+  waiting-in-initramfs signature is confirmed (see
+  `runbooks/access-and-nodes.md` LUKS / initramfs section) — still
+  escalate for `nuc-00` and for any known hardware-fault pattern (e1000e
+  NIC hang, RPi5 Wi-Fi loop) even if the same signature is present.
 - **Cluster ops** — full teardown, version upgrade, reboot-all maintenance
   (`make nuke`, `make upgrade`, `make maintenance`), etcd repair, k3s
   reinstall.

--- a/.claude/skills/self-healing/runbooks/access-and-nodes.md
+++ b/.claude/skills/self-healing/runbooks/access-and-nodes.md
@@ -30,10 +30,41 @@ initramfs until unlock and will not rejoin without intervention.
 - **Forbidden unattended:** `reboot`, `shutdown`, `systemctl reboot`,
   `kubectl debug` reboot paths, or Ansible's generic `reboot` module. See
   `AGENTS.md` Node Reboot Policy.
-- **Escalate unlock / planned reboot** to the user. Documented paths:
-  `make unlock <node-name>` when initramfs dropbear is already waiting;
-  `make maintenance` for rolling LUKS-aware reboots. Details:
-  `documentation/luks_remote_unlock.md`, `documentation/gotcha.md`.
+- **Auto-unlock when the signature is confirmed.** Run `make unlock
+  <node-name>` directly — no escalation needed — when **all** of these
+  hold:
+  - the node is a Raspberry Pi (`raspberrypi-*`), not `nuc-00` (see the
+    NIC-hang bullet below — always escalate that one instead)
+  - the node is listed in `luks_root_nodes` (`ansible/inventory.yaml`)
+  - the node IP responds to ping (network layer is up)
+  - regular SSH (port 22) is refused or times out
+  - the LUKS dropbear-initramfs port (`luks_dropbear_port` in the
+    inventory; `1024` in this cluster) answers with an SSH banner
+    (`documentation/luks_remote_unlock.md`)
+
+  This combination uniquely matches "node powered back on and is waiting
+  in initramfs for the passphrase" (for example after a PoE budget
+  power-loss event, see `documentation/gotcha.md`) — not an unresolved
+  hardware fault, not still fully down.
+
+  `make unlock` reads the passphrase from `OTARU_LUKS_PASSWORD` via
+  `direnv` internally (`--env-passfifo`). **Never read, print, echo, or
+  otherwise inspect that variable yourself** — call the `make` target and
+  let it flow straight through.
+
+  After it returns, poll `kubectl get node <name>` for `Ready` (a few
+  minutes is normal) before continuing the pass. If the command fails, or
+  the node does not reach `Ready` within a reasonable wait, stop retrying
+  and escalate with what was tried.
+
+  **Still escalate:** planned/rolling reboots (`make maintenance` —
+  full-cluster package update and reboot, a much larger action than
+  recovering one already-down node); `nuc-00` and the other known
+  hardware-fault patterns below, even if the same dropbear signature is
+  present, since those need human awareness of a recurring fault, not
+  just a one-off unlock; and any case where the signature above does not
+  fully match (for example SSH also unreachable, or dropbear itself
+  unreachable).
 
 **Hardware replace + stale node password.** If a node was replaced in place
 and reuses the same name, look for `kube-system/<node>.node-password.k3s`

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -838,14 +838,19 @@ budget. This is a switch-side decision, external to the node and to k3s.
 ### Resolution: Treat as a Standard LUKS Reboot Recovery
 
 No different from any other `raspberrypi-*` reboot once power is back --
-follow the normal escalate-and-unlock path
-(`.claude/skills/self-healing/runbooks/access-and-nodes.md`,
-`documentation/luks_remote_unlock.md`): confirm dropbear on port 1024,
-then `make unlock <node-name>`. Do not attempt an unattended
-reboot/power-cycle command; the node is already powered and simply
-waiting for the passphrase. If PoE alerts recur, the switch's port power
-budget or the device mix drawing from it needs review -- that is a
-switch-configuration question, not a k3s/self-healing fix.
+confirm dropbear on port 1024, then `make unlock <node-name>`. This
+specific signature (ping OK, SSH refused, dropbear open, node in
+`luks_root_nodes`, not `nuc-00`) is exactly the case
+`.claude/skills/self-healing/runbooks/access-and-nodes.md` auto-fixes
+directly with `make unlock` -- no escalation needed, and the fix does not
+depend on PoE being the cause. The signature only proves the node is
+waiting in initramfs, not why it lost power in the first place; PoE is
+just the trigger observed so far, and the same recovery applies whichever
+way a Pi loses power. Do not attempt an unattended reboot/power-cycle
+command; the node is already powered and simply waiting for the
+passphrase. If PoE alerts recur, the switch's port power budget or the
+device mix drawing from it needs review -- that is a switch-configuration
+question, not a k3s/self-healing fix.
 
 ## MetalLB LoadBalancer VIP Unreachable When nuc-00 Announces It
 


### PR DESCRIPTION
## Summary

- Previously `make unlock` was always-escalate in the self-healing skill,
  even when the diagnostic signature (ping OK, SSH refused, dropbear open
  on the initramfs port, node in `luks_root_nodes`) uniquely confirms a
  node is just waiting for its LUKS passphrase after powering back on --
  not an unresolved hardware fault.
- Confirmed live this session: `raspberrypi-03` lost power (a PoE budget
  alert cut its switch port), came back into initramfs, and `make unlock
  raspberrypi-03` recovered it cleanly.
- Carves out this one case from `access-and-nodes.md` and the
  `escalation.md` always-escalate list: self-healing now runs `make
  unlock` directly for Raspberry Pi nodes matching the signature, waits
  for `Ready`, and only escalates on failure.
- `nuc-00` and the documented hardware-fault patterns (e1000e NIC hang,
  RPi5 Wi-Fi loop) still always escalate -- those need human awareness of
  a recurring fault, not a one-off unlock. Planned/rolling reboots (`make
  maintenance`) are untouched.
- The fix does not depend on PoE being the cause -- the signature only
  proves the node is waiting in initramfs, not why it lost power.
- The skill is explicitly instructed to never read, print, or inspect
  `OTARU_LUKS_PASSWORD` -- `make unlock` reads it via `direnv`
  internally (`--env-passfifo`).

## Test plan

- [x] `make test` passes
- [x] Verified live against the actual incident: `raspberrypi-03` was
      recovered with `make unlock raspberrypi-03` matching exactly the
      signature this change now auto-triggers on