### PR TITLE
fix(teslamate): bump garbage-collected main image digest

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -34,10 +34,11 @@ deployment:
     # for any floating-tag digest pin here. Bumped to the current main
     # digest again.
     repository: ghcr.io/teslamate-org/teslamate
-    # 2026-08-15: previous main@10690d2d digest was garbage-collected
-    # upstream in turn -- fourth occurrence of this recurring failure mode.
+    # 2026-08-21: previous main@ed3d6109 digest was garbage-collected
+    # upstream in turn -- fifth occurrence of this recurring failure mode
+    # (ImagePullBackOff, confirmed NotFound against the registry).
     # Bumped to the current main digest again.
-    tag: main@sha256:ed3d6109e9245b7c8eb11a55e91efb51865f85fec8fc3f2c00a8c63942cd8ade
+    tag: main@sha256:3751c1ebb9023618bf2869b176b6ff25cc03e97c90b12afc67e3d067c0adc283
   envFrom:
     - secretRef:
         name: teslamate


### PR DESCRIPTION
## Summary

- The pinned `main@ed3d6109` digest for `ghcr.io/teslamate-org/teslamate` was garbage-collected upstream, causing `ImagePullBackOff` on the teslamate Deployment (confirmed via a live `NotFound` against the registry, repeated over 25 minutes).
- Fifth occurrence of this recurring failure mode for this floating `:main` tag pin (see the chart's inline comment history for the prior four).
- Bumped to the current `main` digest (verified as a valid multi-arch OCI image index against `ghcr.io`).

## Test plan

- [x] `make test` passes locally (Helm validation, pinned-digest check)
- [ ] CI green
- [ ] Confirm the teslamate Deployment rolls out cleanly after merge (ImagePullBackOff clears)

Automated fix from the self-healing loop.