### PR TITLE
fix(monitoring): harden Prometheus helper containers

### DIFF
--- a/.claude/skills/self-healing/runbooks/policy.md
+++ b/.claude/skills/self-healing/runbooks/policy.md
@@ -12,4 +12,12 @@ update the commands below.
 
 - Policy deny on a new or changed workload → GitOps-fix the manifest or
   chart to comply.
+- Policy audit after a Helm value change → inspect both the live workload and
+  the rendered chart. A values key can be accepted but ignored by the chart.
+  Do not close the issue until the affected container has the required field.
+- After a Prometheus chart upgrade or hardening change, inspect the rendered
+  Alertmanager, Prometheus server, and config-reloader container security
+  contexts. The current chart uses
+  `prometheus.alertmanager.securityContext` and
+  `prometheus.configmapReload.prometheus.containerSecurityContext`.
 - Cluster-wide policy chart change → escalate.

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -49,6 +49,11 @@ prometheus:
   configmapReload:
     prometheus:
       resources: *smallResources
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
   server:
     deploymentAnnotations:
       secret.reloader.stakater.com/reload: blackbox-scrape-config
@@ -116,7 +121,7 @@ prometheus:
     podDisruptionBudget:
       minAvailable: 1
     resources: *smallResources
-    containerSecurityContext:
+    securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:


### PR DESCRIPTION
## Summary

- Use the supported Alertmanager security-context key.
- Harden the Prometheus config-reloader container.
- Add rendered-workload validation to the self-healing policy runbook.

## Validation

- `make test`