### PR TITLE
fix(longhorn-volume-lib): stop asserting empty scheduling-error annotation

### DIFF
--- a/helm-charts/changedetection-volume/Chart.lock
+++ b/helm-charts/changedetection-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.1
-digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
-generated: "2026-07-05T18:11:18.526674+01:00"
+  version: 0.3.2
+digest: sha256:b5dd0131a639e8db32a6cb8d64b9bbfff58fa919d5c41121e2e04df2d9be7531
+generated: "2026-08-09T20:40:35.685242+01:00"

--- a/helm-charts/changedetection-volume/Chart.yaml
+++ b/helm-charts/changedetection-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.3.1
+  version: 0.3.2
   repository: file://../longhorn-volume-lib

--- a/helm-charts/home-assistant-volume/Chart.lock
+++ b/helm-charts/home-assistant-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.1
-digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
-generated: "2026-07-05T18:11:21.317414+01:00"
+  version: 0.3.2
+digest: sha256:b5dd0131a639e8db32a6cb8d64b9bbfff58fa919d5c41121e2e04df2d9be7531
+generated: "2026-08-09T20:40:39.923438+01:00"

--- a/helm-charts/home-assistant-volume/Chart.yaml
+++ b/helm-charts/home-assistant-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn-volume-lib
-  version: 0.3.1
+  version: 0.3.2
   repository: file://../longhorn-volume-lib

--- a/helm-charts/longhorn-volume-lib/Chart.yaml
+++ b/helm-charts/longhorn-volume-lib/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: longhorn-volume-lib
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.1
+version: 0.3.2
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/longhorn-volume-lib/templates/volume.yaml
+++ b/helm-charts/longhorn-volume-lib/templates/volume.yaml
@@ -7,7 +7,10 @@ kind: PersistentVolume
 metadata:
   name: {{ $key }}-pv
   annotations:
-    longhorn.io/volume-scheduling-error: ''
+    # longhorn.io/volume-scheduling-error is written and cleared by the
+    # Longhorn CSI driver at runtime; asserting it here as empty causes
+    # perpetual Argo CD drift once Longhorn sets it during a transient
+    # scheduling event and does not reset it back to empty afterwards.
     pv.kubernetes.io/provisioned-by: driver.longhorn.io
     volume.kubernetes.io/provisioner-deletion-secret-name: longhorn-crypto
     volume.kubernetes.io/provisioner-deletion-secret-namespace: longhorn-system

--- a/helm-charts/openclaw-volume/Chart.lock
+++ b/helm-charts/openclaw-volume/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn-volume-lib
   repository: file://../longhorn-volume-lib
-  version: 0.3.1
-digest: sha256:027a9d1e9a315f8a940a844943a95c30b8c41241c3d72bfeb392a3067987514c
-generated: "2026-07-05T18:11:24.088336+01:00"
+  version: 0.3.2
+digest: sha256:b5dd0131a639e8db32a6cb8d64b9bbfff58fa919d5c41121e2e04df2d9be7531
+generated: "2026-08-09T20:40:43.818281+01:00"

--- a/helm-charts/openclaw-volume/Chart.yaml
+++ b/helm-charts/openclaw-volume/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
   - name: longhorn-volume-lib
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../longhorn-volume-lib


### PR DESCRIPTION
## Summary

- `openclaw-volume`'s Argo CD Application has been `OutOfSync` for over 10 days on a single PersistentVolume annotation: `longhorn.io/volume-scheduling-error`.
- Longhorn's CSI driver writes and clears this annotation itself at runtime when a scheduling event occurs and resolves. The shared `longhorn-volume-lib` chart hardcoded it to an empty string, so once Longhorn set a real value during a transient scheduling error, the chart's desired state permanently disagreed with the live value even after the volume self-recovered.
- Removed the annotation from the chart template so Longhorn fully owns its lifecycle. Bumped `longhorn-volume-lib` to 0.3.2 and picked it up in all three consumers (`openclaw-volume`, `home-assistant-volume`, `changedetection-volume`) so the same drift class doesn't reappear for the others.

Found via a routine `/self-healing` pass; classified non-trivial (shared chart, three consumers) so merge is left to review rather than auto-merged.

## Test plan

- [x] `make test` passes locally (Helm lint/template, YAML, markdown, EditorConfig, Terraform/Terragrunt lint, zizmor, digest check, Grafana dashboard validation)
- [ ] After merge, confirm Argo CD reconciles `openclaw-volume` (and the other two) to `Synced`