### PR TITLE
fix(istiod): align PDB selector with policy

### DIFF
--- a/helm-charts/istiod/templates/poddisruptionbudget.yaml
+++ b/helm-charts/istiod/templates/poddisruptionbudget.yaml
@@ -15,4 +15,5 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: istiod
       istio: pilot


### PR DESCRIPTION
## Summary

- Select Istiod Pods by both `app.kubernetes.io/name` and `istio: pilot`
- Allow Kyverno to recognise the existing Istiod PodDisruptionBudget

## Validation

- `make test`