### PR TITLE
fix(mesh): cover CNPG services and metrics

### DIFF
--- a/helm-charts/cloudnative-pg-clusters/templates/authorization-policy.yaml
+++ b/helm-charts/cloudnative-pg-clusters/templates/authorization-policy.yaml
@@ -10,6 +10,7 @@ spec:
   action: ALLOW
   selector:
     matchLabels:
+      app.kubernetes.io/name: postgresql
       cnpg.io/cluster: {{ $clusterConfig.clusterName }}
       cnpg.io/podRole: instance
   rules:

--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -1,6 +1,7 @@
 {{- $gateway := .Values.gateway | default dict -}}
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
+{{- $databaseName := .Values.database.secretName -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -46,3 +47,28 @@ spec:
   {{- else }}
   rules: []
   {{- end }}
+{{- range $suffix := list "r" "ro" "rw" }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ printf "%s-%s" $databaseName $suffix }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ printf "%s-%s" $databaseName $suffix }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/hydra
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/hydra-job
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $databaseName }}
+      to:
+        - operation:
+            ports:
+              - "5432"
+{{- end }}

--- a/helm-charts/umami/templates/authorization-policy.yaml
+++ b/helm-charts/umami/templates/authorization-policy.yaml
@@ -2,6 +2,7 @@
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $heartbeatPrincipal := "cluster.local/ns/heartbeats-operator-system/sa/heartbeats-operator-controller-manager" -}}
+{{- $databaseName := .Values.database.secretName -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -23,3 +24,27 @@ spec:
         - operation:
             ports:
               - {{ .Values.service.port | quote }}
+{{- range $suffix := list "r" "ro" "rw" }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ printf "%s-%s" $databaseName $suffix }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  action: ALLOW
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ printf "%s-%s" $databaseName $suffix }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/default
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $databaseName }}
+      to:
+        - operation:
+            ports:
+              - "5432"
+{{- end }}


### PR DESCRIPTION
## Summary

- add least-privilege database Service policies for Hydra and Umami CNPG services
- align the shared CNPG Prometheus policy selector with the required PostgreSQL workload label
- preserve the confirmed live client ServiceAccounts and port 5432 scope

## Validation

- `make test`
- rendered Hydra, Umami, and CNPG policies checked against live Services and ServiceAccounts