### PR TITLE
docs(self-healing): label PRs automated, document-first fixes, no cross-repo refs

### DIFF
--- a/.claude/skills/self-healing/SKILL.md
+++ b/.claude/skills/self-healing/SKILL.md
@@ -175,17 +175,38 @@ user-facing app down → everything else.
 
 Default to GitOps:
 
-1. Diagnose in the live cluster.
+1. Diagnose in the live cluster. For anything beyond a known/routine
+    pattern (a genuine root-cause investigation, not a digest/version
+    bump), check official documentation for the affected component before
+    deciding on a fix — prefer the properly documented configuration over
+    a guess or workaround. If documentation gives a real answer,
+    implement that fix, not a stopgap. Verify the fix actually took
+    effect against the live/rendered state (for example the rendered
+    container spec), not just that `helm template` / `make test` pass —
+    a config override can render without error yet still be a no-op at
+    runtime (see `documentation/gotcha.md` for a case where this happened).
 2. Patch the otaru repo (`helm-charts/`, `argocd/`, manifests).
 3. Run `make test` in the otaru repo before opening a PR. If it fails on
     unrelated drift, journal the failure and escalate — do not bypass
     checks.
 4. Before opening, check journal `pr` and `gh pr list --state open` for the
     same root cause; continue an in-flight PR when one exists.
-5. Branch, commit, push, open a PR.
-6. Classify and merge per `runbooks/merge-policy.md`. Journal the PR URL
+5. Branch, commit, push, open a PR labelled `automated` (`gh pr edit
+    <number> --add-label automated`; create the label first if it does not
+    exist yet). For a non-trivial root-cause fix (not a routine
+    digest/version bump), also open a tracking Issue in this repo
+    (labelled `automated`) describing the problem and fix, and reference
+    it from the PR body (`Closes #<n>`).
+6. Never name, link, or reference another GitHub repository — by org/repo
+    name, issue/PR number, commit SHA, or file path within that repo — in
+    any commit message, Issue, or PR body in this repo. Describe upstream
+    behaviour in our own words instead (for example "the underlying
+    controller's default changed in its 3.5 release line", not a link to
+    the PR that changed it). This applies even when the upstream project
+    is public.
+7. Classify and merge per `runbooks/merge-policy.md`. Journal the PR URL
     and whether merge was auto or held.
-7. Immediately after this PR's outcome is known (merged, or held green for
+8. Immediately after this PR's outcome is known (merged, or held green for
     the user), run `runbooks/branch-cleanup.md` — do not wait for the next
     scheduled run. A PR can merge before you notice; continuing to commit
     to a closed PR's branch wastes work.

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1881,3 +1881,51 @@ python3 -c "import json, os; json.load(open(os.environ['OTARU_TF_CONFIG_FILE']))
 See [Secrets](secrets.md) `tfconfig` for the full schema and sync workflow.
 
 ---
+
+## An Env Var Set to an Empty String Can Silently Be Treated as Unset
+
+### Symptom: Config Override Renders Cleanly but Has No Effect at Runtime
+
+A Helm values override adds a container environment variable set to an
+empty string, intending to blank out a component's built-in non-empty
+default. `helm template` and `make test` both pass, the rendered manifest
+shows the env var exactly as written -- but the running container still
+behaves as if the default were in effect, and if that default conflicts
+with another setting, the pod crash-loops on the *identical* error the
+override was meant to fix.
+
+### Cause: Empty-String-vs-Unset Ambiguity in the Component's Own Config Parsing
+
+Some Go-based controllers resolve a flag's default value from an
+environment variable using a helper that only returns the variable's
+actual value when it is non-empty (unless the specific call site opts in
+to allowing empty values). An environment variable explicitly set to `""`
+is then indistinguishable from an unset one, and the flag silently falls
+back to its non-empty built-in default. Static validation (a clean
+`helm template` render, `make test`) cannot catch this, because the
+override looks correct in the rendered manifest -- the bug only shows up
+in the running process's actual resolved config.
+
+This bit `helm-charts/argocd/values.yaml`: an env var override intended to
+blank out a repo-server flag rendered correctly but had no effect,
+producing a live `CrashLoopBackOff` after merge even though CI was green
+and the pre-merge render looked exactly as intended.
+
+### Resolution: Prefer an Explicit CLI Argument, and Verify Against the Live Pod
+
+When overriding a component's flag to an *empty* value specifically (not
+just a non-default non-empty value), prefer passing it as an explicit
+command-line argument on the container (`extraArgs`-style values.yaml
+keys, when the chart exposes one) rather than an environment variable. A
+CLI argument passed at the process level is authoritative regardless of
+how the binary computes its default, so this does not depend on the
+component's own env-parsing behaviour.
+
+More generally: after any fix intended to change a component's resolved
+runtime config, verify against the live or rendered *container spec*
+(`kubectl get pod ... -o json`, or the exact `args`/`env` in
+`helm template` output) that the value actually took effect, not just
+that the values.yaml diff looks right and CI is green. A clean render is
+necessary but not sufficient evidence that an override works.
+
+---


### PR DESCRIPTION
## Summary

Codifies three policy corrections from this session's argo-cd repo-server incident:

- Every PR the self-healing skill creates gets an `automated` label (creating the label first if needed).
- For a non-trivial root-cause fix, check official documentation for the affected component before deciding on a fix, prefer the properly documented configuration over a workaround, and open a tracking Issue in this repo (also labelled `automated`) describing the problem and fix.
- Never name, link, or reference another GitHub repository -- by org/repo name, issue/PR number, commit SHA, or file path within that repo -- in any commit message, Issue, or PR body in this repo. Describe upstream behaviour in our own words instead.

Also backfilled the `automated` label onto every historical self-healing-created PR found in the journal (`.scratchpad/SELF_HEALING.md`, not tracked in this repo) -- not part of this diff, done directly via the GitHub API.

## Gotcha added

`documentation/gotcha.md`: an environment variable explicitly set to an empty string can be indistinguishable from unset in some components' own config parsing, so a values.yaml override can render cleanly and pass CI while still being a no-op at runtime. Prefer an explicit CLI argument for this class of override, and verify against the live/rendered container spec, not just the values diff.

## Test plan

- [x] `make test` passes
- [ ] CI green