### PR TITLE
chore(jung2bot): decommission the telegram-jung2-bot-cron image

### DIFF
--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -16,13 +16,35 @@ spec:
         spec:
           containers:
             - name: off-work
-              image: {{ .Values.cron.image.repository }}:{{ .Values.cron.image.tag }}
+              image: curlimages/curl:8.21.0
               securityContext:
                 runAsNonRoot: true
+                # curlimages/curl's non-root user ("curl_user") is named, not
+                # numeric, in the image metadata. Kubelet cannot verify
+                # runAsNonRoot from a named user alone, so without an
+                # explicit numeric runAsUser the Job got stuck in
+                # CreateContainerConfigError. UID 100 is curlimages/curl's
+                # documented curl_user.
+                runAsUser: 100
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:
                     - ALL
+              command: [ "sh", "-c" ]
+              args:
+                # Floors "now" down to the CRON_INTERVAL boundary before
+                # calling onOffFromWork, matching the retired Node cron
+                # image: without flooring, Job start jitter (image pull,
+                # scheduling delay) can push the timestamp a minute past
+                # the boundary, so WindowFromTime's offTime never matches
+                # any chat's configured schedule and that fire is silently
+                # skipped.
+                - |
+                  interval_secs=$((CRON_INTERVAL * 60))
+                  now=$(date -u +%s)
+                  floored=$(( now - now % interval_secs ))
+                  timeString=$(date -u -d @$floored +%Y-%m-%dT%H:%M:%SZ)
+                  curl -v -m 5 "$OFF_FROM_WORK_URL?timeString=$timeString"
               env:
                 - name: CRON_INTERVAL
                   value: {{ .Values.cron.offWork.env.cronInterval | quote }}

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -35,9 +35,6 @@ app:
     max: 10
 
 cron:
-  image:
-    repository: ghcr.io/siutsin/telegram-jung2-bot-cron
-    tag: cron-1.1.1@sha256:b309fcbd4bf83452fb35d155b4bae264edb47bfbbce74b6cd7dc6032868122d0
   offWork:
     env:
       cronInterval: 15


### PR DESCRIPTION
## Summary
- The off-work CronJob was the only consumer of the custom
  ghcr.io/siutsin/telegram-jung2-bot-cron image. Its Node source
  (`cron/index.js`) was already deleted from the app repo in the Go
  rewrite, so the image was frozen at cron-1.1.1 with no way to
  rebuild it.
- Replace it with curlimages/curl:8.21.0, the same image
  scale-up-database already uses, and a shell one-liner that
  replicates the Node script's behaviour: floor "now" down to the
  CRON_INTERVAL boundary before calling onOffFromWork. This flooring
  matters -- without it, Job start jitter (image pull, scheduling
  delay) can push the timestamp a minute past the boundary, so
  WindowFromTime's offTime never matches any chat's configured
  schedule and that fire is silently skipped.
- Drop the now-unused `cron.image` values.

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template`, checked rendered CronJob
- [x] Ran the exact shell script in curlimages/curl:8.21.0 locally
  (Apple Container) with CRON_INTERVAL=15: produced
  `2026-08-24T23:45:00Z`, correctly floored to the 15-minute boundary