### PR TITLE
docs: note OAuth JSON-parse variant of stale agentgateway token gotcha

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1826,6 +1826,12 @@ minute.
 `Jwt is expired`, while a direct request to the cluster hostname with a
 fresh Bearer token succeeds.
 
+A stale in-process token can also surface as a garbled proxy error instead of
+a clean 401, for example `HTTP 400: Invalid OAuth error response:
+SyntaxError: JSON Parse error: Unexpected identifier "mcp"` (seen on UniFi
+MCP, 2026-08-08). Same cause, same fix below -- do not chase the JSON parse
+error itself.
+
 ### Cause
 
 The token refresh LaunchAgent updates the cache file, but agentgateway may


### PR DESCRIPTION
## Summary

- Extends the existing "Local agentgateway returns `Jwt is expired` after token refresh" gotcha entry in `documentation/gotcha.md` with the garbled `HTTP 400: Invalid OAuth error response: SyntaxError: JSON Parse error` variant seen on UniFi MCP during self-healing-loop investigation on 2026-08-08.
- Same root cause and fix (`launchctl kickstart -k gui/$(id -u)/com.siutsin.agentgateway`) as the documented entry, so this only extends the Symptom section rather than duplicating the whole entry.

## Test plan

- [x] `make test` passes