### PR TITLE
fix(onepassword-connect): bump ephemeral-storage to give real headroom

### DIFF
--- a/helm-charts/onepassword-connect/values.yaml
+++ b/helm-charts/onepassword-connect/values.yaml
@@ -2,14 +2,19 @@ vpa:
   enabled: true
 
 _shared:
+  # 2026-08-03: ephemeral-storage bumped 64Mi -> 96Mi. 14d peak across pod
+  # history reached ~49.9Mi (78% of the old 64Mi limit); the live pod was
+  # at 70.95%. No eviction history, but headroom was thin. Memory/cpu
+  # unaffected -- VPA (enabled below) manages memory live and does not
+  # control ephemeral-storage.
   resources: &resources
     requests:
       cpu: 50m
       memory: 64Mi
-      ephemeral-storage: 64Mi
+      ephemeral-storage: 96Mi
     limits:
       memory: 64Mi
-      ephemeral-storage: 64Mi
+      ephemeral-storage: 96Mi
   preferredPodAntiAffinity: &preferredPodAntiAffinity
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

- Right-sizing pass (KRR): no CPU/memory changes this round -- all 20
  flagged workloads are already guarded, VPA-managed, or vendor-managed
  (same exclusion set as the previous several passes).
- Ephemeral-storage check found `onepassword-connect`'s `api` and `sync`
  containers (they share one resource block) at 70.95% of their 64Mi
  limit live, with a 14-day peak of ~49.9Mi across pod history -- thin
  headroom for a bootstrap secrets backend with no eviction history yet.
- Bumped ephemeral-storage request and limit together to 96Mi. Resource
  values only -- no secret payloads, ExternalSecret keys, or config
  touched.

## Test plan

- [x] `make test` passes