### PR TITLE
fix(descheduler): retain 100Mi VPA memory floor

### DIFF
--- a/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/descheduler/templates/verticalpodautoscaler.yaml
@@ -17,7 +17,10 @@ spec:
         controlledResources: [memory]
         controlledValues: RequestsAndLimits
         minAllowed:
-          memory: 16Mi
+          # VPA repeatedly attempted a 47Mi in-place downsize while the Pod used ~74Mi,
+          # producing ResizeError events. Keep the established 100Mi KRR guardrail.
+          # The matching Deployment request and limit are both 100Mi.
+          memory: 100Mi
         maxAllowed:
           memory: 128Mi
       - containerName: descheduler


### PR DESCRIPTION
Raises the descheduler VPA memory floor from 16Mi to the established 100Mi guardrail. This stops unsafe in-place downsize attempts that emit recurring ResizeError events.