### PR TITLE
fix(argocd): use CLI arg instead of env var to override client-ca-path

### DIFF
--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -157,12 +157,20 @@ argo-cd:
     # non-empty --client-ca-path outright (cmd/argocd-repo-server/commands/
     # argocd_repo_server.go), regardless of whether that file exists --
     # CrashLoopBackOff on every repo-server pod (see helm-charts/argocd/
-    # Chart.yaml). The chart does not wire the new reposerver.client.ca.path
-    # argocd-cmd-params-cm key into an env var, so override the flag's
-    # underlying env var directly to restore the pre-3.5 empty default.
-    env:
-      - name: ARGOCD_REPO_SERVER_CLIENT_CA_PATH
-        value: ""
+    # Chart.yaml).
+    #
+    # 2026-08-13: an env var override (ARGOCD_REPO_SERVER_CLIENT_CA_PATH: "")
+    # does NOT work and caused a live CrashLoopBackOff after merge -- confirmed
+    # via upstream source (util/env.StringFromEnv, called without the
+    # AllowEmpty option for this flag) that an env var explicitly set to ""
+    # is indistinguishable from unset and silently falls back to the
+    # non-empty default. Even upstream's own documented
+    # argocd-cmd-params-cm.yaml example (reposerver.client.ca.path: "") has
+    # this same bug when combined with --disable-tls. Only an explicit CLI
+    # flag override works, since pflag treats an explicitly-passed argument
+    # as authoritative regardless of the computed default.
+    extraArgs:
+      - --client-ca-path=
     metrics:
       enabled: true
     replicas: 1


### PR DESCRIPTION
Closes #3039.

## Summary

Fixes a live incident introduced by the previous merge: an env var override for the repo-server's client CA path does not actually work, and merging it put the `argocd-repo-server` Deployment into `CrashLoopBackOff` on the new pod (old pod stayed up and kept serving traffic throughout -- no user-facing outage, but the Deployment was stuck mid-rollout).

## Root cause of the previous fix's failure

The repo-server binary resolves its client-CA-path flag default from an environment variable helper that only returns the env var's actual value when it is non-empty, or when the caller opts in to allowing empty values -- this particular flag registration does neither. So an env var explicitly set to an empty string is indistinguishable from unset, and the flag silently falls back to its non-empty built-in default -- the exact value that trips the "cannot combine with disable-tls" validation. The equivalent ConfigMap-based configuration route has the same underlying gap.

## Fix

Pass the flag directly as a container CLI argument (`repoServer.extraArgs: ["--client-ca-path="]`) instead of an env var. A CLI flag passed at the process level is authoritative regardless of the computed default. Confirmed the rendered manifest emits it correctly (`helm template` shows `--client-ca-path=` as a literal `args:` entry, with no leftover env var).

## Test plan

- [x] `helm template argocd helm-charts/argocd` renders `--client-ca-path=` in the repo-server container `args:`, and confirmed no client-ca-path env var remains
- [x] `make test` passes
- [x] CI green
- [ ] After merge: confirm the crash-looping `argocd-repo-server` ReplicaSet is replaced by a healthy one, `argocd` Application back to `Synced`/`Healthy`