### PR TITLE
fix(kyverno-policy): cover the autogen controller rule in the pod-identity-webhook exception

### DIFF
--- a/helm-charts/kyverno-policy/templates/amazon-eks-pod-identity-webhook-exception.yaml
+++ b/helm-charts/kyverno-policy/templates/amazon-eks-pod-identity-webhook-exception.yaml
@@ -2,6 +2,12 @@
 # the upstream chart's values.schema.json hard-rejects that key, so the
 # workload can never comply with require-workload-resources. User-accepted
 # exception, 2026-08-23.
+#
+# require-workload-resources autogenerates a second rule
+# (autogen-require-container-resource-requests-and-limits) that runs the same
+# check against the controller kinds (Deployment, ReplicaSet, ...), not just
+# Pod -- both rules need excepting, or violation events keep firing on the
+# ReplicaSet/Deployment even once the Pod-level rule is excepted.
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
@@ -12,12 +18,15 @@ spec:
     - policyName: require-workload-resources
       ruleNames:
         - require-container-resource-requests-and-limits
+        - autogen-require-container-resource-requests-and-limits
   match:
     any:
       - resources:
           kinds:
             - Pod
+            - Deployment
+            - ReplicaSet
           namespaces:
             - default
           names:
-            - amazon-eks-pod-identity-webhook-*
+            - amazon-eks-pod-identity-webhook*


### PR DESCRIPTION
## Summary

Follow-up to #3095 (merged). The `PolicyException` there only excepted the Pod-level rule (`require-container-resource-requests-and-limits`). Kyverno's `require-workload-resources` also autogenerates a second rule (`autogen-require-container-resource-requests-and-limits`) that runs the identical check against the controller kinds (`Deployment`, `ReplicaSet`), so `PolicyViolation` events kept firing after #3095 merged -- confirmed live via `kubectl get events --field-selector reason=PolicyViolation`.

- Excepts both rule names, not just the Pod one.
- Adds `Deployment` and `ReplicaSet` to `match.any[].resources.kinds`.
- Widens the name pattern from `amazon-eks-pod-identity-webhook-*` to `amazon-eks-pod-identity-webhook*` so it also matches the Deployment's own name (no random suffix, unlike its ReplicaSets/Pods).

Trivial: single-file correction to the exception this session already got sign-off on, no new mechanism or structural change.

## Test plan

- [x] `make test` passes
- [x] `helm template` renders the corrected `PolicyException`
- [ ] After merge: confirm `kubectl get events -A --field-selector reason=PolicyViolation` shows no further hits for this workload