### PR TITLE
fix(argocd): add targetRefs AuthorizationPolicy for metrics Services

### DIFF
--- a/helm-charts/argocd/templates/authorization-policy.yaml
+++ b/helm-charts/argocd/templates/authorization-policy.yaml
@@ -30,3 +30,33 @@ spec:
             ports:
               - {{ .port | quote }}
 {{- end }}
+{{- $metricsServices := list
+  (dict "name" "argocd-application-controller-metrics" "port" "8082")
+  (dict "name" "argocd-server-metrics" "port" "8083")
+  (dict "name" "argocd-repo-server-metrics" "port" "8084")
+  (dict "name" "argocd-applicationset-controller-metrics" "port" "8080")
+-}}
+{{- range $metricsServices }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .name }}-svc
+  namespace: {{ $.Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .name }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - {{ .port | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Kyverno's `require-mesh-authorization-policy` policy (Audit mode) flagged four argocd `*-metrics` Services (`argocd-application-controller-metrics`, `argocd-server-metrics`, `argocd-repo-server-metrics`, `argocd-applicationset-controller-metrics`) as selector-backed ambient Services with no `AuthorizationPolicy` `targetRefs` pointing at them.
- The chart already has per-component `AuthorizationPolicy`s, but they target pods via `selector.matchLabels`, not the Gateway-API-style `targetRefs` the Kyverno check specifically looks for on the Service object.
- Adds one new `targetRefs`-based `AuthorizationPolicy` per metrics Service, **alongside** the existing selector-based ones (additive only, not a replacement) -- same principals (`monitoring-prometheus-server`, ambient waypoint), same ports. `argocd-redis-metrics` has no matching flag since it has no dedicated Service.

**Holding this at green rather than auto-merging**: this touches a core GitOps controller's own authorization posture, so per this repo's merge policy it stays non-trivial even though it's purely additive.

## Test plan

- [x] `make test` passes
- [x] `helm template -s templates/authorization-policy.yaml` renders both the existing selector policies and the new targetRefs policies correctly
- [ ] After merge: confirm the four new `AuthorizationPolicy` objects exist in `argocd` namespace and the Kyverno Audit warning for these four Services clears