### PR TITLE
fix(cnpg): add PDB and app.kubernetes.io/name label to barman-cloud

### DIFF
--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/deployment-barman-cloud.yaml
@@ -17,6 +17,10 @@ spec:
     metadata:
       labels:
         app: barman-cloud
+        # Kyverno's require-pod-disruption-budget policy looks up PDB
+        # coverage by this label; the Deployment's own pod-selector label
+        # stays `app` above (immutable, unrelated).
+        app.kubernetes.io/name: barman-cloud
         # CNPG operator reaches the plugin over direct gRPC; keep it off the ambient dataplane.
         istio.io/dataplane-mode: none
     spec:

--- a/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/poddisruptionbudget-barman-cloud.yaml
+++ b/helm-charts/cloudnative-pg-plugin-barman-cloud/templates/poddisruptionbudget-barman-cloud.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: barman-cloud
+  namespace: cnpg-system
+spec:
+  # Single-replica Deployment with no native PDB option (hand-written
+  # manifest, not a Helm chart with a podDisruptionBudget value). Without
+  # this, descheduler eviction has zero protection against evicting the
+  # only replica -- see documentation/gotcha.md ("Descheduler Eviction
+  # Storms Look Like Self-Resolving Blips, One Check At A Time").
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: barman-cloud


### PR DESCRIPTION
## Summary

- Kyverno's `require-pdb-for-deployment` policy (Audit mode) was erroring on `deployment/barman-cloud` in `cnpg-system`: its JMESPath lookup for PDB coverage assumes every Deployment has an `app.kubernetes.io/name` label, which this hand-written chart never set.
- Adds that label (additive only -- the Deployment's own pod-selector label stays `app: barman-cloud`, unchanged and immutable) plus a `minAvailable: 1` PodDisruptionBudget, matching the pattern already used for other single-replica hand-written charts in this repo (e.g. `k8s-cleaner`).
- Found during a routine `/self-healing` pass; not an active incident (Audit mode only).

## Test plan

- [x] `make test` passes
- [x] `helm template` renders the new PDB and the labeled Deployment correctly
- [ ] After merge: confirm the `barman-cloud` PodDisruptionBudget exists and `kubectl get pdb -n cnpg-system` shows it healthy