### PR TITLE
fix(monitoring): label jung2bot rate panels as per-minute

### DIFF
--- a/helm-charts/monitoring/dashboards/jung2bot.yaml
+++ b/helm-charts/monitoring/dashboards/jung2bot.yaml
@@ -928,7 +928,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1027,7 +1027,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1238,7 +1238,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1337,7 +1337,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1449,7 +1449,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1647,7 +1647,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1858,7 +1858,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1957,7 +1957,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "short",
+                    "unit": "suffix: /min",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -2206,6 +2206,6 @@ grafana:
             "timezone": "browser",
             "title": "jung2bot",
             "uid": "jung2bot",
-            "version": 3,
+            "version": 4,
             "weekStart": ""
           }


### PR DESCRIPTION
## Summary
- Follow-up to #3118. The eight `rate(...)*60` panels used Grafana's plain `short` unit, which only abbreviates numbers (`25.05`) with no time-unit indicator, so the panel gave no clue the value was requests/min without reading its hover description.
- Switch those panels to Grafana's built-in custom unit `suffix: /min`, so the axis ticks, legend value column, and tooltip all show `25.05 /min` directly.

## Test plan
- [x] `python3 hack/validate-grafana-dashboards.py`
- [x] `helm lint` / `helm template` for the monitoring chart
- [x] `make lint-editorconfig`
- [ ] After merge/sync: confirm the panels render with the `/min` suffix in Grafana