### PR TITLE
feat(storage): add CSI snapshot controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ lint-zizmor: ## Run zizmor audit on workflows
 
 .PHONY: lint-editorconfig
 lint-editorconfig: ## Check .editorconfig compliance
-	# Note: Excluding gateway-api and monitoring helm charts due to auto-generated CRD files with long lines
+	# Note: Excluding gateway-api, monitoring, and snapshot-controller generated CRD files with upstream long lines
 	# Excluding unifi terragrunt.hcl due to long SSH public key that cannot be safely split
 	@echo "$(GREEN)Checking .editorconfig compliance...$(NC)"
 	@ec_bin="$$(command -v /opt/homebrew/bin/editorconfig-checker || command -v /usr/local/bin/editorconfig-checker || command -v editorconfig-checker || command -v ec)"; \
@@ -254,7 +254,7 @@ lint-editorconfig: ## Check .editorconfig compliance
 			echo "$(RED)editorconfig-checker is required but not installed. Install editorconfig-checker and re-run make lint-editorconfig.$(NC)"; \
 			exit 1; \
 		fi; \
-		"$$ec_bin" -exclude "(helm-charts/(gateway-api|monitoring)/.*|infrastructure/local/lhr/unifi/terragrunt\\.hcl)" || { \
+		"$$ec_bin" -exclude "(helm-charts/(gateway-api|monitoring|snapshot-controller)/.*|infrastructure/local/lhr/unifi/terragrunt\\.hcl)" || { \
 			echo "$(RED)EditorConfig violations found. Please fix manually or use your editor's .editorconfig support.$(NC)"; \
 			exit 1; \
 		}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Key addresses on the Server network:
 | Security     | [Kyverno](https://github.com/kyverno/kyverno)                                                       | Kubernetes policy engine                                                                                                                                                |
 | Security     | [oidc-provider](helm-charts/oidc-provider)                                                          | Kubernetes OIDC provider and JWKS endpoint                                                                                                                              |
 | Security     | [Ory Hydra](https://www.ory.com/hydra)                                                               | OAuth 2.0 and OpenID Connect issuer for machine clients and JWT validation                                                                                              |
+| Storage      | [CSI Snapshot Controller](https://github.com/kubernetes-csi/external-snapshotter)                   | Kubernetes CSI VolumeSnapshot CRDs and controller used by Longhorn                                                                                                     |
 | Storage      | [Longhorn](https://github.com/longhorn/longhorn)                                                    | Distributed block storage system; backup and restore from/to remote destinations                                                                                        |
 <!-- markdownlint-enable MD060 -->
 

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -304,6 +304,7 @@ local security = [
 ];
 
 local storage = [
+  { wave: '03', name: 'snapshot-controller', namespace: 'kube-system' },
   { wave: '04', name: 'longhorn', namespace: 'longhorn-system', helm: longhornHelm },
   { wave: '05', name: 'longhorn-config', namespace: 'longhorn-system' },
 ];

--- a/helm-charts/snapshot-controller/.helmignore
+++ b/helm-charts/snapshot-controller/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git/
+.gitignore
+.helmignore
+*.tgz

--- a/helm-charts/snapshot-controller/Chart.yaml
+++ b/helm-charts/snapshot-controller/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: snapshot-controller
+description: Kubernetes CSI snapshot controller and CRDs
+type: application
+version: 1.0.0
+appVersion: v8.6.0
+icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg

--- a/helm-charts/snapshot-controller/Makefile
+++ b/helm-charts/snapshot-controller/Makefile
@@ -1,0 +1,3 @@
+.PHONY: run
+run:
+	@bash hack/download-crds.sh

--- a/helm-charts/snapshot-controller/README.md
+++ b/helm-charts/snapshot-controller/README.md
@@ -1,0 +1,9 @@
+# snapshot-controller
+
+This chart vendors the official Kubernetes CSI snapshot CRDs and deploys the matching snapshot controller.
+
+Update the CRDs after changing `appVersion` in `Chart.yaml`:
+
+```shell
+make
+```

--- a/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    shortNames:
+      - vsclass
+      - vsclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            VolumeSnapshotClass specifies parameters that a underlying storage system uses when
+            creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its
+            name in a VolumeSnapshot object.
+            VolumeSnapshotClasses are non-namespaced
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            deletionPolicy:
+              description: |-
+                deletionPolicy determines whether a VolumeSnapshotContent created through
+                the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+                Supported values are "Retain" and "Delete".
+                "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+                "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
+                Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: |-
+                driver is the name of the storage driver that handles this VolumeSnapshotClass.
+                Required.
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            parameters:
+              additionalProperties:
+                type: string
+              description: |-
+                parameters is a key-value map with storage driver specific parameters for creating snapshots.
+                These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: false
+      storage: false
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -1,0 +1,449 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/955"
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    shortNames:
+      - vsc
+      - vscs
+    singular: volumesnapshotcontent
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
+            underlying storage system
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                spec defines properties of a VolumeSnapshotContent created by the underlying storage system.
+                Required.
+              properties:
+                deletionPolicy:
+                  description: |-
+                    deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on
+                    the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+                    Supported values are "Retain" and "Delete".
+                    "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+                    "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
+                    For dynamically provisioned snapshots, this field will automatically be filled in by the
+                    CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding
+                    VolumeSnapshotClass.
+                    For pre-existing snapshots, users MUST specify this field when creating the
+                     VolumeSnapshotContent object.
+                    Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: |-
+                    driver is the name of the CSI driver used to create the physical snapshot on
+                    the underlying storage system.
+                    This MUST be the same as the name returned by the CSI GetPluginName() call for
+                    that driver.
+                    Required.
+                  type: string
+                source:
+                  description: |-
+                    source specifies whether the snapshot is (or should be) dynamically provisioned
+                    or already exists, and just requires a Kubernetes object representation.
+                    This field is immutable after creation.
+                    Required.
+                  properties:
+                    snapshotHandle:
+                      description: |-
+                        snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on
+                        the underlying storage system for which a Kubernetes object representation
+                        was (or should be) created.
+                        This field is immutable.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: snapshotHandle is immutable
+                          rule: self == oldSelf
+                    volumeHandle:
+                      description: |-
+                        volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
+                        should be dynamically taken from.
+                        This field is immutable.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: volumeHandle is immutable
+                          rule: self == oldSelf
+                  type: object
+                  x-kubernetes-validations:
+                    - message: volumeHandle is required once set
+                      rule: '!has(oldSelf.volumeHandle) || has(self.volumeHandle)'
+                    - message: snapshotHandle is required once set
+                      rule: '!has(oldSelf.snapshotHandle) || has(self.snapshotHandle)'
+                    - message: exactly one of volumeHandle and snapshotHandle must be set
+                      rule: (has(self.volumeHandle) && !has(self.snapshotHandle)) || (!has(self.volumeHandle) && has(self.snapshotHandle))
+                sourceVolumeMode:
+                  description: |-
+                    SourceVolumeMode is the mode of the volume whose snapshot is taken.
+                    Can be either “Filesystem” or “Block”.
+                    If not specified, it indicates the source volume's mode is unknown.
+                    This field is immutable.
+                    This field is an alpha field.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: sourceVolumeMode is immutable
+                      rule: self == oldSelf
+                volumeSnapshotClassName:
+                  description: |-
+                    name of the VolumeSnapshotClass from which this snapshot was (or will be)
+                    created.
+                    Note that after provisioning, the VolumeSnapshotClass may be deleted or
+                    recreated with different set of values, and as such, should not be referenced
+                    post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: |-
+                    volumeSnapshotRef specifies the VolumeSnapshot object to which this
+                    VolumeSnapshotContent object is bound.
+                    VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to
+                    this VolumeSnapshotContent's name for the bidirectional binding to be valid.
+                    For a pre-existing VolumeSnapshotContent object, name and namespace of the
+                    VolumeSnapshot object MUST be provided for binding to happen.
+                    This field is immutable after creation.
+                    Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: both spec.volumeSnapshotRef.name and spec.volumeSnapshotRef.namespace must be set
+                      rule: has(self.name) && has(self.__namespace__)
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+              x-kubernetes-validations:
+                - message: sourceVolumeMode is required once set
+                  rule: '!has(oldSelf.sourceVolumeMode) || has(self.sourceVolumeMode)'
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: |-
+                    creationTime is the timestamp when the point-in-time snapshot is taken
+                    by the underlying storage system.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    CSI snapshotter sidecar with the "creation_time" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "creation_time"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                    If not specified, it indicates the creation time is unknown.
+                    The format of this field is a Unix nanoseconds time encoded as an int64.
+                    On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                    since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: |-
+                    error is the last observed error during snapshot creation, if any.
+                    Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: |-
+                        message is a string detailing the encountered error during snapshot
+                        creation if specified.
+                        NOTE: message may be logged, and it should not contain sensitive
+                        information.
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: |-
+                    readyToUse indicates if a snapshot is ready to be used to restore a volume.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    CSI snapshotter sidecar with the "ready_to_use" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                    otherwise, this field will be set to "True".
+                    If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: |-
+                    restoreSize represents the complete size of the snapshot in bytes.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    CSI snapshotter sidecar with the "size_bytes" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                    When restoring a volume from this snapshot, the size of the volume MUST NOT
+                    be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                    If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: |-
+                    snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system.
+                    If not specified, it indicates that dynamic snapshot creation has either failed
+                    or it is still in progress.
+                  type: string
+                volumeGroupSnapshotHandle:
+                  description: |-
+                    VolumeGroupSnapshotHandle is the CSI "group_snapshot_id" of a group snapshot
+                    on the underlying storage system.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+              properties:
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                  type: string
+                source:
+                  description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/helm-charts/snapshot-controller/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -1,0 +1,340 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    shortNames:
+      - vs
+    singular: volumesnapshot
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            VolumeSnapshot is a user's request for either creating a point-in-time
+            snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                spec defines the desired characteristics of a snapshot requested by a user.
+                More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+                Required.
+              properties:
+                source:
+                  description: |-
+                    source specifies where a snapshot will be created from.
+                    This field is immutable after creation.
+                    Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: |-
+                        persistentVolumeClaimName specifies the name of the PersistentVolumeClaim
+                        object representing the volume from which a snapshot should be created.
+                        This PVC is assumed to be in the same namespace as the VolumeSnapshot
+                        object.
+                        This field should be set if the snapshot does not exists, and needs to be
+                        created.
+                        This field is immutable.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: persistentVolumeClaimName is immutable
+                          rule: self == oldSelf
+                    volumeSnapshotContentName:
+                      description: |-
+                        volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent
+                        object representing an existing volume snapshot.
+                        This field should be set if the snapshot already exists and only needs a representation in Kubernetes.
+                        This field is immutable.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: volumeSnapshotContentName is immutable
+                          rule: self == oldSelf
+                  type: object
+                  x-kubernetes-validations:
+                    - message: persistentVolumeClaimName is required once set
+                      rule: '!has(oldSelf.persistentVolumeClaimName) || has(self.persistentVolumeClaimName)'
+                    - message: volumeSnapshotContentName is required once set
+                      rule: '!has(oldSelf.volumeSnapshotContentName) || has(self.volumeSnapshotContentName)'
+                    - message: exactly one of volumeSnapshotContentName and persistentVolumeClaimName must be set
+                      rule: (has(self.volumeSnapshotContentName) && !has(self.persistentVolumeClaimName)) || (!has(self.volumeSnapshotContentName) && has(self.persistentVolumeClaimName))
+                volumeSnapshotClassName:
+                  description: |-
+                    VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                    requested by the VolumeSnapshot.
+                    VolumeSnapshotClassName may be left nil to indicate that the default
+                    SnapshotClass should be used.
+                    A given cluster may have multiple default Volume SnapshotClasses: one
+                    default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass,
+                    VolumeSnapshotSource will be checked to figure out what the associated
+                    CSI Driver is, and the default VolumeSnapshotClass associated with that
+                    CSI Driver will be used. If more than one VolumeSnapshotClass exist for
+                    a given CSI Driver and more than one have been marked as default,
+                    CreateSnapshot will fail and generate an event.
+                    Empty string is not allowed for this field.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: volumeSnapshotClassName must not be the empty string when set
+                      rule: size(self) > 0
+              required:
+                - source
+              type: object
+            status:
+              description: |-
+                status represents the current information of a snapshot.
+                Consumers must verify binding between VolumeSnapshot and
+                VolumeSnapshotContent objects is successful (by validating that both
+                VolumeSnapshot and VolumeSnapshotContent point at each other) before
+                using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: |-
+                    boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                    object to which this VolumeSnapshot object intends to bind to.
+                    If not specified, it indicates that the VolumeSnapshot object has not been
+                    successfully bound to a VolumeSnapshotContent object yet.
+                    NOTE: To avoid possible security issues, consumers must verify binding between
+                    VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that
+                    both VolumeSnapshot and VolumeSnapshotContent point at each other) before using
+                    this object.
+                  type: string
+                creationTime:
+                  description: |-
+                    creationTime is the timestamp when the point-in-time snapshot is taken
+                    by the underlying storage system.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    snapshot controller with the "creation_time" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "creation_time"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                    If not specified, it may indicate that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: |-
+                    error is the last observed error during snapshot creation, if any.
+                    This field could be helpful to upper level controllers(i.e., application controller)
+                    to decide whether they should continue on waiting for the snapshot to be created
+                    based on the type of error reported.
+                    The snapshot controller will keep retrying when an error occurs during the
+                    snapshot creation. Upon success, this error field will be cleared.
+                  properties:
+                    message:
+                      description: |-
+                        message is a string detailing the encountered error during snapshot
+                        creation if specified.
+                        NOTE: message may be logged, and it should not contain sensitive
+                        information.
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: |-
+                    readyToUse indicates if the snapshot is ready to be used to restore a volume.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    snapshot controller with the "ready_to_use" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                    otherwise, this field will be set to "True".
+                    If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: |-
+                    restoreSize represents the minimum size of volume required to create a volume
+                    from this snapshot.
+                    In dynamic snapshot creation case, this field will be filled in by the
+                    snapshot controller with the "size_bytes" value returned from CSI
+                    "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                    value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                    When restoring a volume from this snapshot, the size of the volume MUST NOT
+                    be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                    If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                volumeGroupSnapshotName:
+                  description: |-
+                    VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot of which this
+                    VolumeSnapshot is a part of.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+              properties:
+                source:
+                  description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                  type: string
+              required:
+                - source
+              type: object
+            status:
+              description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                  type: string
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/snapshot-controller/hack/download-crds.sh
+++ b/helm-charts/snapshot-controller/hack/download-crds.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SNAPSHOTTER_VERSION=$(yq -e '.appVersion' "$SCRIPT_DIR/../Chart.yaml")
+CRD_BASE_URL="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/client/config/crd"
+CRD_PATH="$SCRIPT_DIR/../crds"
+
+mkdir -p "$CRD_PATH"
+
+for crd in \
+  snapshot.storage.k8s.io_volumesnapshotclasses.yaml \
+  snapshot.storage.k8s.io_volumesnapshotcontents.yaml \
+  snapshot.storage.k8s.io_volumesnapshots.yaml; do
+  curl --silent --show-error --retry-all-errors --fail --location "${CRD_BASE_URL}/${crd}" \
+    | yq e 'select(.)' - > "$CRD_PATH/$crd"
+done

--- a/helm-charts/snapshot-controller/templates/deployment.yaml
+++ b/helm-charts/snapshot-controller/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: snapshot-controller
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: snapshot-controller
+  minReadySeconds: 35
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: snapshot-controller
+    spec:
+      serviceAccountName: snapshot-controller
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: snapshot-controller
+          image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=5
+            - --leader-election=true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/helm-charts/snapshot-controller/templates/pod-disruption-budget.yaml
+++ b/helm-charts/snapshot-controller/templates/pod-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: snapshot-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: snapshot-controller

--- a/helm-charts/snapshot-controller/templates/rbac.yaml
+++ b/helm-charts/snapshot-controller/templates/rbac.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/snapshot-controller/values.yaml
+++ b/helm-charts/snapshot-controller/values.yaml
@@ -1,0 +1,13 @@
+controller:
+  image:
+    # Upstream v8.6.0 deploys this v8.5.0 controller image.
+    repository: registry.k8s.io/sig-storage/snapshot-controller
+    tag: v8.5.0@sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+      ephemeral-storage: 32Mi
+    limits:
+      memory: 64Mi
+      ephemeral-storage: 32Mi


### PR DESCRIPTION
## Summary

- vendor Kubernetes CSI VolumeSnapshot CRDs from external-snapshotter v8.6.0
- deploy the upstream snapshot controller with hardened resources and digest-pinned image
- reconcile the controller before Longhorn through Argo CD

## Validation

- [0;32mValidating ArgoCD manifest rendering...[0m 
[0;32mArgoCD manifest validation passed![0m 
[0;32mChecking YAML syntax...[0m 
[0;32mYAML syntax check passed![0m 
# Note: Excluding gateway-api, monitoring, and snapshot-controller generated CRD files with upstream long lines
# Excluding unifi terragrunt.hcl due to long SSH public key that cannot be safely split
[0;32mChecking .editorconfig compliance...[0m 
[0;32mEditorConfig compliance check passed![0m 
[0;32mLinting Terraform files...[0m 
[0;32mTerraform linting passed![0m 
[0;32mLinting Terragrunt files...[0m 
[0;32mTerragrunt linting passed![0m 
[0;32mChecking Markdown files...[0m 
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !**/node_modules/** !**/.terraform/** !**/.venv/** !**/.scratchpad/**
Linting: 47 files
Summary: 0 issues in 0 files
[0;32mMarkdown linting passed![0m 
[0;32mRunning zizmor audit...[0m 
[0;32mValidating Helm charts...[0m 
- Helm server-side dry run for the CRDs and controller resources
- Argo CD manifest validation