### PR TITLE
feat(jung2bot): deploy prod to 6.1.0

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.0.0@sha256:fb511047fed6b1d8b983ee8af664e7930dc3db9c09310706b66a4ef0e8a99671
+    tag: jung2bot-6.1.0@sha256:7ab65aeaf61f3864ca0c83ec462f6079b86a724c7642bc9c5198fb638799ceef
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
## Summary
- Pin jung2bot (prod) to the jung2bot-6.1.0 multi-arch image index
  digest, same image already running in jung2bot-dev.
- Fixes loose command-prefix matching (telegram-jung2-bot#3121) and
  closes the version gap that caused ScrapeTargetDown alerts: prod was
  on jung2bot-6.0.0, built before the metrics feature merged, so it
  never opened the Service's port 9090 that the shared chart's scrape
  config (#3115, #3117) now expects.

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template` for prod values, checked rendered image
- [x] jung2bot-6.1.0 already verified live in jung2bot-dev: pod
  healthy, /metrics returning real app series, Prometheus target `up`