### PR TITLE
chore(jung2bot): refresh dev capacity and Helm dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,11 +182,13 @@ generate-diagrams: poetry-install format-python ## Generate architecture diagram
 	@echo "$(GREEN)Architecture diagrams generated at assets/$(OUTPUT_FILE).png$(NC)"
 
 # Validation and linting targets
+# Chart archives are ignored, so validation restores the exact versions in Chart.lock.
 .PHONY: validate-helm-charts
 validate-helm-charts: ## Validate all Helm charts
 	@echo "$(GREEN)Validating Helm charts...$(NC)"
 	@for chart in helm-charts/*/; do \
 		if [ -f "$$chart/Chart.yaml" ]; then \
+			helm dependency build "$$chart" > /dev/null || exit 1; \
 			helm dependency list "$$chart" | awk ' \
 				NR > 1 && NF > 0 && $$4 !~ /^(ok|unpacked)$$/ { \
 					print "Helm dependency not current in " chart ": " $$0; \

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -14,7 +14,7 @@ app:
     messageTable: jung2bot-dev-messages
     # Must exceed the tables' provisioned read capacity of 1, or UpdateTable is
     # a no-op that the service reports as success.
-    scaleUpReadCapacity: 5
+    scaleUpReadCapacity: 2
     stage: dev
   autoscaling:
     min: 1

--- a/helm-charts/kiali/Chart.lock
+++ b/helm-charts/kiali/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kiali-server
   repository: https://kiali.org/helm-charts
-  version: 2.30.0
-digest: sha256:8ab647f54b15ad901988b61e68b62710b319d4267252f83436d142ef1513fa83
-generated: "2026-08-04T11:16:36.463262794Z"
+  version: 2.31.0
+digest: sha256:24fe565ae92770ed7bf4f5d989412969eb36eaa048f2ce65c542b65c6ae9f76c
+generated: "2026-08-24T21:05:32.828488+01:00"


### PR DESCRIPTION
## Summary
- reduce the Jung2Bot dev DynamoDB scale-up read capacity from 5 to 2
- update Kiali from 2.30.0 to 2.31.0 within its existing 2.x range
- build Chart.lock-pinned Helm dependencies before chart validation

## Validation
- make update-helm-deps
- make test