### PR TITLE
refactor(kyverno): move policy bypasses to exceptions

### DIFF
--- a/helm-charts/kyverno-policy/templates/policy-exceptions.yaml
+++ b/helm-charts/kyverno-policy/templates/policy-exceptions.yaml
@@ -1,0 +1,264 @@
+# PolicyExceptions keep every deliberate policy bypass separate from the
+# ClusterPolicy which it affects. The Kyverno controllers accept exceptions
+# only from this chart's trusted namespace (see helm-charts/kyverno/values.yaml).
+---
+# Kubernetes and Kyverno manage these platform namespaces. Their workloads are
+# not fully owned by this repository, so resource and image-tag requirements
+# cannot be corrected here. Keep the namespace scope explicit and auditable.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: platform-workload-policy-exceptions
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-workload-resources
+      ruleNames:
+        - require-container-resource-requests-and-limits
+        - autogen-require-container-resource-requests-and-limits
+        - autogen-cronjob-require-container-resource-requests-and-limits
+    - policyName: require-image-tag
+      ruleNames:
+        - require-container-image-tag
+        - autogen-require-container-image-tag
+        - autogen-cronjob-require-container-image-tag
+        - disallow-latest-image-tag
+        - autogen-disallow-latest-image-tag
+        - autogen-cronjob-disallow-latest-image-tag
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - DaemonSet
+            - Deployment
+            - Job
+            - ReplicaSet
+            - ReplicationController
+            - StatefulSet
+            - CronJob
+          namespaces:
+            - kube-node-lease
+            - kube-public
+            - kube-system
+            - kyverno
+---
+# These workloads are platform-managed or require privileges incompatible with
+# the generic hardening policy. Keep the exception bounded to their namespaces.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: platform-container-hardening-exceptions
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-container-hardening
+      ruleNames:
+        - require-allow-privilege-escalation-false
+        - require-drop-all-capabilities
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - istio-system
+            - kube-system
+            - longhorn-system
+            - metallb-system
+---
+# Node exporter needs host-level access for node telemetry and cannot meet the
+# generic container-hardening policy. Limit this exception to its exact label.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: prometheus-node-exporter-container-hardening
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-container-hardening
+      ruleNames:
+        - require-allow-privilege-escalation-false
+        - require-drop-all-capabilities
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - monitoring
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-node-exporter
+---
+# Longhorn and Kubernetes control-plane workloads are dynamically generated,
+# so this repository cannot safely attach PDBs to all of them.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: platform-pod-disruption-budget-exceptions
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-pod-disruption-budget
+      ruleNames:
+        - require-pdb-for-deployment
+  match:
+    any:
+      - resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+          namespaces:
+            - kube-node-lease
+            - kube-public
+            - kube-system
+            - kyverno
+            - longhorn-system
+---
+# These pre-existing routes are explicitly grandfathered until each gains its
+# own Envoy Gateway SecurityPolicy. New routes cannot use an annotation bypass.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: grandfathered-httproutes-without-security-policy
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-security-policy
+      ruleNames:
+        - require-security-policy-for-httproutes
+  match:
+    any:
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - argocd
+          names:
+            - argocd-internal
+            - argocd-public
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - blocky
+          names:
+            - blocky-internal-doh
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - changedetection
+          names:
+            - changedetection-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - cyberchef
+          names:
+            - cyberchef-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - excalidraw
+          names:
+            - excalidraw-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - gateway
+          names:
+            - kiali-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - home-assistant
+          names:
+            - home-assistant-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - httpbin
+          names:
+            - httpbin-public
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - hydra
+          names:
+            - hydra-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - jellyfin
+          names:
+            - jellyfin-internal
+            - jellyfin-sftpgo-internal-http
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - jsoncrack
+          names:
+            - jsoncrack-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - jung2bot
+          names:
+            - jung2bot-public
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - jung2bot-dev
+          names:
+            - jung2bot-public
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - longhorn-system
+          names:
+            - longhorn-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - monitoring
+          names:
+            - monitoring-grafana-internal
+            - monitoring-loki-internal
+            - monitoring-prometheus-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - openclaw
+          names:
+            - openclaw-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - teslamate
+          names:
+            - teslamate-grafana-internal
+            - teslamate-internal
+      - resources:
+          kinds:
+            - HTTPRoute
+          namespaces:
+            - umami
+          names:
+            - umami-collect
+            - umami-internal

