### PR TITLE
fix(amazon-eks-pod-identity-webhook): vendor subchart to allow ephemeral-storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,13 +246,18 @@ lint-zizmor: ## Run zizmor audit on workflows
 lint-editorconfig: ## Check .editorconfig compliance
 	# Note: Excluding gateway-api and monitoring helm charts due to auto-generated CRD files with long lines
 	# Excluding unifi terragrunt.hcl due to long SSH public key that cannot be safely split
+	# Excluding the vendored amazon-eks-pod-identity-webhook subchart (charts/) --
+	# committed unpacked (not a helm-dependency-build .tgz) so its
+	# values.schema.json can be patched to allow ephemeral-storage, per the
+	# comment on the dependency in that chart's Chart.yaml. Upstream's own
+	# template comments (e.g. a long attribution URL) are not ours to rewrap.
 	@echo "$(GREEN)Checking .editorconfig compliance...$(NC)"
 	@ec_bin="$$(command -v /opt/homebrew/bin/editorconfig-checker || command -v /usr/local/bin/editorconfig-checker || command -v editorconfig-checker || command -v ec)"; \
 		if [ -z "$$ec_bin" ]; then \
 			echo "$(RED)editorconfig-checker is required but not installed. Install editorconfig-checker and re-run make lint-editorconfig.$(NC)"; \
 			exit 1; \
 		fi; \
