### PR TITLE
fix(longhorn): bump csi-plugin sidecar ephemeral-storage 32Mi -> 48Mi

### DIFF
--- a/helm-charts/longhorn/values.yaml
+++ b/helm-charts/longhorn/values.yaml
@@ -100,14 +100,24 @@ longhorn:
     # several 100+Gi filesystems at once (one PVC is 320Gi). This is a real,
     # measured floor, not a guess -- raised to 4Gi to give solid margin above
     # the ~845MiB KDF baseline plus overhead.
+    # right-sizing 2026-08-06: longhorn-csi-plugin, node-driver-registrar,
+    # and longhorn-liveness-probe ephemeral-storage bumped 32Mi -> 48Mi.
+    # These three (the longhorn-csi-plugin DaemonSet pod's containers) were
+    # a "no data yet" placeholder reusing the gateway chart's convention,
+    # unlike the incident-driven memory sizing above. Prometheus showed the
+    # DaemonSet pod on raspberrypi-03 (spcgc) peaking at ~23.55Mi over 14d
+    # (73% of the old 32Mi limit); other node instances ranged 2-22Mi. The
+    # exporter only reports pod-level usage, not per-container, so the
+    # true per-container split is unknown -- bumped conservatively rather
+    # than assuming the full pod total lands on one container.
     systemManagedCSIComponentsResourceLimits: >-
       {"csi-attacher":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-provisioner":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-resizer":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
       "csi-snapshotter":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"4Gi","ephemeral-storage":"32Mi"}},
-      "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}},
-      "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"32Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"32Mi"}}}
+      "longhorn-csi-plugin":{"requests":{"cpu":"25m","memory":"64Mi","ephemeral-storage":"48Mi"},"limits":{"memory":"4Gi","ephemeral-storage":"48Mi"}},
+      "node-driver-registrar":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"48Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"48Mi"}},
+      "longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"32Mi","ephemeral-storage":"48Mi"},"limits":{"memory":"32Mi","ephemeral-storage":"48Mi"}}}
   defaultBackupStore:
     backupTarget: ~
     backupTargetCredentialSecret: b2-secret


### PR DESCRIPTION
## Summary
- Weekly right-sizing pass: `longhorn-csi-plugin`, `node-driver-registrar`, and `longhorn-liveness-probe` (the longhorn-csi-plugin DaemonSet's sidecars) showed `ephemeral_storage_container_limit_percentage` at ~75% of their 32Mi limit.
- Prometheus 14-day pod-level peak on raspberrypi-03's instance was ~23.55Mi (73% of 32Mi); other node instances ranged 2-22Mi.
- These three were a "no data yet" placeholder value reusing another chart's convention, not incident-hardened like the memory sizing in the same `systemManagedCSIComponentsResourceLimits` block. Bumped to 48Mi request and limit for headroom.

## Test plan
- [x] `make test` passes
- [ ] ArgoCD syncs and the longhorn-csi-plugin DaemonSet pods restart cleanly with the new limit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>