### PR TITLE
docs(self-healing): document two gotchas from today's incidents

### DIFF
--- a/.claude/skills/self-healing/runbooks/ingress-mesh.md
+++ b/.claude/skills/self-healing/runbooks/ingress-mesh.md
@@ -29,6 +29,51 @@ clients, also consider RPi ARP/promisc issues documented in
 `documentation/gotcha.md` — host networking fixes are **escalate** (not
 unattended GitOps).
 
+### Envoy Gateway upgrade drops UDPRoute/TCPRoute after a Gateway API CRD version gap
+
+**Symptom:** after bumping `helm-charts/envoy-gateway` (`gateway-helm`) to a
+newer version, UDP/TCP-based routes stop working — this cluster's shared
+Gateway VIP `192.168.10.51` serves DNS (Blocky, 53 TCP/UDP), CoAP
+(Home Assistant, UDP 5683), and SFTP (Jellyfin, TCP 2022) alongside normal
+HTTPS — while `HTTPRoute`-based ingress on the same VIP keeps working fine.
+`kubectl get gateway <name> -n <ns> -o jsonpath='{range
+.status.listeners[*]}{.name}{": "}{.attachedRoutes}{"\n"}{end}'` shows
+`attachedRoutes: 0` for the affected TCP/UDP listeners while `https` stays
+non-zero.
+
+**Cause:** a newer Envoy Gateway version can require Gateway API **v1**
+`TCPRoute`/`UDPRoute` CRDs. If this cluster's `gateway-api` CRD chart still
+only serves `v1alpha2`, the controller logs (on the `envoy-gateway` pod)
+exactly this at startup:
+
+```text
+UDPRoute CRD not found, skipping UDPRoute watch
+TCPRoute CRD not found, skipping TCPRoute watch
+```
+
+Confirm which API versions are actually served:
+`kubectl get crd udproutes.gateway.networking.k8s.io
+tcproutes.gateway.networking.k8s.io -o jsonpath='{.spec.versions[*].name}'`.
+
+**Fix (GitOps, trivial):** bump `helm-charts/gateway-api`'s CRDs to a version
+that serves `v1` for `TCPRoute`/`UDPRoute` (this cluster: `v1.6.1`), and
+update any `TCPRoute`/`UDPRoute` manifests' `apiVersion` from `v1alpha2` to
+`v1` to match. After merge, apply the new CRDs server-side and restart
+`envoy-gateway` rather than waiting for its own reconcile loop:
+
+```bash
+kubectl apply --server-side --force-conflicts -f helm-charts/gateway-api/crds/
+kubectl rollout restart deployment/envoy-gateway -n envoy-gateway-system
+```
+
+Precedent: `gateway-helm` `1.9.0` (PR #3086) broke this; fixed by bumping
+`gateway-api` CRDs to `1.6.1` (PR #3087), 2026-08-22.
+
+**Verification caveat:** `attachedRoutes` on the Gateway status can lag —
+it stayed `0` in one observed case even after Argo synced the fix and live
+traffic had already recovered. Verify with a real protocol-level test
+(e.g. `dig @<vip> <host>` for DNS) rather than trusting the counter alone.
+
 ## Heartbeat down: Cloudflare Access 403
 
 **Symptom:** `kubectl get heartbeat -A` (or a user-reported "otaru heartbeat

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -97,6 +97,27 @@
   - This is now a recurring-enough pattern to spot-check on any
     `Progressing` finding, not just wait for a report.
 
+- **`tcpSocket`-only probes hide a wedged application layer.** A pod can
+  show `1/1 Running`, `0` restarts, and pass both readiness and liveness
+  probes indefinitely while its actual application has stopped processing
+  requests entirely — if both probes are `tcpSocket` (checking only that
+  the listener socket accepts connections), Kubernetes has no way to detect
+  a deadlocked or wedged process that leaves the socket open but never
+  responds. Confirmed on `unifi-mcp`: pod `Ready` for 17+ hours with zero
+  log activity, silently failing every real tool call, while `kubectl get
+  deployment unifi-mcp -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}{"\n"}{.livenessProbe}'`
+  showed `tcpSocket` for both.
+  - **Detect:** the probe check above, plus comparing recent log timestamps
+    against when traffic was actually being sent to the pod — a long silent
+    gap despite active use is the tell.
+  - **Fix (live, allowlisted):** `kubectl rollout restart deployment/<name>`
+    — matches the existing "misbehaving Deployment, config already correct
+    in Git" entry in `runbooks/merge-policy.md`.
+  - **Durable fix (GitOps, trivial, single-app probe tweak):** if the
+    workload exposes a real HTTP health endpoint, switch both probes to
+    `httpGet` in its chart so a future hang is actually caught instead of
+    needing another manual restart.
+
 - **VPA-driven resource changes are expected, not an incident.**
   `helm-charts/vpa/` runs a live admission-controller and updater for a
   growing set of workloads (`kubectl get vpa -A` lists them). A pod whose


### PR DESCRIPTION
## Summary
- Documents the Envoy Gateway `1.9.0` upgrade dropping `UDPRoute`/`TCPRoute` watch when the cluster's Gateway API CRDs are still `v1alpha2`-only (root cause behind today's DNS/CoAP/SFTP outage, PR #3086/#3087).
- Documents `tcpSocket`-only readiness/liveness probes hiding a wedged application layer, confirmed on `unifi-mcp` (pod `Ready` for 17+ hours with zero log activity).

Documentation-only change to the self-healing skill's runbooks, no chart or cluster impact.

## Test plan
- [x] `make test` passes