### PR TITLE
fix(jung2bot): add workload-selector AuthorizationPolicy for metrics

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -53,3 +53,27 @@ spec:
               - "9090"
             paths:
               - /metrics
+---
+# Kyverno's require-mesh-authorization-policy checks for a workload-selector
+# policy separately from the Service targetRefs one above: Prometheus scrapes
+# the pod IP directly, which targetRefs policies don't cover.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.name }}-workload
+  namespace: {{ .Values.namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $prometheusNamespace }}/sa/{{ $prometheusServiceAccount }}
+              - {{ $waypointPrincipal }}
+      to:
+        - operation:
+            ports:
+              - "9090"


### PR DESCRIPTION
## Summary
- Kyverno's `require-mesh-authorization-policy` cluster policy has
  been failing (audit-only, non-blocking) on both jung2bot and
  jung2bot-dev pods since the metrics scrape config merged (#3115,
  #3117): the AuthorizationPolicy uses `targetRefs` against the
  Service, but Prometheus scrapes the pod IP directly, which
  `targetRefs` policies don't cover per Kyverno's rule.
- Add a `jung2bot-workload` selector-based AuthorizationPolicy scoped
  to just the metrics port (9090) for the Prometheus and waypoint
  principals, matching what Kyverno's policy checks for. Doesn't
  widen the existing gateway ingress rules.

## Test plan
- [x] `helm lint helm-charts/jung2bot` for both prod and dev values
- [x] `helm template`, checked rendered policy for dev