### PR TITLE
fix(cluster): resolve trivial policy warnings

### DIFF
--- a/helm-charts/argocd/templates/authorization-policy.yaml
+++ b/helm-charts/argocd/templates/authorization-policy.yaml
@@ -16,9 +16,10 @@ metadata:
   namespace: {{ $.Values.namespace }}
 spec:
   action: ALLOW
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ .name }}
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .name }}-metrics
   rules:
     - from:
         - source:

--- a/helm-charts/argocd/values.yaml
+++ b/helm-charts/argocd/values.yaml
@@ -250,6 +250,10 @@ argo-cd:
             done
             echo "Secret argocd-jsonnet-secret found!"
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
           runAsUser: 1000
         resources:
           requests:
@@ -295,6 +299,10 @@ argo-cd:
         command:
           - /var/run/argocd/argocd-cmp-server
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
           runAsNonRoot: true
           runAsUser: 999
         image: ghcr.io/siutsin/images/go-jsonnet:v0.22.0-rc1-202603220524@sha256:7ae80ae8875c82a2bbb239ad476146188435eea0c46d6ee5f55a32b84221ce7f

--- a/helm-charts/descheduler/templates/poddisruptionbudget.yaml
+++ b/helm-charts/descheduler/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: descheduler
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: descheduler

--- a/helm-charts/heartbeats/templates/poddisruptionbudget.yaml
+++ b/helm-charts/heartbeats/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: heartbeats-operator-controller-manager
+  namespace: heartbeats-operator-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: heartbeats-operator

--- a/helm-charts/k3s-apiserver-loadbalancer/templates/poddisruptionbudget.yaml
+++ b/helm-charts/k3s-apiserver-loadbalancer/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: k3s-apiserver-loadbalancer-controller-manager
+  namespace: k3s-apiserver-loadbalancer-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k3s-apiserver-loadbalancer

--- a/helm-charts/kubernetes-mcp-server/templates/poddisruptionbudget.yaml
+++ b/helm-charts/kubernetes-mcp-server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubernetes-mcp-server
+  namespace: {{ .Values.namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-mcp-server

--- a/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
@@ -30,7 +30,11 @@ spec:
             urlPath: "/apis/policy/v1/namespaces/{{ "{{" }} request.namespace {{ "}}" }}/poddisruptionbudgets"
             jmesPath: >-
               items[?spec.selector.matchLabels."app.kubernetes.io/name" ==
-              '{{ "{{" }} request.object.spec.template.metadata.labels."app.kubernetes.io/name" {{ "}}" }}']
+              '{{ "{{" }} request.object.spec.template.metadata.labels."app.kubernetes.io/name" || '' {{ "}}" }}' ||
+              spec.selector.matchLabels.app ==
+              '{{ "{{" }} request.object.spec.template.metadata.labels.app || '' {{ "}}" }}' ||
+              spec.selector.matchLabels."gateway.networking.k8s.io/gateway-name" ==
+              '{{ "{{" }} request.object.spec.template.metadata.labels."gateway.networking.k8s.io/gateway-name" || '' {{ "}}" }}']
               | length(@)
       validate:
         allowExistingViolations: true

--- a/helm-charts/longhorn-config/templates/recurring-job.yaml
+++ b/helm-charts/longhorn-config/templates/recurring-job.yaml
@@ -14,17 +14,3 @@ spec:
   # no way back. Backups are incremental to S3, so the extra copies are cheap.
   retain: 4
   concurrency: 1
----
-apiVersion: longhorn.io/v1beta2
-kind: RecurringJob
-metadata:
-  name: trim
-  namespace: {{ .Values.namespace }}
-spec:
-  cron: "55 * * * *"
-  task: filesystem-trim
-  groups:
-    - trim
-  name: trim
-  retain: 0
-  concurrency: 1

--- a/helm-charts/metallb/templates/poddisruptionbudget.yaml
+++ b/helm-charts/metallb/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: metallb-controller
+  namespace: {{ .Values.namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metallb

--- a/helm-charts/monitoring/templates/authorization-policy.yaml
+++ b/helm-charts/monitoring/templates/authorization-policy.yaml
@@ -8,6 +8,50 @@
 {{- $fluentBitPrincipal := printf "cluster.local/ns/%s/sa/monitoring-fluent-bit" .Values.namespace -}}
 {{- $lokiPrincipal := printf "cluster.local/ns/%s/sa/monitoring-loki" .Values.namespace -}}
 {{- $lokiCanaryPrincipal := printf "cluster.local/ns/%s/sa/loki-canary" .Values.namespace -}}
+{{- $alertmanagerPrincipal := printf "cluster.local/ns/%s/sa/monitoring-alertmanager" .Values.namespace -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-alertmanager
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-alertmanager
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $prometheusPrincipal }}
+              - {{ $alertmanagerPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9093"
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: monitoring-alertmanager-headless
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: monitoring-alertmanager-headless
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ $alertmanagerPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9093"
+---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -90,6 +90,11 @@ prometheus:
       limits:
         memory: 3730Mi
         ephemeral-storage: 256Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     persistentVolume:
       size: 100Gi
       labels:
@@ -111,6 +116,11 @@ prometheus:
     podDisruptionBudget:
       minAvailable: 1
     resources: *smallResources
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     persistence:
       enabled: true
       size: 1Gi
@@ -147,6 +157,11 @@ prometheus:
     podDisruptionBudget:
       minAvailable: 1
     resources: *smallResources
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
   serverFiles:
     recording_rules.yml:
       groups:
@@ -575,6 +590,11 @@ fluent-bit:
         - rm
         - -f
         - /var/log/fluent-bit-tail.db
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
       resources:
         requests:
           cpu: 10m
@@ -594,6 +614,11 @@ fluent-bit:
     - name: fluent-bit-state
       mountPath: /var/fluent-bit-state
   resources: *smallResources
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists


### PR DESCRIPTION
## Summary

- add missing workload PDBs and recognise standard PDB selectors
- complete ambient-mesh and container-hardening policy requirements
- remove the unsupported Longhorn filesystem-trim recurring job

## Validation

- make test reaches Helm validation, but the existing kubernetes-mcp-server OCI dependency requires unavailable docker-credential-osxkeychain