### PR TITLE
fix(jung2bot): name every Service port

### DIFF
--- a/helm-charts/jung2bot/templates/service.yaml
+++ b/helm-charts/jung2bot/templates/service.yaml
@@ -7,7 +7,8 @@ spec:
   selector:
     app.kubernetes.io/name: {{ .Values.name }}
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 3000
       targetPort: 3000
     - name: metrics


### PR DESCRIPTION
## Summary
- #3115 added a named `metrics` port to the jung2bot Service without
  naming the existing 3000 port. Kubernetes requires every port on a
  Service to be named once it has more than one, so ArgoCD's sync has
  been failing since merge: `Service "jung2bot" is invalid:
  spec.ports[0].name: Required value`.
- Name the existing port `http`.

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template` for dev values, checked rendered Service