### PR TITLE
feat(jung2bot): switch both environments to the final 6.0.0 release

### DIFF
--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -7,7 +7,7 @@ secret:
 app:
   # Pinned here so dev and prod can diverge if needed; rollback is one line.
   image:
-    tag: jung2bot-6.0.0-rc.1@sha256:f2cb74887fbc0212a09b75363618f2401b121443b87f9f6d2184c2e4354630c1
+    tag: jung2bot-6.0.0@sha256:fb511047fed6b1d8b983ee8af664e7930dc3db9c09310706b66a4ef0e8a99671
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.0.0-rc.1@sha256:f2cb74887fbc0212a09b75363618f2401b121443b87f9f6d2184c2e4354630c1
+    tag: jung2bot-6.0.0@sha256:fb511047fed6b1d8b983ee8af664e7930dc3db9c09310706b66a4ef0e8a99671
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
rc.1 -> 6.0.0. Both dev and prod ran rc.1 successfully this session (verified end-to-end: webhook, all commands, off-work delivery, onScaleUp, internal-only routing, right-sized resources). 6.0.0 adds one fix on top: a cosmetic 204/JSON-encode error (no functional impact, was already confirmed harmless live in prod).

Rollback: one line back to jung2bot-5.2.1@sha256:a75c29f70aa9b1c961386989c223b777b8c85502c50a9ac333349786102ed94d if needed.