### PR TITLE
docs(self-healing): add runbook for stale WebGazer IP allowlist

### DIFF
--- a/.claude/skills/self-healing/references/escalation.md
+++ b/.claude/skills/self-healing/references/escalation.md
@@ -40,7 +40,12 @@ merge).
 - **Mass impact** — cluster-wide restart, draining **multiple** nodes, bulk
   deletes across namespaces.
 - **Infrastructure as code** — any Terraform/OpenTofu/Terragrunt apply,
-  Ansible setup/disk-encryption playbooks.
+  Ansible setup/disk-encryption playbooks. **One narrow exception:** the
+  Cloudflare Access WebGazer IP allowlist refresh — see
+  `runbooks/ingress-mesh.md` ("Heartbeat down: Cloudflare Access WebGazer
+  IP allowlist stale"), user-authorised 2026-08-08 as routine because the
+  blast radius is a single static IP list feeding one bypass policy, not
+  the Access application itself.
 - **Secrets** — editing chart secret payloads, password-manager items,
   ExternalSecret source keys.
 - **GitOps controller** — Application/resource delete, force sync with prune,

--- a/.claude/skills/self-healing/runbooks/ingress-mesh.md
+++ b/.claude/skills/self-healing/runbooks/ingress-mesh.md
@@ -29,6 +29,63 @@ clients, also consider RPi ARP/promisc issues documented in
 `documentation/gotcha.md` — host networking fixes are **escalate** (not
 unattended GitOps).
 
+## Heartbeat down: Cloudflare Access WebGazer IP allowlist stale
+
+**Symptom:** `kubectl get heartbeat -A` (or a user-reported "otaru heartbeat
+down" alert) shows one `Heartbeat` `healthy: false` with `lastStatus: 403`
+and `message: status code is not within expected ranges`, while every other
+Heartbeat CR is healthy and the rest of the cluster (nodes, pods, Argo CD
+Applications) checks out clean.
+
+**Confirm it is this, not a real backend problem:**
+
+```bash
+kubectl get heartbeat <name> -n <namespace> -o yaml   # read status + spec.endpointsSecret
+TARGET=$(kubectl get secret <endpointsSecret.name> -n <namespace> \
+  -o jsonpath='{.data.<targetEndpointKey>}' | base64 -d)
+curl -sI "$TARGET"   # look for cf-access-domain / cf-access-aud response headers
+```
+
+Cloudflare Access response headers (`cf-access-domain`, `cf-access-aud`) on
+a 403 confirm Cloudflare Access rejected the request before it reached the
+cluster — this is not a workload or GitOps issue, do not chase pods/Argo CD
+for this symptom.
+
+**Root cause:** the target hostname sits behind a Cloudflare Zero Trust
+Access application (`infrastructure/cloud/cloudflare/access`), with a
+policy that lets WebGazer.io's own probe IPs bypass Access
+(`infrastructure/modules/cloudflare-access/webgazer.tf`, backed by the
+static file `infrastructure/modules/cloudflare-access/ip/webgazer.txt`).
+WebGazer rotates its published probe IPs
+(`https://api.webgazer.io/ip-addresses`) without notice; the static file
+drifts out of sync, an unrecognised probe IP gets 403'd, and the heartbeat
+that IP was checking flips unhealthy.
+
+**Fix (routine, user-authorised 2026-08-08 — no need to ask first):**
+
+1. Compare current vs live:
+  `diff <(sort infrastructure/modules/cloudflare-access/ip/webgazer.txt) <(curl -s https://api.webgazer.io/ip-addresses | python3 -c "import json,sys; print('\n'.join(sorted(json.load(sys.stdin))))")`
+2. Replace the file contents with the current API response, one IP per
+  line, sorted the same way as the existing file, trailing newline.
+3. `make test` (Terraform/Terragrunt lint only — this does not apply
+  anything).
+4. `cd infrastructure/cloud/cloudflare/access && terragrunt plan` — confirm
+  the plan touches **only** `cloudflare_zero_trust_list.webgazer` (`0 to
+  add, 1 to change, 0 to destroy`). If the plan shows anything else,
+  stop and escalate instead — the narrow exception covers this exact
+  scoped change, not any other drift in this stack.
+5. `terragrunt apply -auto-approve` in that same directory.
+6. Verify: wait for the `Heartbeat`'s next check (its `interval`, e.g. 5m)
+  and confirm `status.healthy` flips to `true`. Note the check
+  immediately after `apply` may still fail once (Cloudflare edge
+  propagation lag) — that alone is not a fix failure, wait one more
+  interval before treating it as unresolved.
+7. Commit, push, open a PR referencing the stale-date and the new IP diff.
+  Classify as **trivial** and auto-merge once green (same as any other
+  single-concern, already-applied, no-secrets change) — the general
+  infra-as-code escalation rule does not apply to this specific,
+  narrow, pre-scoped fix.
+
 ## P2 path: Service mesh
 
 - `kubectl -n istio-system get pods` — mesh dashboard or ambient components

--- a/.claude/skills/self-healing/runbooks/merge-policy.md
+++ b/.claude/skills/self-healing/runbooks/merge-policy.md
@@ -74,8 +74,11 @@ dashboard/log retention unrelated to backup storage, non-secret feature
 flags that do not change exposure/auth/privilege, adding a
 PodDisruptionBudget with `minAvailable: 1` to a single-replica hand-written
 app chart (or enabling a bundled subchart's native PDB values option) that
-has no PDB at all, and manifest nits to satisfy an **existing** policy (no
-policy chart rewrite). Do not auto-merge `hostNetwork`, privileged
+has no PDB at all, manifest nits to satisfy an **existing** policy (no
+policy chart rewrite), and the Cloudflare Access WebGazer IP allowlist
+refresh described in `runbooks/ingress-mesh.md` (the one named exception to
+the infrastructure-as-code escalate rule in `references/escalation.md`,
+scoped strictly to that file and that `terragrunt plan` shape). Do not auto-merge `hostNetwork`, privileged
 `securityContext`, Service exposure, or auth flag changes — treat those as
 non-trivial. Excluding a workload from this PDB fix (vendored/generated
 operator manifests, or anything where an eviction mid-operation has a


### PR DESCRIPTION
## Summary

- Documents today's diagnosis (Heartbeat down -> Cloudflare Access 403 -> stale WebGazer probe-IP allowlist) as a runbook procedure in `runbooks/ingress-mesh.md`, so a future occurrence can be handled without asking first.
- Adds one narrow, named exception to the infra-as-code escalate rule in `references/escalation.md` and `runbooks/merge-policy.md`, scoped strictly to that one static IP-list file and that one `terragrunt plan` shape (`0 to add, 1 to change, 0 to destroy`, only the WebGazer list resource). Every other Terraform/OpenTofu/Terragrunt apply remains escalate-only.

## Test plan

- [x] `make test` passes