### PR TITLE
fix(kyverno): exempt generated Longhorn workloads

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1085,12 +1085,38 @@ already busy cluster.
 
 ---
 
+## Longhorn Generated Workloads Cannot Set All Resources
+
+**Problem:** Kyverno reports missing resource requests and limits for Longhorn engine-image, instance-manager,
+manager, UI, driver-deployer, and recurring-backup workloads.
+
+Longhorn Manager creates these workloads after Helm applies the chart. Longhorn 1.12.1 provides resource settings
+for Longhorn Manager and selected CSI components only. The instance-manager setting reserves CPU only. It does not
+set memory or ephemeral-storage resources. [Longhorn settings][longhorn-settings]
+
+Do not patch the generated Pods. Longhorn Manager replaces them, and a live change can disrupt storage operations.
+Do not use one generic resource value. In the 14 days before this exception, instance managers used up to 855Mi of
+memory, while engine-image, UI, and driver-deployer Pods used less than 36Mi.
+
+### Resolution: Keep a Narrow Resource Policy Exception
+
+`helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml` excludes only the generated
+Longhorn component labels from the three `require-workload-resources` rules. The exception does not exclude the
+namespace or other Longhorn workloads.
+
+Keep `longhornManager.resources` and `systemManagedCSIComponentsResourceLimits` in
+`helm-charts/longhorn/values.yaml`. Review this exception after every Longhorn upgrade. Remove a component match
+when Longhorn supports full resource settings for that component.
+
+---
+
 [envoy-issue]: https://github.com/envoyproxy/envoy/issues/23339
 [metallb-troubleshooting]: https://metallb.universe.tf/troubleshooting/#using-wifi-and-cant-reach-the-service
 [cilium-issue]: https://github.com/cilium/cilium/issues/19038
 [longhorn-issue]: https://github.com/longhorn/longhorn/issues/4143
 [longhorn-12225]: https://github.com/longhorn/longhorn/issues/12225
 [longhorn-6645]: https://github.com/longhorn/longhorn/issues/6645
+[longhorn-settings]: https://longhorn.io/docs/1.12.1/references/settings/
 
 ---
 

--- a/helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml
+++ b/helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml
@@ -1,0 +1,75 @@
+# Longhorn Manager creates these workload types after Helm applies this chart.
+# Longhorn 1.12.1 exposes no resource template for them. The resource policy
+# cannot be satisfied without mutating storage control-plane Pods at runtime.
+# Keep this exception limited to the generated component labels. The Longhorn
+# Manager and CSI resources remain configured in helm-charts/longhorn/values.yaml.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: longhorn-generated-workload-resources
+  namespace: {{ .Values.namespace }}
+spec:
+  exceptions:
+    - policyName: require-workload-resources
+      ruleNames:
+        - require-container-resource-requests-and-limits
+        - autogen-require-container-resource-requests-and-limits
+        - autogen-cronjob-require-container-resource-requests-and-limits
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - DaemonSet
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              longhorn.io/component: engine-image
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              longhorn.io/component: instance-manager
+      - resources:
+          kinds:
+            - Pod
+            - DaemonSet
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              app: longhorn-manager
+      - resources:
+          kinds:
+            - Pod
+            - Deployment
+            - ReplicaSet
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              app: longhorn-ui
+      - resources:
+          kinds:
+            - Pod
+            - Deployment
+            - ReplicaSet
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              app: longhorn-driver-deployer
+      - resources:
+          kinds:
+            - Pod
+            - Job
+            - CronJob
+          namespaces:
+            - longhorn-system
+          selector:
+            matchLabels:
+              recurring-job.longhorn.io: backup


### PR DESCRIPTION
## Summary\n- add a scoped resource-policy exception for Longhorn workloads that Longhorn Manager generates\n- retain enforcement for all other workloads\n- document the upstream configuration limit and observed resource usage\n\n## Validation\n- make test\n- helm template kyverno-policy helm-charts/kyverno-policy --namespace kyverno\n- kubectl apply --server-side --dry-run=server for the rendered PolicyException