### PR TITLE
feat(jung2bot): let dev run the Go rewrite independently of prod

### DIFF
--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -4,12 +4,23 @@ secret:
   remoteRef:
     key: jung2bot-dev
 
+# Off while dev trials the Go rewrite. The VPA is memory-only and would shrink
+# the request to fit Go, so a rollback to the heavier JS image would OOMKill.
+vpa:
+  enabled: false
+
 app:
+  # Pinned here so dev and prod can run different images. JS is 5.x, Go is 6.x,
+  # same repository, so a rollback is one line.
+  image:
+    tag: jung2bot-5.2.1@sha256:a75c29f70aa9b1c961386989c223b777b8c85502c50a9ac333349786102ed94d
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug
     messageTable: jung2bot-dev-messages
-    scaleUpReadCapacity: 1
+    # Must exceed the tables' provisioned read capacity of 1, or UpdateTable is
+    # a no-op that the service reports as success.
+    scaleUpReadCapacity: 5
     stage: dev
   autoscaling:
     min: 1

--- a/infrastructure/cloud/aws/jung2bot-dev/dynamodb/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/dynamodb/terragrunt.hcl
@@ -6,18 +6,30 @@ terraform {
   source = "${get_parent_terragrunt_dir()}//modules/aws-dynamodb"
 }
 
+# Provisioned, like prod, so dev can exercise onScaleUp. That calls UpdateTable
+# with a provisioned throughput, which DynamoDB rejects on an on-demand table.
+# Capacity stays at the module minimum of 1, inside the always-free allowance,
+# with a ceiling of 10 so autoscaling can return the table to 1 afterwards.
 inputs = {
   tables = {
     chatIds = {
-      attributes = [{ name = "chatId", type = "N" }, ]
-      hash_key   = "chatId"
-      name       = "jung2bot-dev-chatIds"
+      attributes          = [{ name = "chatId", type = "N" }, ]
+      autoscaling_enabled = true
+      autoscaling_read    = { max_capacity = 10 }
+      autoscaling_write   = { max_capacity = 10 }
+      billing_mode        = "PROVISIONED"
+      hash_key            = "chatId"
+      name                = "jung2bot-dev-chatIds"
     }
     messages = {
-      attributes = [{ name = "chatId", type = "N" }, { name = "dateCreated", type = "S" }]
-      hash_key   = "chatId"
-      name       = "jung2bot-dev-messages"
-      range_key  = "dateCreated"
+      attributes          = [{ name = "chatId", type = "N" }, { name = "dateCreated", type = "S" }]
+      autoscaling_enabled = true
+      autoscaling_read    = { max_capacity = 10 }
+      autoscaling_write   = { max_capacity = 10 }
+      billing_mode        = "PROVISIONED"
+      hash_key            = "chatId"
+      name                = "jung2bot-dev-messages"
+      range_key           = "dateCreated"
     }
   }
 }


### PR DESCRIPTION
Let dev run the Go rewrite of telegram-jung2-bot without touching prod.

- Pin `app.image.tag` in dev to the current JS image, so this PR changes nothing that is running. Switching dev to Go later, or back, is one line.
- Turn off the VPA for dev. It would drift the pod towards a low memory floor and cause OOMKills on rollback.
- Switch dev DynamoDB tables to provisioned (1 RCU/WCU, matching prod), and raise `scaleUpReadCapacity` from 1 to 5. On-demand tables reject the scale-up call today, so `onScaleUp` always returns 503 on dev.

All changes are dev-only. Prod is untouched.
