### PR TITLE
fix(vpa): lower recommender's global min-resource floor

### DIFF
--- a/helm-charts/vpa/values.yaml
+++ b/helm-charts/vpa/values.yaml
@@ -34,6 +34,18 @@ vertical-pod-autoscaler:
       renewBefore: 360h
   recommender:
     replicas: 1
+    # 2026-08-22: the recommender's compiled-in defaults
+    # (--pod-recommendation-min-memory-mb=250,
+    # --pod-recommendation-min-cpu-millicores=25) are a global floor that
+    # overrides every VPA's own tuned per-workload minAllowed. Idle
+    # workloads (cyberchef, jsoncrack, excalidraw, reloader, k8s-cleaner --
+    # real usage 4-29Mi) were all being clamped up to ~250Mi regardless of
+    # their own minAllowed (32Mi). Set both flags near zero so each VPA's
+    # own minAllowed/maxAllowed does the real work instead of this
+    # one-size-fits-all default.
+    extraArgs:
+      - --pod-recommendation-min-memory-mb=1
+      - --pod-recommendation-min-cpu-millicores=1
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary

- The VPA recommender's compiled-in defaults (`--pod-recommendation-min-memory-mb=250`, `--pod-recommendation-min-cpu-millicores=25`) apply a global floor to every recommendation, overriding each VPA's own tuned per-workload `minAllowed`.
- Confirmed live: cyberchef, jsoncrack, excalidraw, reloader, and k8s-cleaner (real usage 4-29Mi each) all had `uncappedTarget` clamped to ~250Mi despite their own `minAllowed` being 32Mi.
- Set both flags to `1` on the recommender so each VPA's own `minAllowed`/`maxAllowed` is the actual constraint, not this one-size-fits-all default.

## Test plan

- [x] `make test` passes (Helm chart validation)
- [x] `helm template` confirms both `extraArgs` render on the recommender container
- [ ] CI green
- [ ] After merge: confirm the affected VPAs' `target` recommendations drift down toward real usage over the next few reconcile cycles (memory histogram takes some time to re-settle)