### PR TITLE
feat(jung2bot): deploy 6.1.0 to dev, scrape Prometheus metrics

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -2,6 +2,10 @@
 {{- $gatewayName := $gateway.name | default "gateway" -}}
 {{- $gatewayNamespace := $gateway.namespace | default "gateway" -}}
 {{- $stagePrefix := printf "/jung2bot/%s" .Values.app.env.stage -}}
+{{- $monitoring := .Values.monitoring | default dict -}}
+{{- $prometheusServiceAccount := $monitoring.prometheusServiceAccount | default "monitoring-prometheus-server" -}}
+{{- $prometheusNamespace := $monitoring.namespace | default "monitoring" -}}
+{{- $waypointPrincipal := "cluster.local/ns/istio-waypoints/sa/waypoint" -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -36,3 +40,16 @@ spec:
             paths:
               - {{ $stagePrefix }}/onOffFromWork
               - {{ $stagePrefix }}/onScaleUp
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            methods:
+              - GET
+            ports:
+              - "9090"
+            paths:
+              - /metrics

--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.name }}
         app.kubernetes.io/version: {{ $version | quote }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: /metrics
     spec:
       affinity:
         podAntiAffinity:
@@ -41,6 +45,8 @@ spec:
                 - ALL
           ports:
             - containerPort: 3000
+            - name: metrics
+              containerPort: 9090
           livenessProbe:
             httpGet:
               path: "jung2bot/{{ .Values.app.env.stage }}/ping"

--- a/helm-charts/jung2bot/templates/service.yaml
+++ b/helm-charts/jung2bot/templates/service.yaml
@@ -10,4 +10,8 @@ spec:
     - protocol: TCP
       port: 3000
       targetPort: 3000
+    - name: metrics
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
   type: ClusterIP

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -7,7 +7,7 @@ secret:
 app:
   # Pinned here so dev and prod can diverge if needed; rollback is one line.
   image:
-    tag: jung2bot-6.0.0@sha256:fb511047fed6b1d8b983ee8af664e7930dc3db9c09310706b66a4ef0e8a99671
+    tag: jung2bot-6.1.0@sha256:7ab65aeaf61f3864ca0c83ec462f6079b86a724c7642bc9c5198fb638799ceef
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug


### PR DESCRIPTION
## Summary
- Pin jung2bot-dev to the jung2bot-6.1.0 multi-arch image index digest
  (fixes loose command-prefix matching, telegram-jung2-bot#3121).
- Expose the app's dedicated :9090/metrics endpoint: metrics port on
  the Deployment/Service, prometheus.io/* pod annotations for the
  prometheus chart's annotation-based discovery, and an
  AuthorizationPolicy rule allowing monitoring-prometheus-server and
  the ambient waypoint to GET /metrics (same pattern as blocky).

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template` for both dev and prod values, checked rendered
  Deployment/Service/AuthorizationPolicy
- [x] `make test` (pre-existing, unrelated `validate-helm-charts`
  failure on clean master too: missing docker-credential-osxkeychain
  for an unrelated OCI chart pull)