### PR TITLE
fix(hardening): secure Reloader and TeslaMate jobs

### DIFF
--- a/helm-charts/reloader/values.yaml
+++ b/helm-charts/reloader/values.yaml
@@ -10,6 +10,11 @@ reloader:
       enabled: true
       minAvailable: 1
     deployment:
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
       resources:
         requests:
           cpu: 50m
@@ -24,4 +29,3 @@ reloader:
             - weight: 100
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
-

--- a/helm-charts/teslamate/templates/backup.yaml
+++ b/helm-charts/teslamate/templates/backup.yaml
@@ -15,6 +15,11 @@ spec:
           containers:
             - name: {{ .Values.name }}-backup
               image: postgres:{{ .Values.backup.database.postgresVersion }}-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -16,6 +16,11 @@ spec:
           containers:
             - name: verify-pg-dump
               image: postgres:{{ .Values.backup.database.postgresVersion }}-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               command: ["/bin/sh", "-c"]
               args:
                 - |
@@ -109,6 +114,11 @@ spec:
 
             - name: postgres-sidecar
               image: postgres:{{ .Values.backup.database.postgresVersion }}-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               env:
                 - name: POSTGRES_USER
                   valueFrom:

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -79,6 +79,11 @@ spec:
           containers:
             - name: verify-pitr
               image: alpine/kubectl:1.35.2@sha256:ec8f734b0a103ae63b5c008b99477f240f4109a8449c2f4947aa231e69b11745
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               command: ["/bin/sh", "-c"]
               args:
                 - |


### PR DESCRIPTION
## Summary

- Prevent privilege escalation in the Reloader container
- Drop all Linux capabilities from Reloader and TeslaMate backup Jobs

## Validation

- `make test`