### PR TITLE
fix(hydra): allow CNPG test database access

### DIFF
--- a/helm-charts/hydra/templates/authorization-policy.yaml
+++ b/helm-charts/hydra/templates/authorization-policy.yaml
@@ -64,6 +64,7 @@ spec:
     - from:
         - source:
             principals:
+              - cluster.local/ns/{{ $.Values.namespace }}/sa/default
               - cluster.local/ns/{{ $.Values.namespace }}/sa/hydra
               - cluster.local/ns/{{ $.Values.namespace }}/sa/hydra-job
               - cluster.local/ns/{{ $.Values.namespace }}/sa/{{ $databaseName }}


### PR DESCRIPTION
## Summary

- allow the CNPG post-sync database test Job to reach Hydra PostgreSQL
- retain the existing least-privilege Hydra, migration, and CNPG controller identities

## Validation

- `make test`
- rendered Hydra database policy inspected
- live failed test Job confirmed to use the Kubernetes default ServiceAccount