### PR TITLE
fix(argocd): fix broken redis targetRef and drop duplicate metrics policies

### DIFF
--- a/helm-charts/argocd/templates/authorization-policy.yaml
+++ b/helm-charts/argocd/templates/authorization-policy.yaml
@@ -1,11 +1,11 @@
 {{- $prometheusPrincipal := "cluster.local/ns/monitoring/sa/monitoring-prometheus-server" -}}
 {{- $waypointPrincipal := "cluster.local/ns/istio-waypoints/sa/waypoint" -}}
 {{- $components := list
-  (dict "name" "argocd-application-controller" "port" "8082")
-  (dict "name" "argocd-server" "port" "8083")
-  (dict "name" "argocd-repo-server" "port" "8084")
-  (dict "name" "argocd-applicationset-controller" "port" "8080")
-  (dict "name" "argocd-redis" "port" "9121")
+  (dict "name" "argocd-application-controller" "port" "8082" "hasMetricsService" true)
+  (dict "name" "argocd-server" "port" "8083" "hasMetricsService" true)
+  (dict "name" "argocd-repo-server" "port" "8084" "hasMetricsService" true)
+  (dict "name" "argocd-applicationset-controller" "port" "8080" "hasMetricsService" true)
+  (dict "name" "argocd-redis" "port" "9121" "hasMetricsService" false)
 -}}
 {{- range $components }}
 ---
@@ -16,40 +16,21 @@ metadata:
   namespace: {{ $.Values.namespace }}
 spec:
   action: ALLOW
+{{- if .hasMetricsService }}
   targetRefs:
     - group: ""
       kind: Service
       name: {{ .name }}-metrics
-  rules:
-    - from:
-        - source:
-            principals:
-              - {{ $prometheusPrincipal }}
-              - {{ $waypointPrincipal }}
-      to:
-        - operation:
-            ports:
-              - {{ .port | quote }}
+{{- else }}
+  # No dedicated -metrics Service exists for this component (its metrics
+  # port is scraped directly off the pod), so a Service targetRef would be
+  # a dangling reference -- Kyverno's require-mesh-authorization-policy
+  # check only looks at Service-backed traffic, so it never flagged this
+  # one. Stay on pod-selector targeting.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .name }}
 {{- end }}
-{{- $metricsServices := list
-  (dict "name" "argocd-application-controller-metrics" "port" "8082")
-  (dict "name" "argocd-server-metrics" "port" "8083")
-  (dict "name" "argocd-repo-server-metrics" "port" "8084")
-  (dict "name" "argocd-applicationset-controller-metrics" "port" "8080")
--}}
-{{- range $metricsServices }}
----
-apiVersion: security.istio.io/v1
-kind: AuthorizationPolicy
-metadata:
-  name: {{ .name }}-svc
-  namespace: {{ $.Values.namespace }}
-spec:
-  action: ALLOW
-  targetRefs:
-    - group: ""
-      kind: Service
-      name: {{ .name }}
   rules:
     - from:
         - source:


### PR DESCRIPTION
## Summary

Two concurrent fixes for the same Kyverno `require-mesh-authorization-policy` finding landed back to back (#3091, then #3094 from a different concurrent agent session) and left `helm-charts/argocd/templates/authorization-policy.yaml` in a broken and redundant state. Found during a routine `/self-healing` scheduled pass.

- **Live regression**: `argocd-redis-metrics` now has `targetRefs` pointing at a Service (`argocd-redis-metrics`) that does not exist -- redis exposes its metrics port (9121) directly off the pod, with no dedicated Service. Confirmed live: `kubectl get authorizationpolicy -n argocd argocd-redis-metrics -o jsonpath='{.status}'` shows `"reason":"TargetNotFound","status":"False","type":"WaypointAccepted"`. Reverted this one component back to pod-selector targeting, with a comment explaining why it's the exception.
- **Redundancy**: the other four components ended up with two `AuthorizationPolicy` objects each -- `<name>-metrics` (converted to `targetRefs` in place by #3094) and `<name>-metrics-svc` (added alongside by #3091, `targetRefs` to the same Service). Both grant the identical ALLOW rule. Dropped the redundant `-svc` loop entirely; the in-place conversion already covers it. GitOps prune will remove the four orphaned `-svc` objects on sync.

**Holding this at green rather than auto-merging**: touches argocd's own chart, and this repo's merge policy treats that as non-trivial by default even for a bugfix (it's not a pure revert to a prior known-good state, so the incident-revert auto-merge exception doesn't apply either).

## Test plan

- [x] `make test` passes
- [x] `helm template -s templates/authorization-policy.yaml` renders `targetRefs` for the four real metrics Services, `selector` for redis, and no `-svc` duplicates
- [ ] After merge: confirm `argocd-redis-metrics` shows `WaypointAccepted: True`, the four `-svc` AuthorizationPolicy objects are pruned, and no new Kyverno Audit findings appear for this chart