### PR TITLE
fix(argocd): wire jung2bot dashboard into monitoring valueFiles

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -157,6 +157,7 @@ local _ignoreDifferences = {
 local _grafanaDashboards = [
   'dashboards/blocky.yaml',
   'dashboards/container-log-dashboard.yaml',
+  'dashboards/jung2bot.yaml',
   'dashboards/kyverno-policy-metrics.yaml',
   'dashboards/onzack-cluster-monitoring.yaml',
   'dashboards/prometheus-stats.yaml',


### PR DESCRIPTION
## Summary
- #3118 added `helm-charts/monitoring/dashboards/jung2bot.yaml` but never added it to the monitoring `Application`'s `spec.source.helm.valueFiles` list in `argocd/manifest.jsonnet`, so ArgoCD would never actually render the dashboard's ConfigMap despite syncing the file's presence in the repo.
- Add `dashboards/jung2bot.yaml` to `_grafanaDashboards`.

## Test plan
- [x] `make validate-argocd-manifest`
- [ ] After merge/sync: confirm the monitoring Application syncs to this commit and the jung2bot dashboard ConfigMap/Grafana sidecar picks it up