### PR TITLE
fix(argocd): revert repo-server TLS regression in argo-cd 10.2.3

### DIFF
--- a/helm-charts/argocd/Chart.lock
+++ b/helm-charts/argocd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 10.2.3
-digest: sha256:db5cc0d48ae22f397e01da18b31430a78f1ce7a0a2c05c6f764a746199530ae9
-generated: "2026-08-12T08:13:38.774119133Z"
+  version: 10.2.2
+digest: sha256:0ee79db7ad8a64cc1db3f31c983ce39f47928dfdd994410a5fe7cec1a2505f38
+generated: "2026-08-12T09:55:12.808418+01:00"

--- a/helm-charts/argocd/Chart.yaml
+++ b/helm-charts/argocd/Chart.yaml
@@ -6,5 +6,11 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: argo-cd
-  version: 10.2.3
+  # Pinned below latest: 10.2.3's repo-server unconditionally derives
+  # --client-ca-path even with reposerver.disable.tls: true set (no
+  # argocd-repo-server-tls secret present here), and the repo-server CLI
+  # rejects that combination outright -- CrashLoopBackOff on every repo-server
+  # pod. Reverted to the last known-good 10.2.2 until upstream fixes this;
+  # do not bump past 10.2.3 without confirming the regression is resolved.
+  version: 10.2.2
   repository: https://argoproj.github.io/argo-helm

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,5 +26,14 @@
       ],
       abandonmentThreshold: null,
     },
+    {
+      // 10.2.3's repo-server crash-loops with reposerver.disable.tls: true
+      // (see helm-charts/argocd/Chart.yaml comment). Remove this pin once
+      // the fix is confirmed in a later argo-cd chart release.
+      matchDepNames: [
+        'argo-cd',
+      ],
+      allowedVersions: '<=10.2.2',
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Today's Renovate bump (#3033, argo-cd 10.2.2 -> 10.2.3) broke the `argocd-repo-server`: `Error: --client-ca-path cannot be used when --disable-tls is enabled`.
- We set `reposerver.disable.tls: true` deliberately (ambient HBONE east-west encryption conflicts with app-layer TLS + waypoint interception, per the existing chart comment). No `argocd-repo-server-tls` secret exists in the cluster, so this isn't something wrong on our side -- the 10.2.3 repo-server binary appears to unconditionally derive `--client-ca-path` regardless.
- Impact was contained: the previous ReplicaSet's pod (28h old at the time) kept `Running` and serving reconciliation throughout, so Argo CD itself stayed usable but its own Application flipped `Degraded` and the new ReplicaSet crash-looped.
- Reverted `helm-charts/argocd/Chart.yaml`/`Chart.lock` to the last known-good `10.2.2`, and added a Renovate `packageRules` pin (`allowedVersions: '<=10.2.2'`) so it doesn't immediately reopen a PR that reintroduces the same regression.

Found and fixed via a routine `/self-healing` pass. Classifying non-trivial (touches Argo CD's own chart version, the GitOps reconciler everything else depends on) -- leaving the merge to review rather than auto-merging, even though this is a pure revert to a previously-stable state.

## Test plan

- [x] `make test` passes locally (Helm lint/template, YAML, EditorConfig, Terraform/Terragrunt lint, zizmor, digest check, Grafana dashboard validation)
- [ ] After merge, confirm the `argocd` Application returns to `Synced`/`Healthy` and the repo-server pod stabilizes without crash-looping