### PR TITLE
feat(jung2bot): make admin routes internal-only unconditionally

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -22,7 +22,6 @@ spec:
         - operation:
             ports:
               - "3000"
-{{- if .Values.adminRoutesInternalOnly }}
             paths:
               - {{ $stagePrefix }}/
               - {{ $stagePrefix }}/ping
@@ -37,4 +36,3 @@ spec:
             paths:
               - {{ $stagePrefix }}/onOffFromWork
               - {{ $stagePrefix }}/onScaleUp
-{{- end }}

--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -26,16 +26,8 @@ spec:
               env:
                 - name: CRON_INTERVAL
                   value: {{ .Values.cron.offWork.env.cronInterval | quote }}
-{{- if .Values.adminRoutesInternalOnly }}
                 - name: OFF_FROM_WORK_URL
                   value: {{ printf "%s%s/onOffFromWork" $internalBaseURL $stagePrefix | quote }}
-{{- else }}
-                - name: OFF_FROM_WORK_URL
-                  valueFrom:
-                    secretKeyRef:
-                      key: OFF_FROM_WORK_URL
-                      name: jung2bot-secrets
-{{- end }}
               resources:
                 requests:
                   cpu: "0.1"
@@ -90,16 +82,8 @@ spec:
                 - "5"
                 - "$(SCALE_UP_URL)"
               env:
-{{- if .Values.adminRoutesInternalOnly }}
                 - name: SCALE_UP_URL
                   value: {{ printf "%s%s/onScaleUp" $internalBaseURL $stagePrefix | quote }}
-{{- else }}
-                - name: SCALE_UP_URL
-                  valueFrom:
-                    secretKeyRef:
-                      key: SCALE_UP_URL
-                      name: jung2bot-secrets
-{{- end }}
               resources:
                 requests:
                   cpu: "0.5"

--- a/helm-charts/jung2bot/templates/external-secret.yaml
+++ b/helm-charts/jung2bot/templates/external-secret.yaml
@@ -26,19 +26,3 @@ spec:
         key: {{ .Values.secret.remoteRef.key }}
         metadataPolicy: None
         property: EVENT_QUEUE_URL
-    - secretKey: OFF_FROM_WORK_URL
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        nullBytePolicy: Ignore
-        key: {{ .Values.secret.remoteRef.key }}
-        metadataPolicy: None
-        property: OFF_FROM_WORK_URL
-    - secretKey: SCALE_UP_URL
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        nullBytePolicy: Ignore
-        key: {{ .Values.secret.remoteRef.key }}
-        metadataPolicy: None
-        property: SCALE_UP_URL

--- a/helm-charts/jung2bot/templates/route-public.yaml
+++ b/helm-charts/jung2bot/templates/route-public.yaml
@@ -16,7 +16,6 @@ spec:
       name: {{ $gatewayName }}
       namespace: {{ $gatewayNamespace }}
   rules:
-{{- if .Values.adminRoutesInternalOnly }}
     - matches:
         - path:
             type: Exact
@@ -37,15 +36,3 @@ spec:
           name: {{ .Values.name }}
           port: 3000
           weight: 1
-{{- else }}
-    - matches:
-        - path:
-            type: PathPrefix
-            value: {{ $stagePrefix }}/
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: {{ .Values.name }}
-          port: 3000
-          weight: 1
-{{- end }}

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -1,10 +1,5 @@
 namespace: jung2bot-dev
 
-# onOffFromWork/onScaleUp were reachable from the public internet with no
-# auth in dev (inherited from JS, which never validated the scheduler
-# token). This routes them to only the in-cluster CronJobs instead.
-adminRoutesInternalOnly: true
-
 secret:
   remoteRef:
     key: jung2bot-dev

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -11,11 +11,6 @@ namespace: jung2bot
 vpa:
   enabled: true
 
-# Restricts onOffFromWork/onScaleUp to in-cluster callers instead of the
-# public Gateway route. Off here until the dev-verified rollout lands here
-# too in a follow-up change.
-adminRoutesInternalOnly: false
-
 secret:
   remoteRef:
     key: jung2bot


### PR DESCRIPTION
Dev ran clean on `adminRoutesInternalOnly` (PR #3079). Drops the flag entirely, applies internal-only routing to prod too. Pure deletion, no new behaviour.

Verified: `helm template` for prod now matches dev's already-proven shape (two-rule AuthorizationPolicy, two Exact HTTPRoute matches, cron env vars pointing at the in-cluster Service). JS still handles `onOffFromWork`/`onScaleUp` at the same paths, so this is safe while prod still runs JS.