### PR TITLE
feat(jung2bot): restrict onOffFromWork/onScaleUp to in-cluster callers

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $stagePrefix := printf "/jung2bot/%s" .Values.app.env.stage -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -21,3 +22,19 @@ spec:
         - operation:
             ports:
               - "3000"
+{{- if .Values.adminRoutesInternalOnly }}
+            paths:
+              - {{ $stagePrefix }}/
+              - {{ $stagePrefix }}/ping
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ .Values.namespace }}/sa/default
+      to:
+        - operation:
+            ports:
+              - "3000"
+            paths:
+              - {{ $stagePrefix }}/onOffFromWork
+              - {{ $stagePrefix }}/onScaleUp
+{{- end }}

--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -1,3 +1,5 @@
+{{- $stagePrefix := printf "/jung2bot/%s" .Values.app.env.stage -}}
+{{- $internalBaseURL := printf "http://%s.%s.svc.cluster.local:3000" .Values.name .Values.namespace -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -24,11 +26,16 @@ spec:
               env:
                 - name: CRON_INTERVAL
                   value: {{ .Values.cron.offWork.env.cronInterval | quote }}
+{{- if .Values.adminRoutesInternalOnly }}
+                - name: OFF_FROM_WORK_URL
+                  value: {{ printf "%s%s/onOffFromWork" $internalBaseURL $stagePrefix | quote }}
+{{- else }}
                 - name: OFF_FROM_WORK_URL
                   valueFrom:
                     secretKeyRef:
                       key: OFF_FROM_WORK_URL
                       name: jung2bot-secrets
+{{- end }}
               resources:
                 requests:
                   cpu: "0.1"
@@ -83,11 +90,16 @@ spec:
                 - "5"
                 - "$(SCALE_UP_URL)"
               env:
+{{- if .Values.adminRoutesInternalOnly }}
+                - name: SCALE_UP_URL
+                  value: {{ printf "%s%s/onScaleUp" $internalBaseURL $stagePrefix | quote }}
+{{- else }}
                 - name: SCALE_UP_URL
                   valueFrom:
                     secretKeyRef:
                       key: SCALE_UP_URL
                       name: jung2bot-secrets
+{{- end }}
               resources:
                 requests:
                   cpu: "0.5"

--- a/helm-charts/jung2bot/templates/route-public.yaml
+++ b/helm-charts/jung2bot/templates/route-public.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $stagePrefix := printf "/jung2bot/%s" .Values.app.env.stage -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -15,13 +16,36 @@ spec:
       name: {{ $gatewayName }}
       namespace: {{ $gatewayNamespace }}
   rules:
+{{- if .Values.adminRoutesInternalOnly }}
     - matches:
         - path:
-            type: PathPrefix
-            value: /{{ .Values.name }}/{{ .Values.app.env.stage }}/
+            type: Exact
+            value: {{ $stagePrefix }}/
       backendRefs:
         - group: ""
           kind: Service
           name: {{ .Values.name }}
           port: 3000
           weight: 1
+    - matches:
+        - path:
+            type: Exact
+            value: {{ $stagePrefix }}/ping
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.name }}
+          port: 3000
+          weight: 1
+{{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $stagePrefix }}/
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.name }}
+          port: 3000
+          weight: 1
+{{- end }}

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -1,5 +1,10 @@
 namespace: jung2bot-dev
 
+# onOffFromWork/onScaleUp were reachable from the public internet with no
+# auth in dev (inherited from JS, which never validated the scheduler
+# token). This routes them to only the in-cluster CronJobs instead.
+adminRoutesInternalOnly: true
+
 secret:
   remoteRef:
     key: jung2bot-dev

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -11,6 +11,11 @@ namespace: jung2bot
 vpa:
   enabled: true
 
+# Restricts onOffFromWork/onScaleUp to in-cluster callers instead of the
+# public Gateway route. Off here until the dev-verified rollout lands here
+# too in a follow-up change.
+adminRoutesInternalOnly: false
+
 secret:
   remoteRef:
     key: jung2bot


### PR DESCRIPTION
`onOffFromWork` and `onScaleUp` are meant to be called only by the in-cluster CronJobs, but ride along on the public Gateway route (needed for Telegram's webhook) with no working auth in dev — inherited unchanged from legacy JS, which never validated the scheduler token server-side.

- AuthorizationPolicy: gateway principal scoped to just the webhook + `/ping`; CronJobs' own ServiceAccount allowed only on the two admin paths.
- Public HTTPRoute: drops the broad prefix match for those two paths.
- CronJobs call the in-cluster Service directly, so `OFF_FROM_WORK_URL`/`SCALE_UP_URL` no longer need to be secrets.

Gated behind `adminRoutesInternalOnly`, `true` in dev only. Prod's rendering is byte-for-byte unchanged (diffed `helm template` output before/after this change). Prod flips the flag in a follow-up PR once dev has run clean.