### PR TITLE
fix(kyverno): match Longhorn driver deployer prefix

### DIFF
--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -1101,8 +1101,8 @@ memory, while engine-image, UI, and driver-deployer Pods used less than 36Mi.
 ### Resolution: Keep a Narrow Resource Policy Exception
 
 `helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml` excludes only the generated
-Longhorn component labels from the three `require-workload-resources` rules. The exception does not exclude the
-namespace or other Longhorn workloads.
+Longhorn component labels and the `longhorn-driver-deployer*` resource prefix from the three
+`require-workload-resources` rules. The exception does not exclude the namespace or other Longhorn workloads.
 
 Keep `longhornManager.resources` and `systemManagedCSIComponentsResourceLimits` in
 `helm-charts/longhorn/values.yaml`. Review this exception after every Longhorn upgrade. Remove a component match

--- a/helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml
+++ b/helm-charts/kyverno-policy/templates/longhorn-resource-policy-exception.yaml
@@ -3,6 +3,8 @@
 # cannot be satisfied without mutating storage control-plane Pods at runtime.
 # Keep this exception limited to the generated component labels. The Longhorn
 # Manager and CSI resources remain configured in helm-charts/longhorn/values.yaml.
+# The driver-deployer Deployment has no component label. Its generated resources
+# use the stable longhorn-driver-deployer prefix instead.
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
@@ -60,9 +62,8 @@ spec:
             - ReplicaSet
           namespaces:
             - longhorn-system
-          selector:
-            matchLabels:
-              app: longhorn-driver-deployer
+          names:
+            - longhorn-driver-deployer*
       - resources:
           kinds:
             - Pod


### PR DESCRIPTION
## Summary
- Match the driver-deployer controller and generated children by the stable resource-name prefix.
- Retain the narrow longhorn-system scope.
- Document why this component cannot use a label selector.

## Validation
- make test
- Rendered Helm manifest
- Kubernetes server-side dry-run