### PR TITLE
fix(jung2bot): re-allow port 3000 in the workload AuthorizationPolicy

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -56,7 +56,12 @@ spec:
 ---
 # Kyverno's require-mesh-authorization-policy checks for a workload-selector
 # policy separately from the Service targetRefs one above: Prometheus scrapes
-# the pod IP directly, which targetRefs policies don't cover.
+# the pod IP directly, which targetRefs policies don't cover. A
+# selector-based policy makes ztunnel enforce L4 authorization on the pod
+# for ALL traffic, not just the ports it lists, so port 3000 (gateway
+# ingress and the onOffFromWork/onScaleUp cron calls) must be re-allowed
+# here too -- L7 path restriction for those routes still comes from the
+# targetRefs policy above.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -68,6 +73,15 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Values.name }}
   rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
+              - cluster.local/ns/{{ .Values.namespace }}/sa/default
+      to:
+        - operation:
+            ports:
+              - "3000"
     - from:
         - source:
             principals:


### PR DESCRIPTION
## Summary
- OUTAGE: both jung2bot and jung2bot-dev stopped responding to
  Telegram commands after #3125 merged. Confirmed via gateway access
  logs: real Telegram webhook requests (verified source IP
  91.108.5.48) getting 503 upstream_reset_before_response_started
  (UC) on every attempt.
- Root cause: a selector-based AuthorizationPolicy makes ztunnel
  enforce L4 authorization directly on the pod for ALL traffic, not
  just the ports it lists. #3125's jung2bot-workload policy only
  allowed port 9090 for Prometheus, so ztunnel started resetting
  every other connection to the pod, including the gateway's webhook
  traffic on port 3000.
- Fix: re-allow port 3000 for the gateway and namespace default SA in
  the workload policy, matching what the targetRefs policy already
  permits at L7 (path restriction still comes from that policy).

## Test plan
- [x] `helm lint helm-charts/jung2bot`
- [x] `helm template`, checked rendered policy