### PR TITLE
fix(jung2bot): allow waypoint identity through the workload AuthorizationPolicy

### DIFF
--- a/helm-charts/jung2bot/templates/authorization-policy.yaml
+++ b/helm-charts/jung2bot/templates/authorization-policy.yaml
@@ -61,7 +61,13 @@ spec:
 # for ALL traffic, not just the ports it lists, so port 3000 (gateway
 # ingress and the onOffFromWork/onScaleUp cron calls) must be re-allowed
 # here too -- L7 path restriction for those routes still comes from the
-# targetRefs policy above.
+# targetRefs policy above. The waypoint's own identity must also be listed:
+# traffic that reaches this pod via the waypoint (gateway ingress, cron
+# calls -- anything routed through the Service) arrives at ztunnel as the
+# waypoint's SPIFFE identity, not the original caller's, so omitting it
+# here causes ztunnel to reject the waypoint's proxied connection outright
+# (503 "upstream connect error", ztunnel log "policy rejection: allow
+# policies exist, but none allowed" -- caused a live outage 2026-08-25).
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -78,6 +84,7 @@ spec:
             principals:
               - cluster.local/ns/{{ $gatewayNamespace }}/sa/{{ $gatewayName }}
               - cluster.local/ns/{{ .Values.namespace }}/sa/default
+              - {{ $waypointPrincipal }}
       to:
         - operation:
             ports:


### PR DESCRIPTION
## Summary

- Live outage: both `jung2bot` and `jung2bot-dev` Applications are Degraded, serving 503 on all traffic through the gateway/waypoint path (external requests, plus the `off-work`/`scale-up-database` CronJobs) since the `jung2bot-workload` selector-based AuthorizationPolicy merged.
- Root cause (confirmed via ztunnel access logs): traffic proxied through the waypoint arrives at the destination pod's ztunnel carrying the **waypoint's own SPIFFE identity** (`istio-waypoints/sa/waypoint`), not the original caller's. The workload policy's port-3000 rule only allowed the gateway and namespace-default service accounts, so ztunnel rejected the waypoint's proxied connection outright (`policy rejection: allow policies exist, but none allowed`).
- Fix: add the waypoint principal to the port-3000 rule alongside the existing ones. Comment added documenting why.

## Validation

- `helm lint helm-charts/jung2bot` (prod and dev values) — pass
- `helm template` — rendered policy confirmed includes the waypoint principal on port 3000
- Full `make test` blocked locally by an unrelated environment gap (`docker-credential-osxkeychain` missing for one OCI chart fetch), not by this change; CI has proper credentials