### PR TITLE
infra: migrate Cloudflare/UniFi/B2 config to tfconfig, fix heartbeat runbook

### DIFF
--- a/.claude/skills/self-healing/runbooks/ingress-mesh.md
+++ b/.claude/skills/self-healing/runbooks/ingress-mesh.md
@@ -29,7 +29,7 @@ clients, also consider RPi ARP/promisc issues documented in
 `documentation/gotcha.md` — host networking fixes are **escalate** (not
 unattended GitOps).
 
-## Heartbeat down: Cloudflare Access WebGazer IP allowlist stale
+## Heartbeat down: Cloudflare Access 403
 
 **Symptom:** `kubectl get heartbeat -A` (or a user-reported "otaru heartbeat
 down" alert) shows one `Heartbeat` `healthy: false` with `lastStatus: 403`
@@ -37,7 +37,7 @@ and `message: status code is not within expected ranges`, while every other
 Heartbeat CR is healthy and the rest of the cluster (nodes, pods, Argo CD
 Applications) checks out clean.
 
-**Confirm it is this, not a real backend problem:**
+**Step 1 — confirm it is Cloudflare Access, not a workload problem:**
 
 ```bash
 kubectl get heartbeat <name> -n <namespace> -o yaml   # read status + spec.endpointsSecret
@@ -50,6 +50,97 @@ Cloudflare Access response headers (`cf-access-domain`, `cf-access-aud`) on
 a 403 confirm Cloudflare Access rejected the request before it reached the
 cluster — this is not a workload or GitOps issue, do not chase pods/Argo CD
 for this symptom.
+
+**Step 2 — find out who is actually making the check. Do not assume it is an
+external probe (e.g. WebGazer) without checking.** The `heartbeats-operator`
+(`heartbeats-operator-controller-manager` in
+`heartbeats-operator-system`) performs the target health check **itself,
+from inside the cluster**, for every `Heartbeat` CR — the `healthyEndpoint`/
+`unhealthyEndpoint` URLs it also calls (e.g. `heartbeat.webgazer.io/...`)
+are only a dead-man's-switch status *report*, not the entity doing the
+probing. Confirm which one actually returned the 403:
+
+```bash
+kubectl logs -n heartbeats-operator-system \
+  deploy/heartbeats-operator-controller-manager --tail=200 \
+  | grep '"name":"<heartbeat-name>"'
+```
+
+A `"Health check completed"` line with `"status_code":403` for the target
+endpoint confirms the operator pod's own outbound request was denied — this
+is the common case for any `Heartbeat` whose target is this cluster's own
+public hostname (the request exits via the home router, then hairpins back
+in through the Cloudflare Tunnel).
+
+### Common cause: stale "Cluster IP List" after an ISP dynamic-IP change
+
+Because the check originates in-cluster, the source IP Cloudflare Access
+sees is the cluster's **own current public egress IP** — not any
+third-party service's IP. The bypass policy for this is "Cluster IP List"
+(fed by `tfconfig.cloudflare.zone.tunnel_ip_list`, see
+`infrastructure/modules/cloudflare-access/cluster.tf`). If the home ISP
+reassigns the public IP (e.g. during a WAN outage — see
+`documentation/gotcha.md`) and this list still has the old value, the
+operator's own check gets 403'd, indefinitely, until the list is updated.
+
+Diagnose:
+
+```bash
+# Actual current public egress IP as seen from inside the cluster
+kubectl run ip-check-$(date +%s) --image=curlimages/curl --restart=Never \
+  --command -- curl -s https://ifconfig.me
+# then kubectl logs/delete the pod
+
+# Live Cloudflare Access bypass list contents (Cluster IP List)
+curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/gateway/lists/<cluster-list-id>/items?per_page=50"
+```
+
+If the egress IP is not covered by the list, that is the cause. Confirm it
+is a genuine ISP reassignment (not a one-off fluke) by checking who owns
+the new IP and how many unrelated ranges that ISP announces:
+
+```bash
+whois -h whois.ripe.net <ip>   # confirms owning org/ASN
+curl -s "https://stat.ripe.net/data/announced-prefixes/data.json?resource=AS<n>" \
+  | python3 -c "import json,sys; print([p['prefix'] for p in json.load(sys.stdin)['data']['prefixes']])"
+```
+
+A residential ISP can announce many unrelated blocks (this cluster's ISP:
+119 prefixes across 5+ unrelated /16-ish ranges, observed 2026-08-09) —
+dynamic-IP reassignment can jump between completely different blocks, not
+just rotate within one local pool, so **no CIDR is guaranteed safe
+long-term**. Pinning the specific `/21` (or similar) containing the current
+IP is a practical middle ground, not a permanent fix — a future
+cross-pool reassignment will need this diagnosis repeated.
+
+**Fix — escalate, do not auto-apply.** Unlike the WebGazer allowlist below,
+this is **not** a pre-scoped, narrow exception: the right CIDR width is a
+judgement call each time (and building an automated IP-sync job is a real
+alternative worth raising with the user rather than assuming). Present the
+diagnosis and let the user choose:
+
+1. Update `tfconfig.cloudflare.zone.tunnel_ip_list` to the new value
+  (`op document edit tfconfig ...` — editing `tfconfig` itself, and only
+  `tfconfig`, is fine per `references/escalation.md`; do not read any
+  other 1Password item).
+2. Sync locally:
+  `op document get tfconfig --vault github-otaru > "$OTARU_TF_CONFIG_FILE"`.
+3. `terragrunt plan` in `infrastructure/cloud/cloudflare/access` — confirm
+  the plan touches **only** `cloudflare_zero_trust_list.cluster` (`0 to
+  add, 1 to change, 0 to destroy`).
+4. **Escalate the `terragrunt apply` step itself** — ask the user to run it
+  or explicitly approve it; do not run it unattended.
+5. Verify the same way as the WebGazer fix below (wait for the next
+  `Heartbeat` check interval, `status.healthy` flips to `true`).
+
+## Heartbeat down: Cloudflare Access WebGazer IP allowlist stale
+
+Only relevant when Step 2 above actually shows an **external** probe (not
+the in-cluster operator) being denied, or as routine hygiene independent of
+any specific incident — this list drifting stale does not, by itself,
+explain a 403 on a `Heartbeat` whose check the operator performs itself
+(the common case above).
 
 **Root cause:** the target hostname sits behind a Cloudflare Zero Trust
 Access application (`infrastructure/cloud/cloudflare/access`), with a

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1848,3 +1848,36 @@ still inject a previously read token until the process restarts.
 Architecture: [MCP authentication](mcp-auth.md).
 
 ---
+
+## `tfconfig` Hex-Looking IDs Silently Break `jsondecode()` Without Quotes
+
+### Symptom: Terragrunt Plan Fails to Parse `tfconfig`
+
+`terragrunt plan`/`apply` fails with `jsondecode(file(get_env("OTARU_TF_CONFIG_FILE")))`
+errors such as `Expecting ',' delimiter` at the line holding an account or
+zone ID, or (if the file happens to parse) locals end up missing an expected
+nested key entirely.
+
+### Cause: Unquoted Hex-String ID
+
+Cloudflare account/zone IDs are 32-character lowercase hex strings (`0-9a-f`).
+When hand-edited into the `tfconfig` 1Password Document as a bare value
+(`"id": 1033b99f3b339da676a3a416423b88f3`), the leading digits make it look
+like a JSON number to a careless editor, but the trailing hex letters make it
+invalid JSON syntax outright -- it is not a case of the wrong type, the file
+does not parse at all past that point.
+
+### Resolution: Quote Hex IDs and Re-sync
+
+Always quote hex-string IDs as JSON strings: `"id": "1033b99f3b339da676a3a416423b88f3"`.
+After any edit to the `tfconfig` Document, re-sync the local file and validate
+before trusting a `terragrunt plan`:
+
+```bash
+op document get tfconfig --vault github-otaru > "$OTARU_TF_CONFIG_FILE"
+python3 -c "import json, os; json.load(open(os.environ['OTARU_TF_CONFIG_FILE']))"
+```
+
+See [Secrets](secrets.md) `tfconfig` for the full schema and sync workflow.
+
+---

--- a/documentation/secrets.md
+++ b/documentation/secrets.md
@@ -40,23 +40,13 @@ export OTARU_TF_CONFIG_FILE="${OTARU_SECRETS_DIR}/tfconfig"
 
 export B2_APPLICATION_KEY=...
 export B2_APPLICATION_KEY_ID=...
-export B2_CNPG_BACKUP_BUCKET=...
-export B2_MEDIA_STORAGE_BUCKET=...
 
-export CLOUDFLARE_ACCOUNT_ID=...
 export CLOUDFLARE_API_TOKEN=...
 export CLOUDFLARE_TUNNEL_SECRET=...
-export CLOUDFLARE_ZONE=example.com
-export CLOUDFLARE_ZONE_ID=...
-export CLOUDFLARE_ZONE_SUBDOMAIN=subdomain
-export CLOUDFLARE_ZONE_TUNNEL_IP_LIST='["1.2.3.4/32"]'
-export CLOUDFLARE_DNS_IP=192.168.12.34
-export CLOUDFLARE_DNS_SUBDOMAINS='["subdomain1.internal","subdomain2.internal"]'
 
-# UniFi provider reads UNIFI_API (not UNIFI_API_URL). Keep both if other tools
-# still use UNIFI_API_URL.
-export UNIFI_API_URL=...
-export UNIFI_API="${UNIFI_API_URL}"
+# Controller URL is not an env var -- it comes from tfconfig
+# (unifi.controller.api_url), interpolated into the generated provider block
+# in infrastructure/root.hcl.
 export UNIFI_USERNAME=...
 export UNIFI_PASSWORD=...
 export UNIFI_LHR_WLAN01_PASSWORD=...
@@ -78,13 +68,39 @@ export GITHUB_TOKEN="$(gh auth token)"
 Terraform configuration that should stay outside the public repository belongs
 in `~/dotfiles/secrets/otaru/tfconfig`. Keep this local JSON file synchronized
 with the `tfconfig` Document item in the `github-otaru` 1Password vault,
-matching the existing `envrc` Document pattern. Only sensitive Terraform values
-belong here. Keep stable keys, fixed IPs, device roles, and other non-sensitive
-desired configuration in HCL:
+matching the existing `envrc` Document pattern. This covers Terraform values
+that are not credential secrets but would still reveal personal or home-network
+details if committed (Cloudflare zone/account identifiers, tunnel egress IP
+ranges, internal subdomain naming, UniFi client/device MACs). Keep everything
+else (module structure, non-identifying defaults) in HCL:
 
 ```json
 {
+  "b2": {
+    "bucket": {
+      "cnpg_backup": "example-cnpg-backup",
+      "media_storage": "example-media-storage"
+    }
+  },
+  "cloudflare": {
+    "account": {
+      "id": "..."
+    },
+    "zone": {
+      "hostname": "example.com",
+      "id": "...",
+      "subdomain": "example-subdomain",
+      "tunnel_ip_list": ["1.2.3.4/32"],
+      "dns_ip": "192.168.12.34"
+    },
+    "dns": {
+      "device-key": "subdomain.internal"
+    }
+  },
   "unifi": {
+    "controller": {
+      "api_url": "https://unifi.example.com"
+    },
     "clients": {
       "device-name": {
         "mac": "00:00:00:00:00:00"
@@ -99,16 +115,17 @@ desired configuration in HCL:
 }
 ```
 
-OpenTofu/Terragrunt providers take credentials from the environment only
-(see `infrastructure/root.hcl`):
+OpenTofu/Terragrunt providers take credentials from the environment
+(see `infrastructure/root.hcl`); UniFi's controller URL is the one non-secret
+exception, sourced from `tfconfig` instead:
 
-| Provider   | Environment variables                                                      |
-| ---------- | -------------------------------------------------------------------------- |
-| AWS        | standard AWS SDK chain (`AWS_PROFILE`, keys, etc.)                         |
-| B2         | `B2_APPLICATION_KEY`, `B2_APPLICATION_KEY_ID`                              |
-| Cloudflare | `CLOUDFLARE_API_TOKEN`                                                     |
-| GitHub     | `GITHUB_TOKEN`                                                             |
-| UniFi      | `UNIFI_USERNAME`, `UNIFI_PASSWORD`, `UNIFI_API`                            |
+| Provider   | Environment variables                              |
+|------------|----------------------------------------------------|
+| AWS        | standard AWS SDK chain (`AWS_PROFILE`, keys, etc.) |
+| B2         | `B2_APPLICATION_KEY`, `B2_APPLICATION_KEY_ID`      |
+| Cloudflare | `CLOUDFLARE_API_TOKEN`                             |
+| GitHub     | `GITHUB_TOKEN`                                     |
+| UniFi      | `UNIFI_USERNAME`, `UNIFI_PASSWORD`                 |
 
 Run `gh auth login` before Terraform targets or Helm OCI chart updates that
 need GitHub. Export `GITHUB_TOKEN` as above so the GitHub provider does not

--- a/infrastructure/cloud/b2/bucket/.terraform.lock.hcl
+++ b/infrastructure/cloud/b2/bucket/.terraform.lock.hcl
@@ -2,16 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/backblaze/b2" {
-  version     = "0.8.12"
-  constraints = "~> 0.8"
+  version     = "0.13.2"
+  constraints = "~> 0.13"
   hashes = [
-    "h1:+zf4b76chIrJbVcbzoenR8X+uFFnGhUjPUACpnBIYcs=",
-    "h1:BEkDopTPomebKDT/yhSQ2zp0zQUF9p6REQ/uKVXMiHM=",
-    "h1:DKZehZTdHC0fJzAA74yMzUaHm1PisNaNaBQjAOSS9kk=",
-    "h1:rA+Y9HyJGPV7kU52+9vKRM90RiGjdwj9Tas5ZImfsw0=",
-    "zh:bc9d25d21adeafba8edde8d6ffb6150cd5c86c207412c8941347966be3363de5",
-    "zh:c538eaea1b15379635b9d8a2cb862248813022bb0de5481741f18fcc77a10a1b",
-    "zh:cc2767797ad27b9a3b4ad97b6a2f3eeea9f50a6000bbcfa9b44189945dae30b3",
-    "zh:d83b5f0e632ea56570a0737c1896f049367201cc67f5de83baa24272ccdd56a4",
+    "h1:CvSGLZjfK6nBmUwWAttzVd/Yl43efMBP6k8MTYcfKSo=",
+    "h1:JrsBRoUeXwYXU0MUIyYfzatFzTG46nxn07gid7lMsK8=",
+    "h1:SLAIwqv4rdVsM2PaAZbUzAU0GLv+4VqYnjE8/MadR9w=",
+    "h1:ZLs3VUlLAnQGQFZPMKZiIcsuNCcyS4hnQqjuH31pqvY=",
+    "h1:dD31XsGhaqYadSqGeVjTrfB2La8SZmzrVjV1d7CTZEY=",
+    "zh:18200e500f82b6a017f65e59675be44c95c37fe75f95366a5e1f2cd5bed83d43",
+    "zh:702b2f81c76d36113be91aba7f99703e5993ccdb655b81b707379655f4aee7c9",
+    "zh:a77ca7f9b7e4f2559be2153f4c3d50916e460d4e940842f7a261b05e82bed79f",
+    "zh:bc94e85036235ab61d8743a1e5012be2da4bbb75b34f00ee48648bae67ce1386",
+    "zh:ce235c956b02f10748cd764cbf52caecc0e229fe8393d99a8c93c0a0317d0d1b",
   ]
 }

--- a/infrastructure/cloud/b2/bucket/terragrunt.hcl
+++ b/infrastructure/cloud/b2/bucket/terragrunt.hcl
@@ -7,8 +7,9 @@ terraform {
 }
 
 locals {
-  media_storage_bucket = get_env("B2_MEDIA_STORAGE_BUCKET")
-  cnpg_backup_bucket   = get_env("B2_CNPG_BACKUP_BUCKET")
+  tfconfig             = jsondecode(file(get_env("OTARU_TF_CONFIG_FILE")))
+  media_storage_bucket = local.tfconfig.b2.bucket.media_storage
+  cnpg_backup_bucket   = local.tfconfig.b2.bucket.cnpg_backup
 }
 
 inputs = {

--- a/infrastructure/cloud/cloudflare/access/terragrunt.hcl
+++ b/infrastructure/cloud/cloudflare/access/terragrunt.hcl
@@ -3,11 +3,12 @@ include {
 }
 
 locals {
-  account_id = get_env("CLOUDFLARE_ACCOUNT_ID")
-  zone       = get_env("CLOUDFLARE_ZONE")
-  zone_id    = get_env("CLOUDFLARE_ZONE_ID")
-  subdomain  = get_env("CLOUDFLARE_ZONE_SUBDOMAIN")
-  ip_list    = jsondecode(get_env("CLOUDFLARE_ZONE_TUNNEL_IP_LIST", "[]"))
+  tfconfig   = jsondecode(file(get_env("OTARU_TF_CONFIG_FILE")))
+  account_id = local.tfconfig.cloudflare.account.id
+  zone       = local.tfconfig.cloudflare.zone.hostname
+  zone_id    = local.tfconfig.cloudflare.zone.id
+  subdomain  = local.tfconfig.cloudflare.zone.subdomain
+  ip_list    = local.tfconfig.cloudflare.zone.tunnel_ip_list
 }
 
 terraform {

--- a/infrastructure/cloud/cloudflare/dns/terragrunt.hcl
+++ b/infrastructure/cloud/cloudflare/dns/terragrunt.hcl
@@ -3,10 +3,10 @@ include {
 }
 
 locals {
-  zone_id    = get_env("CLOUDFLARE_ZONE_ID")
   tfconfig   = jsondecode(file(get_env("OTARU_TF_CONFIG_FILE")))
+  zone_id    = local.tfconfig.cloudflare.zone.id
   subdomains = local.tfconfig.cloudflare.dns
-  ip         = get_env("CLOUDFLARE_DNS_IP")
+  ip         = local.tfconfig.cloudflare.zone.dns_ip
 }
 
 terraform {

--- a/infrastructure/cloud/cloudflare/tunnel/terragrunt.hcl
+++ b/infrastructure/cloud/cloudflare/tunnel/terragrunt.hcl
@@ -3,10 +3,11 @@ include {
 }
 
 locals {
-  zone_id       = get_env("CLOUDFLARE_ZONE_ID")
-  zone          = get_env("CLOUDFLARE_ZONE")
-  account_id    = get_env("CLOUDFLARE_ACCOUNT_ID")
-  name          = get_env("CLOUDFLARE_ZONE_SUBDOMAIN")
+  tfconfig      = jsondecode(file(get_env("OTARU_TF_CONFIG_FILE")))
+  zone_id       = local.tfconfig.cloudflare.zone.id
+  zone          = local.tfconfig.cloudflare.zone.hostname
+  account_id    = local.tfconfig.cloudflare.account.id
+  name          = local.tfconfig.cloudflare.zone.subdomain
   tunnel_secret = get_env("CLOUDFLARE_TUNNEL_SECRET")
 }
 

--- a/infrastructure/root.hcl
+++ b/infrastructure/root.hcl
@@ -21,6 +21,10 @@ locals {
   needs_github = startswith(local.unit_path, "cloud/cloudflare/access")
   needs_unifi  = startswith(local.unit_path, "local/")
 
+  # Only read tfconfig for units that need it, so a missing/invalid file does
+  # not block plans for stacks that have nothing to do with UniFi.
+  unifi_api_url = local.needs_unifi ? jsondecode(file(get_env("OTARU_TF_CONFIG_FILE"))).unifi.controller.api_url : ""
+
   required_providers_hcl = join("\n", compact([
     local.needs_aws ? <<-EOT
     aws = {
@@ -79,8 +83,14 @@ EOT
     local.needs_cloudflare ? "provider \"cloudflare\" {}" : "",
     # Credentials: GITHUB_TOKEN
     local.needs_github ? "provider \"github\" {}" : "",
-    # Credentials: UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_API
-    local.needs_unifi ? "provider \"unifi\" {}" : "",
+    # Credentials: UNIFI_USERNAME, UNIFI_PASSWORD. The controller URL is not a
+    # credential -- it comes from tfconfig (unifi.controller.api_url) below, not env.
+    local.needs_unifi ? <<-EOT
+provider "unifi" {
+  api_url = "${local.unifi_api_url}"
+}
+EOT
+    : "",
   ]))
 }
 
@@ -88,7 +98,9 @@ EOT
 terraform_binary = "tofu"
 
 # Provider credentials are read from the process environment (see documentation/secrets.md).
-# Do not interpolate secrets into this generate block — they would land in .terragrunt-cache.
+# Do not interpolate secrets into this generate block -- they would land in
+# .terragrunt-cache. tfconfig-sourced non-secret config (e.g. unifi.controller.api_url)
+# is the one exception; it is not credential material.
 generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"


### PR DESCRIPTION
## Summary

- Moves `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE`, `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_ZONE_SUBDOMAIN`, `CLOUDFLARE_ZONE_TUNNEL_IP_LIST`, `CLOUDFLARE_DNS_IP`, `B2_CNPG_BACKUP_BUCKET`, `B2_MEDIA_STORAGE_BUCKET`, and the UniFi controller URL (previously `UNIFI_API`) out of `envrc` and into the `tfconfig` 1Password Document, matching the existing pattern `dns/terragrunt.hcl` already used for `cloudflare.dns`.
- Fixes an unrelated pre-existing b2 provider lock drift found while validating the migration.
- Updates `documentation/secrets.md` to match the new `tfconfig` schema, and adds a `documentation/gotcha.md` entry for a JSON-quoting bug hit twice while hand-editing `tfconfig` (a bare hex-string ID is invalid JSON, not just the wrong type).
- Restructures the self-healing skill's Heartbeat-down runbook: the health check is performed by the in-cluster `heartbeats-operator` for most Heartbeats, not an external prober -- documents how to tell the difference and the common root cause (stale Cloudflare Access IP allowlist after an ISP dynamic-IP change), found and fixed live during this session.

## Verification

Every touched Terraform/Terragrunt unit (`access`, `tunnel`, `dns`, `b2/bucket`, `unifi`, `unifi-firewall-rules`) was already applied live and confirmed via `terragrunt plan`: no changes, live infrastructure matches the new config source exactly. This PR only catches up version control to match already-applied state -- merging does not trigger any new infrastructure change.

## Test plan

- [x] `make test` passes
- [x] `terragrunt plan` on every touched unit shows no drift