### PR TITLE
chore(jung2bot): simplify off-work curl command

### DIFF
--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -33,7 +33,7 @@ spec:
               command: [ "sh", "-c" ]
               args:
                 # Zeroes seconds so onOffFromWork sees a clean minute mark.
-                - curl -v -m 5 "$OFF_FROM_WORK_URL?timeString=$(date -u +%Y-%m-%dT%H:%M:00Z)"
+                - curl -f -v -m 5 "$OFF_FROM_WORK_URL?timeString=$(date -u +%Y-%m-%dT%H:%M:00Z)"
               env:
                 - name: OFF_FROM_WORK_URL
                   value: {{ printf "%s%s/onOffFromWork" $internalBaseURL $stagePrefix | quote }}

--- a/helm-charts/jung2bot/templates/cron-job.yaml
+++ b/helm-charts/jung2bot/templates/cron-job.yaml
@@ -32,22 +32,9 @@ spec:
                     - ALL
               command: [ "sh", "-c" ]
               args:
-                # Floors "now" down to the CRON_INTERVAL boundary before
-                # calling onOffFromWork, matching the retired Node cron
-                # image: without flooring, Job start jitter (image pull,
-                # scheduling delay) can push the timestamp a minute past
-                # the boundary, so WindowFromTime's offTime never matches
-                # any chat's configured schedule and that fire is silently
-                # skipped.
-                - |
-                  interval_secs=$((CRON_INTERVAL * 60))
-                  now=$(date -u +%s)
-                  floored=$(( now - now % interval_secs ))
-                  timeString=$(date -u -d @$floored +%Y-%m-%dT%H:%M:%SZ)
-                  curl -v -m 5 "$OFF_FROM_WORK_URL?timeString=$timeString"
+                # Zeroes seconds so onOffFromWork sees a clean minute mark.
+                - curl -v -m 5 "$OFF_FROM_WORK_URL?timeString=$(date -u +%Y-%m-%dT%H:%M:00Z)"
               env:
-                - name: CRON_INTERVAL
-                  value: {{ .Values.cron.offWork.env.cronInterval | quote }}
                 - name: OFF_FROM_WORK_URL
                   value: {{ printf "%s%s/onOffFromWork" $internalBaseURL $stagePrefix | quote }}
               resources:


### PR DESCRIPTION
## Summary
- Follow-up to #3122. Drop the CRON_INTERVAL-floor arithmetic and the
  now-unused CRON_INTERVAL env var. curlimages/curl is already warm on
  every node, so the Job starts well within the same clock minute as
  the schedule fire -- zeroing seconds is enough.
- Add -f so curl actually fails (and the Job's backoffLimit retries)
  on a 5xx instead of silently exiting 0.

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template`, checked rendered CronJob