--- a/helm-charts/kyverno-policy/templates/require-container-hardening-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-container-hardening-policy.yaml
@@ -15,21 +15,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-{{- with .Values.requireContainerHardeningPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-          - resources:
-              namespaces:
-                - monitoring
-              selector:
-                matchLabels:
-                  app.kubernetes.io/name: prometheus-node-exporter
-{{- end }}
       validate:
         allowExistingViolations: true
         failureAction: Audit
@@ -49,21 +34,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-{{- with .Values.requireContainerHardeningPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-          - resources:
-              namespaces:
-                - monitoring
-              selector:
-                matchLabels:
-                  app.kubernetes.io/name: prometheus-node-exporter
-{{- end }}
       validate:
         allowExistingViolations: true
         failureAction: Audit

--- a/helm-charts/kyverno-policy/templates/require-image-tag-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-image-tag-policy.yaml
@@ -15,15 +15,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-{{- with .Values.requireImageTagPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-{{- end }}
       validate:
         allowExistingViolations: true
         failureAction: Audit
@@ -41,15 +32,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-{{- with .Values.requireImageTagPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-{{- end }}
       validate:
         allowExistingViolations: true
         failureAction: Audit

--- a/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-pod-disruption-budget-policy.yaml
@@ -15,15 +15,6 @@ spec:
               kinds:
                 - Deployment
                 - StatefulSet
-{{- with .Values.requirePodDisruptionBudgetPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-{{- end }}
       context:
         - name: matchingPdbCount
           apiCall:

--- a/helm-charts/kyverno-policy/templates/require-security-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/require-security-policy.yaml
@@ -17,17 +17,6 @@ spec:
               operations:
                 - CREATE
                 - UPDATE
-{{- with .Values.requireSecurityPolicy.excludedRoutes }}
-      exclude:
-        any:
-{{- range . }}
-          - resources:
-              namespaces:
-                - {{ .namespace }}
-              names:
-                - {{ .name }}
-{{- end }}
-{{- end }}
       context:
         - name: securityPolicyCount
           apiCall:
@@ -48,17 +37,13 @@ spec:
           targetRefs pointing at that HTTPRoute, at least one jwt.providers
           entry, and authorization.defaultAction Deny. Envoy Gateway can
           resolve backends to pod IPs and bypass Service waypoints, so mesh
-          AuthorizationPolicy alone is not enough. Pre-existing routes are
-          listed under requireSecurityPolicy.excludedRoutes; for a one-off
-          opt-out set gateway.otaru.io/skip-security-policy=true.
+          AuthorizationPolicy alone is not enough. Every exception must be an
+          explicit, GitOps-managed PolicyException.
         deny:
           conditions:
             all:
               - key: "{{ `{{ securityPolicyCount }}` }}"
                 operator: Equals
                 value: 0
-              - key: {{ printf "{{ request.object.metadata.annotations.\"gateway.otaru.io/skip-security-policy\" || '' }}" | quote }}
-                operator: NotEquals
-                value: "true"
   validationFailureAction: {{ .Values.requireSecurityPolicy.failureAction }}
 {{- end }}

--- a/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
+++ b/helm-charts/kyverno-policy/templates/workload-resources-policy.yaml
@@ -15,15 +15,6 @@ spec:
           - resources:
               kinds:
                 - Pod
-{{- with .Values.workloadResourcesPolicy.excludedNamespaces }}
-      exclude:
-        any:
-          - resources:
-              namespaces:
-{{- range . }}
-                - {{ . }}
-{{- end }}
-{{- end }}
       validate:
         allowExistingViolations: true
         failureAction: Audit

--- a/helm-charts/kyverno-policy/values.yaml
+++ b/helm-charts/kyverno-policy/values.yaml
@@ -52,11 +52,6 @@ clusterSecretStorePolicy:
 
 workloadResourcesPolicy:
   enabled: true
-  excludedNamespaces:
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - kyverno
 
 meshAuthorizationPolicy:
   enabled: true
@@ -68,61 +63,11 @@ meshAuthorizationPolicy:
 # Cluster-wide: every HTTPRoute needs a companion Envoy Gateway
 # SecurityPolicy (JWT + deny-by-default). EG can hit pod IPs and bypass
 # Service waypoints, so mesh AuthorizationPolicy alone is not enough.
-# excludedRoutes lists pre-existing routes grandfathered without JWT;
-# remove entries only when that route gains a real SecurityPolicy.
-# k8s-mcp-internal and unifi-mcp-internal are intentionally not listed.
+# Grandfathered routes are declared as explicit PolicyExceptions in
+# templates/policy-exceptions.yaml, not as exclusions on this policy.
 requireSecurityPolicy:
   enabled: true
   failureAction: Enforce
-  excludedRoutes:
-    - namespace: argocd
-      name: argocd-internal
-    - namespace: argocd
-      name: argocd-public
-    - namespace: blocky
-      name: blocky-internal-doh
-    - namespace: changedetection
-      name: changedetection-internal
-    - namespace: cyberchef
-      name: cyberchef-internal
-    - namespace: excalidraw
-      name: excalidraw-internal
-    - namespace: gateway
-      name: kiali-internal
-    - namespace: home-assistant
-      name: home-assistant-internal
-    - namespace: httpbin
-      name: httpbin-public
-    - namespace: hydra
-      name: hydra-internal
-    - namespace: jellyfin
-      name: jellyfin-internal
-    - namespace: jellyfin
-      name: jellyfin-sftpgo-internal-http
-    - namespace: jsoncrack
-      name: jsoncrack-internal
-    - namespace: jung2bot
-      name: jung2bot-public
-    - namespace: jung2bot-dev
-      name: jung2bot-public
-    - namespace: longhorn-system
-      name: longhorn-internal
-    - namespace: monitoring
-      name: monitoring-grafana-internal
-    - namespace: monitoring
-      name: monitoring-loki-internal
-    - namespace: monitoring
-      name: monitoring-prometheus-internal
-    - namespace: openclaw
-      name: openclaw-internal
-    - namespace: teslamate
-      name: teslamate-grafana-internal
-    - namespace: teslamate
-      name: teslamate-internal
-    - namespace: umami
-      name: umami-collect
-    - namespace: umami
-      name: umami-internal
 
 barmanObjectStorePolicy:
   enabled: true
@@ -145,35 +90,17 @@ barmanObjectStorePolicy:
 
 requireImageTagPolicy:
   enabled: true
-  excludedNamespaces:
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - kyverno
 
 requireContainerHardeningPolicy:
   enabled: true
-  excludedNamespaces:
-    - longhorn-system
-    - istio-system
-    - metallb-system
-    - kube-system
 
 # 2026-07-25: audit-only policy added after the missing-PDB
 # eviction-storm pattern caused real outages for umami, home-assistant,
 # and prometheus-server on the same day (see documentation/gotcha.md).
-# Excluded namespaces are the same system-managed/dynamic components
-# already established as out of scope for hand-written PDB fixes
-# (helm-charts/*/templates -- Longhorn CSI/UI/driver-deployer are
-# created directly by longhorn-manager, not by any chart here).
+# System-managed and dynamic components are explicitly excepted in
+# templates/policy-exceptions.yaml. Longhorn CSI/UI/driver-deployer are
+# created directly by longhorn-manager, not by a chart here.
 # Audit mode first: this reports violations without blocking anything,
-# so the initial run against ~30+ pre-existing gaps does not need every
-# exclusion tuned up front.
+# so initial reports do not block workload admission.
 requirePodDisruptionBudgetPolicy:
   enabled: true
-  excludedNamespaces:
-    - longhorn-system
-    - kube-system
-    - kube-node-lease
-    - kube-public
-    - kyverno


### PR DESCRIPTION
## Summary

- replace policy-level namespace and route exclusions with explicit PolicyException resources
- remove the HTTPRoute annotation bypass so every exemption is GitOps-managed
- retain policy allowlists and non-ambient Service applicability checks

## Validation

- helm template plus server-side dry-run validation
- make test