### PR TITLE
fix(monitoring): enrol Loki canary in ambient

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -489,9 +489,6 @@ grafana:
 loki:
   deploymentMode: SingleBinary
   lokiCanary:
-    podLabels:
-      # loki-canary performs direct Loki health checks and should not be intercepted by ambient mesh.
-      istio.io/dataplane-mode: none
     resources: *smallResources
   gateway:
     resources: *smallResources


### PR DESCRIPTION
## Summary

- enrol the Loki canary in the monitoring namespace ambient mesh
- preserve encrypted mTLS traffic through the Loki gateway
- leave Fluent Bit and the direct Loki ingestion path unchanged

## Validation

- [0;32mValidating ArgoCD manifest rendering...[0m 
[0;32mArgoCD manifest validation passed![0m 
[0;32mChecking YAML syntax...[0m 
[0;32mYAML syntax check passed![0m 
# Note: Excluding gateway-api and monitoring helm charts due to auto-generated CRD files with long lines
# Excluding unifi terragrunt.hcl due to long SSH public key that cannot be safely split
[0;32mChecking .editorconfig compliance...[0m 
[0;32mEditorConfig compliance check passed![0m 
[0;32mLinting Terraform files...[0m 
[0;32mTerraform linting passed![0m 
[0;32mLinting Terragrunt files...[0m 
[0;32mTerragrunt linting passed![0m 
[0;32mChecking Markdown files...[0m 
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !**/node_modules/** !**/.terraform/** !**/.venv/** !**/.scratchpad/**
Linting: 46 files
Summary: 0 issues in 0 files
[0;32mMarkdown linting passed![0m 
[0;32mRunning zizmor audit...[0m 
[0;32mValidating Helm charts...[0m 
- [0;32mValidating Helm charts...[0m 