### PR TITLE
feat(jung2bot): switch both dev and prod to Go rc.1

### DIFF
--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -10,10 +10,9 @@ vpa:
   enabled: false
 
 app:
-  # Pinned here so dev and prod can run different images. JS is 5.x, Go is 6.x,
-  # same repository, so a rollback is one line.
+  # Pinned here so dev and prod can diverge if needed; rollback is one line.
   image:
-    tag: jung2bot-6.0.0-alpha.1@sha256:d0e17f968aafac1910ce60d39410972279d84af30b67dccdebdf2fa23a33f694
+    tag: jung2bot-6.0.0-rc.1@sha256:f2cb74887fbc0212a09b75363618f2401b121443b87f9f6d2184c2e4354630c1
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-5.2.1@sha256:a75c29f70aa9b1c961386989c223b777b8c85502c50a9ac333349786102ed94d
+    tag: jung2bot-6.0.0-rc.1@sha256:f2cb74887fbc0212a09b75363618f2401b121443b87f9f6d2184c2e4354630c1
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
Prod's first Go cutover. Both environments adopt `jung2bot-6.0.0-rc.1` together.

Prerequisites already merged: internal-only admin routes (#3079, #3080), prod secret requirement dropped (bot repo `nextgen`, verified: config loads fine for prod without `WEBHOOK_SECRET_TOKEN`/`SCHEDULER_SECRET_TOKEN`).

Rollback: one line back to `jung2bot-5.2.1@sha256:a75c29f70aa9b1c961386989c223b777b8c85502c50a9ac333349786102ed94d` in `values.yaml` if anything goes wrong.