### PR TITLE
fix(unifi): keep WAN IPv6 disabled in GitOps

### DIFF
--- a/infrastructure/local/lhr/unifi/terragrunt.hcl
+++ b/infrastructure/local/lhr/unifi/terragrunt.hcl
@@ -157,7 +157,7 @@ inputs = {
     wan00 = {
       name        = "Internet 1"
       wan_dns     = []
-      wan_type_v6 = "dhcpv6"
+      wan_type_v6 = "disabled"
     }
   }
   vlan = {


### PR DESCRIPTION
## Summary
- Hyperoptic's IPv6 provisioning proved unreliable during today's troubleshooting: the WAN interface got an address, but prefix delegation never propagated down to any client-facing VLAN despite matching config and a manual DHCPv6 release/renew cycle.
- WAN IPv6 was manually disabled live via the UniFi controller to resolve the resulting client connectivity issue.
- This PR brings GitOps back in sync (`wan_type_v6 = "disabled"`) so a future `terragrunt apply` does not silently re-enable it and reintroduce the same problem.

## Test plan
- [x] `terragrunt plan` in `infrastructure/local/lhr/unifi` shows "No changes. Your infrastructure matches the configuration."