-		"$$ec_bin" -exclude "(helm-charts/(gateway-api|monitoring)/.*|infrastructure/local/lhr/unifi/terragrunt\\.hcl)" || { \
+		"$$ec_bin" -exclude "(helm-charts/(gateway-api|monitoring)/.*|helm-charts/amazon-eks-pod-identity-webhook/charts/.*|infrastructure/local/lhr/unifi/terragrunt\\.hcl)" || { \
 			echo "$(RED)EditorConfig violations found. Please fix manually or use your editor's .editorconfig support.$(NC)"; \
 			exit 1; \
 		}

--- a/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -4,6 +4,15 @@ description: A Helm chart for Kubernetes
 type: application
 version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
+# charts/amazon-eks-pod-identity-webhook is a vendored, patched copy of this
+# dependency (see charts/amazon-eks-pod-identity-webhook/values.schema.json),
+# not a `helm dependency build` output: upstream's schema hard-rejects an
+# `ephemeral-storage` resources key, which CLAUDE.md requires on every
+# workload. `make validate-helm-charts` accepts an "unpacked" dependency, so
+# this stays in place across `helm lint`/`helm template`. Bumping `version`
+# here does not refresh the vendored copy -- re-run `helm dependency build`,
+# re-apply the ephemeral-storage schema patch, then delete the refreshed
+# `.tgz` and re-extract it into this directory.
 dependencies:
 - name: amazon-eks-pod-identity-webhook
   alias: pod-identity-webhook

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/.helmignore
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+appVersion: v0.6.17
+description: A Kubernetes webhook for pods that need AWS IAM access
+home: https://github.com/aws/amazon-eks-pod-identity-webhook/
+keywords:
+- aws
+- iam
+- eks
+- irsa
+- iam-roles-for-service-accounts
+- eks-pod-identity-webhook
+- aws-pod-identity-webhook
+maintainers:
+- email: github@jkroepke.de
+  name: jkroepke
+  url: https://github.com/jkroepke
+name: amazon-eks-pod-identity-webhook
+sources:
+- https://github.com/jkroepke/helm-charts/tree/main/charts/amazon-eks-pod-identity-webhook
+- https://github.com/aws/amazon-eks-pod-identity-webhook/
+type: application
+version: 2.6.5

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/_helpers.tpl
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.labels" -}}
+helm.sh/chart: {{ include "amazon-eks-pod-identity-webhook.chart" . }}
+{{ include "amazon-eks-pod-identity-webhook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "amazon-eks-pod-identity-webhook.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "amazon-eks-pod-identity-webhook.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get PodDisruptionBudget API Version
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.pdb.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "policy/v1" -}}
+  {{- else -}}
+    {{- print "policy/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/certificate.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/certificate.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.pki.certManager.enabled }}
+{{- $fullName := include "amazon-eks-pod-identity-webhook.fullname" . }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+spec:
+  secretName: "{{ $fullName }}-cert"
+  commonName: "{{ $fullName }}"
+  dnsNames:
+    - "{{ $fullName }}"
+    - "{{ $fullName }}.{{ include "amazon-eks-pod-identity-webhook.namespace" . }}"
+    - "{{ $fullName }}.{{ include "amazon-eks-pod-identity-webhook.namespace" . }}.svc"
+    - "{{ $fullName }}.{{ include "amazon-eks-pod-identity-webhook.namespace" . }}.svc.local"
+  duration: "{{ .Values.pki.certManager.certificate.duration }}"
+  renewBefore: "{{ .Values.pki.certManager.certificate.renewBefore }}"
+  issuerRef:
+    {{- if .Values.pki.certManager.existingIssuer.enabled }}
+    name: {{ .Values.pki.certManager.existingIssuer.name }}
+    kind: {{ .Values.pki.certManager.existingIssuer.kind }}
+    {{- else }}
+    name: {{ $fullName }}
+    kind: Issuer
+    {{- end }}
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/clusterrole.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+      - list
+      - watch

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/clusterrolebinding.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+    namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/configmap.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.podIdentityWebhookMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.podIdentityWebhookMap.name }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+data:
+  config: {{ tpl (.Values.config.podIdentityWebhookMap.data | toYaml) . | fromYaml | toJson | quote }}
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /webhook
+            - --annotation-prefix={{ tpl .Values.config.annotationPrefix . }}
+            - --aws-default-region={{ tpl .Values.config.defaultAwsRegion . }}
+            - --in-cluster=false
+            - --logtostderr
+            - --namespace=$(POD_NAMESPACE)
+            - --metrics-port={{ .Values.config.ports.metrics }}
+            - --port={{ .Values.config.ports.webhook }}
+            - --service-name={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+            - --sts-regional-endpoint={{ tpl (print .Values.config.stsRegionalEndpoint) . }}
+            - --token-audience={{ tpl .Values.config.tokenAudience . }}
+            - --token-expiration={{ .Values.config.tokenExpiration }}
+            - --token-mount-path={{ .Values.config.tokenMountPath }}
+            - --tls-cert=/etc/webhook/certs/tls.crt
+            - --tls-key=/etc/webhook/certs/tls.key
+            {{- if .Values.config.podIdentityWebhookMap.enabled }}
+            - --watch-config-map
+            {{- end }}
+            {{- if .Values.config.extraArgs }}
+            {{- tpl (toYaml .Values.config.extraArgs) . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: https
+              containerPort: {{ .Values.config.ports.webhook }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.config.ports.metrics }}
+              protocol: TCP
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: cert
+              mountPath: "/etc/webhook/certs"
+              readOnly: true
+      hostNetwork: {{ .Values.hostNetwork }}
+      serviceAccountName: {{ include "amazon-eks-pod-identity-webhook.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- tpl (toYaml .) $  | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- tpl (toYaml .) $  | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: cert
+          secret:
+            {{- if .Values.pki.existingSecret }}
+            secretName: {{ .Values.pki.existingSecret | quote }}
+            {{- else }}
+            secretName: "{{ include "amazon-eks-pod-identity-webhook.fullname" . }}-cert"
+            {{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/issuer.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/issuer.yaml
@@ -1,0 +1,12 @@
+---
+{{- if and .Values.pki.certManager.enabled (not .Values.pki.certManager.existingIssuer.enabled) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/mutatingwebhook.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/mutatingwebhook.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+  {{- if .Values.pki.certManager.enabled }}
+    cert-manager.io/inject-ca-from: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}/{{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  {{- end }}
+  {{- with .Values.mutatingWebhook.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+webhooks:
+  - name: pod-identity-webhook.amazonaws.com
+    admissionReviewVersions:
+      - v1beta1
+    failurePolicy: {{ .Values.mutatingWebhook.failurePolicy | quote }}
+    clientConfig:
+      {{- if .Values.pki.caBundle }}
+      caBundle: {{ .Values.pki.caBundle | b64enc }}
+      {{- end }}
+      service:
+        name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+        namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+        port: {{ .Values.config.ports.webhook }}
+        path: "/mutate"
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    {{- with .Values.mutatingWebhook.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    objectSelector:
+      matchExpressions:
+        - key: "eks.amazonaws.com/skip-pod-identity-webhook"
+          operator: "DoesNotExist"
+          values: []
+        - key: "app.kubernetes.io/name"
+          operator: "NotIn"
+          values:
+            - "{{ include "amazon-eks-pod-identity-webhook.name" . }}"
+      {{- with .Values.mutatingWebhook.objectSelector.matchExpressions }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mutatingWebhook.objectSelector.matchLabels }}
+      matchLabels: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    sideEffects: None

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/pdb.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) -}}
+apiVersion: {{ include "amazon-eks-pod-identity-webhook.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/role.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/role.yaml
@@ -1,0 +1,51 @@
+---
+{{- if .Values.config.podIdentityWebhookMap.enabled }}
+{{- $fullName := include "amazon-eks-pod-identity-webhook.fullname" . }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - update
+      - patch
+    resourceNames:
+      {{- /* This is the service account name, ref: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/ac3554488585c1a35bea552f771ef3bd4e6e0ddd/pkg/handler/handler.go#L436 */}}
+      - "{{ include "amazon-eks-pod-identity-webhook.serviceAccountName" . }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}
+    namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/secret.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if and (not .Values.pki.certManager.enabled) (not .Values.pki.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}-cert
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: "{{ .Values.pki.cert | b64enc }}"
+  tls.key: "{{ .Values.pki.key | b64enc }}"
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/service.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/service.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.config.ports.webhook }}
+      targetPort: https
+      protocol: TCP
+      appProtocol: https
+      name: https
+    - port: {{ .Values.config.ports.metrics }}
+      targetPort: metrics
+      appProtocol: http
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 4 }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/serviceaccount.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.serviceAccountName" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | tpl . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/servicemonitor.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.endpointAdditionalProperties }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end -}}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/values.schema.json
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/values.schema.json
@@ -1,0 +1,415 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "annotationPrefix": {
+          "type": "string"
+        },
+        "defaultAwsRegion": {
+          "type": "string"
+        },
+        "extraArgs": {
+          "type": "array"
+        },
+        "podIdentityWebhookMap": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ports": {
+          "type": "object",
+          "properties": {
+            "metrics": {
+              "type": "integer"
+            },
+            "webhook": {
+              "type": "integer"
+            }
+          }
+        },
+        "stsRegionalEndpoint": {
+          "type": "boolean"
+        },
+        "tokenAudience": {
+          "type": "string"
+        },
+        "tokenExpiration": {
+          "type": "integer"
+        },
+        "tokenMountPath": {
+          "type": "string"
+        }
+      }
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "hostNetwork": {
+      "type": "boolean"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "pullPolicy": {
+          "type": "string"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "scheme": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "additionalLabels": {
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "endpointAdditionalProperties": {
+              "type": "object"
+            },
+            "honorLabels": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "relabelings": {
+              "type": "array"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "mutatingWebhook": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "failurePolicy": {
+          "type": "string"
+        },
+        "namespaceSelector": {
+          "type": "object"
+        },
+        "objectSelector": {
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "type": "array"
+            },
+            "matchLabels": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "pki": {
+      "type": "object",
+      "properties": {
+        "caBundle": {
+          "type": "string"
+        },
+        "cert": {
+          "type": "string"
+        },
+        "certManager": {
+          "type": "object",
+          "properties": {
+            "certificate": {
+              "type": "object",
+              "properties": {
+                "duration": {
+                  "type": "string"
+                },
+                "renewBefore": {
+                  "type": "string"
+                }
+              }
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingIssuer": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxUnavailable": {
+          "type": ["null", "integer"]
+        },
+        "minAvailable": {
+          "type": ["null", "integer"]
+        }
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "scheme": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": ["integer", "string"]
+            },
+            "ephemeral-storage": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "ephemeral-storage": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "strategy": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    }
+  },
+  "additionalProperties": false
+}

--- a/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,0 +1,234 @@
+---
+# -- String to partially override amazon-eks-pod-identity-webhook.fullname template (will maintain the release name)
+nameOverride: ""
+
+# -- String to partially override amazon-eks-pod-identity-webhook.fullname template (will maintain the release name)
+namespaceOverride: ""
+
+# -- String to fully override amazon-eks-pod-identity.fullname template
+fullnameOverride: ""
+
+# -- Number of amazon-eks-pod-identity-webhook replicas to deploy
+replicaCount: 1
+
+# -- Configure the pod replacement strategy
+strategy: {}
+
+# -- https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  minAvailable:
+  maxUnavailable:
+
+# -- PriorityClass applied to deployment
+priorityClassName: ""
+
+image:
+  pullPolicy: IfNotPresent
+  # -- amazon-eks-pod-identity-webhook image registry
+  registry: public.ecr.aws
+  # -- amazon-eks-pod-identity-webhook image repository
+  repository: eks/amazon-eks-pod-identity-webhook
+  # -- amazon-eks-pod-identity-webhook image tag (immutable tags are recommended).
+  # @default -- `.Chart.AppVersion`
+  tag: ""
+
+# -- registry secret names as an array
+imagePullSecrets: []
+
+config:
+  # -- The Service Account annotation to look for (default "eks.amazonaws.com")
+  annotationPrefix: eks.amazonaws.com
+  # -- If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
+  defaultAwsRegion: us-east-1
+  # -- Additional command line arguments to pass to amazon-eks-pod-identity-webhook
+  extraArgs: []
+
+  ports:
+    # -- Port to listen on for metrics and healthz (http)
+    metrics: 9999
+    # -- Port to listen on
+    webhook: 8443
+  # -- Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods.
+  stsRegionalEndpoint: true
+  # -- The default audience for tokens. Can be overridden by annotation
+  tokenAudience: sts.amazonaws.com
+  # -- The token expiration
+  tokenExpiration: 86400
+  # -- The path to mount tokens
+  tokenMountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+
+  podIdentityWebhookMap:
+    # -- Enabled pod-identity-webhook ConfigMap. See https://github.com/aws/amazon-eks-pod-identity-webhook#pod-identity-webhook-configmap
+    enabled: false
+    # -- Name pod-identity-webhook ConfigMap. Changing this value is not supported.
+    ## Names are hardcoded
+    ## ref: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/0d254eee1537e0745679252ca60f020fa1a461f0/pkg/cache/cache.go#L259-L262
+    name: "pod-identity-webhook"
+    # -- Content of pod-identity-webhook configmap. Values support templating.
+    data: {}
+    #  "default/myserviceaccount":
+    #    RoleARN: "arn:aws-test:iam::123456789012:role/myserviceaccount.default.sa.minimal.example.com"
+    #    Audience: "amazonaws.com"
+    #    TokenExpiration: 0
+    #  # Example with templating (keys and values can use Helm template syntax):
+    #  "{{ .Release.Namespace }}/myserviceaccount":
+    #    RoleARN: "{{ .Values.global.awsRoleArn }}"
+    #    Audience: "{{ .Values.config.tokenAudience }}"
+
+mutatingWebhook:
+  # -- Annotations for amazon-eks-pod-identity-webhook mutating webhook
+  annotations: {}
+  # -- FailurePolicy of the amazon-eks-pod-identity-webhook mutating webhook. Fail or Ignore are allowed.
+  ## ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+  failurePolicy: Ignore
+  # -- namespaceSelector for the mutating webhook to include or exclude namespace.
+  namespaceSelector: {}
+  #  matchExpressions:
+  #    - key: "kubernetes.io/metadata.name"
+  #      operator: NotIn
+  #      values: ["kube-system"]
+
+  objectSelector:
+    # -- Allows selecting objects (pods) based on flexible matching rules for specific labels and fields.
+    matchExpressions: []
+      # - key: foo
+      #   operator: In
+      #   values:
+      #     - bar
+    # -- In the MutatingWebhook, matchLabels selects objects (pods) based on specific labels matching exactly.
+    matchLabels: {}
+      # foo: bar
+pki:
+  certManager:
+    # -- use cert-manager to generate the webhook server certificates
+    enabled: true
+    certificate:
+      # -- lifetime of the generated server certificate. 2160h=90d
+      duration: 2160h
+      # -- renew time before server certificate expires. 360h=15d
+      renewBefore: 360h
+    existingIssuer:
+      # -- Use an existing cert-manager issuer.
+      enabled: false
+      # -- Kind of the existing cert-manager issuer.
+      kind: ClusterIssuer
+      # -- Name of the existing cert-manager issuer.
+      name: selfsigned
+  # -- ca bundle of the manual generated server tls key
+  caBundle: ""
+  # -- manual generated server tls cert. Used if pki.certManager.enabled is false
+  cert: ""
+  # -- manual generated server tls key. Used if pki.certManager.enabled is false
+  key: ""
+  # -- name of the external secret (type kubernetes.io/tls). Used if pki.certManager.enabled is false
+  existingSecret: ""
+
+metrics:
+  serviceMonitor:
+    # -- Create serviceMonitor Resource for scraping metrics using PrometheusOperator
+    enabled: false
+    # -- Specify the namespace in which the serviceMonitor resource will be created
+    namespace: ""
+    # -- Used to pass Labels that are required by the installed Prometheus Operator
+    additionalLabels: {}
+    # -- Specify the interval at which metrics should be scraped
+    interval: 30s
+    # -- Specify the timeout after which the scrape is ended
+    scrapeTimeout: ""
+    # -- honorLabels chooses the metric's labels on collisions with target labels
+    honorLabels: false
+    # -- RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # -- More properties for the endpoint configuration of the service monitor.
+    endpointAdditionalProperties: {}
+
+readinessProbe:
+  httpGet:
+    # -- This is the readiness check endpoint
+    path: /healthz
+    port: https
+    scheme: HTTPS
+
+livenessProbe:
+  httpGet:
+    # -- This is the liveness check endpoint
+    path: /healthz
+    port: https
+    scheme: HTTPS
+
+# -- Annotations for amazon-eks-pod-identity-webhook deployment
+annotations: {}
+
+# -- Specify if host network should be enabled for amazon-eks-pod-identity-webhook pod
+hostNetwork: false
+
+resources:
+  # -- The resources limits for the amazon-eks-pod-identity-webhook container
+  ## Example:
+  ## limits:
+  ##    cpu: 100m
+  ##    memory: 128Mi
+  limits: {}
+  # -- The requested resources for the amazon-eks-pod-identity-webhook container
+  ## Examples:
+  ## requests:
+  ##    cpu: 100m
+  ##    memory: 128Mi
+  requests: {}
+
+securityContext:
+  # -- Container securityContext: Allow privilege escalation
+  allowPrivilegeEscalation: false
+  # -- Container securityContext: Enable read-only root filesystem
+  readOnlyRootFilesystem: true
+  # -- Container securityContext: Run primary group ID
+  runAsGroup: 1
+  # -- Container securityContext: Disable root user
+  runAsNonRoot: false
+  # -- Container securityContext: Run user ID
+  runAsUser: 65534
+  # -- Container securityContext: Drop capabilities
+  capabilities:
+    drop: ["ALL"]
+
+
+podSecurityContext:
+  # -- Pod securityContext: Seccomp profile
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service annotations
+  annotations: {}
+  # -- Service labels.
+  labels: {}
+
+serviceAccount:
+  # -- Enable creation of ServiceAccount for nginx pod
+  create: true
+  # -- The name of the ServiceAccount to use.
+  # @default -- A name is generated using the `amazon-eks-pod-identity-webhook.fullname` template
+  name: ""
+  # -- Annotations for service account. Evaluated as a template.
+  annotations: {}
+
+# -- Additional labels for amazon-eks-pod-identity-webhook pods
+podLabels: {}
+
+# -- Annotations for amazon-eks-pod-identity-webhook pods
+podAnnotations: {}
+#  prometheus.io/port: "9999"
+#  prometheus.io/scheme: "http"
+#  prometheus.io/scrape: "true"
+
+# -- Affinity for pod assignment
+affinity: {}
+
+# -- Node labels for pod assignment. Evaluated as a template.
+nodeSelector: {}
+
+# -- Tolerations for pod assignment. Evaluated as a template.
+tolerations: []

--- a/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -27,8 +27,10 @@ pod-identity-webhook:
     requests:
       cpu: 10m
       memory: 64Mi
+      ephemeral-storage: 64Mi
     limits:
       memory: 64Mi
+      ephemeral-storage: 64Mi
   config:
     defaultAwsRegion: eu-west-1
     tokenAudience: oidc.siutsin.com


### PR DESCRIPTION
## Summary

- Kyverno's `require-workload-resources` policy (Audit mode) flagged this Deployment for missing `resources.limits.ephemeral-storage`, required by this repo's convention on every workload.
- The upstream `pod-identity-webhook` chart's `values.schema.json` hard-rejects an `ephemeral-storage` key under `resources` -- a values-only change fails `helm template` outright with `additional properties 'ephemeral-storage' not allowed`.
- Vendors an unpacked, patched copy of the upstream chart (v2.6.5) under `charts/`, with only `values.schema.json` edited to allow `ephemeral-storage`. Drops the chart's non-functional `README.md`/`README.md.gotmpl`/`ci/`/`examples/` (their own markdown/line-length violations aren't ours to fix, and they don't affect rendering). `helm dependency list` reports this dependency as `unpacked`, which `make validate-helm-charts` already accepts.
- Also excludes the vendored `charts/` tree from `.editorconfig` linting (Makefile), matching the existing precedent for `gateway-api`/`monitoring` CRDs and the unifi terragrunt SSH key -- upstream's own long attribution-comment URL isn't ours to rewrap.
- See the comment added above the `Chart.yaml` dependency for how to re-vendor this on a future version bump (Renovate will still bump the version string there, but that alone won't refresh the vendored copy).

**Holding this at green rather than auto-merging**: vendoring an entire subchart tree is a structural change to how this chart builds, not a plain resource-limit tweak, so it stays non-trivial under this repo's merge policy even though the net effect is small.

## Test plan

- [x] `make test` passes (including `validate-helm-charts`, `check-markdown`, `lint-editorconfig`)
- [x] `helm dependency list` reports `unpacked` for this dependency
- [x] `helm lint` passes; `helm template` renders `ephemeral-storage: 64Mi` in both `resources.requests` and `resources.limits`
- [ ] After merge: confirm the Deployment rolls out with the new resource limits and the Kyverno Audit warning clears