### PR TITLE
fix(cloudflare-tunnel): add app.kubernetes.io/name to PDB selector

### DIFF
--- a/helm-charts/cloudflare-tunnel/templates/pdb.yaml
+++ b/helm-charts/cloudflare-tunnel/templates/pdb.yaml
@@ -7,4 +7,9 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
+      # app.kubernetes.io/name added so Kyverno's require-pdb-for-deployment
+      # policy recognises this PDB; pod: cloudflared alone already matched
+      # every pod (see templates/deployment.yaml), so this only satisfies
+      # the policy check and does not change which pods are protected.
+      app.kubernetes.io/name: {{ .Values.name }}
       pod: cloudflared


### PR DESCRIPTION
## Summary

- The `cloudflare-tunnel` PodDisruptionBudget selects on `pod: cloudflared` only. Kyverno's `require-pod-disruption-budget/require-pdb-for-deployment` policy checks specifically for a PDB selecting via `app.kubernetes.io/name`, so it could not recognise this PDB and fired a `PolicyViolation` event, even though the PDB is real and working (`disruptionsAllowed: 1`, `currentHealthy: 2`).
- The deployment's pod template already carries both `app.kubernetes.io/name: cloudflare-tunnel` and `pod: cloudflared`, so adding the former to the PDB selector is additive only — every existing pod already matches it, and disruption protection is unchanged.

## Test plan

- [x] `make test` passes