### PR TITLE
fix(monitoring): scope Pushgateway security context

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -157,7 +157,7 @@ prometheus:
     podDisruptionBudget:
       minAvailable: 1
     resources: *smallResources
-    securityContext:
+    containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:


### PR DESCRIPTION
## Summary

- apply Pushgateway hardening at container scope
- unblock the monitoring Argo CD reconciliation

## Validation

- Helm template confirms the rendered Pushgateway container context
- make test reaches Helm validation, then stops on a missing cached Amazon webhook dependency in the fresh worktree