### PR TITLE
feat(jung2bot): add FIFO message-save queues

### DIFF
--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -90,3 +90,5 @@ spec:
                 secretKeyRef:
                   key: EVENT_QUEUE_URL
                   name: jung2bot-secrets
+            - name: MESSAGE_SAVE_QUEUE_URL
+              value: {{ printf "https://sqs.%s.amazonaws.com/%s/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.messageSaveQueueName | quote }}

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -11,6 +11,7 @@ app:
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug
+    messageSaveQueueName: jung2bot-dev-message-save-queue.fifo
     messageTable: jung2bot-dev-messages
     # Must exceed the tables' provisioned read capacity of 1, or UpdateTable is
     # a no-op that the service reports as success.

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -26,6 +26,7 @@ app:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds
     logLevel: info
+    messageSaveQueueName: jung2bot-prod-message-save-queue.fifo
     messageTable: jung2bot-prod-messages
     profile: default
     scaleUpReadCapacity: 600

--- a/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/iam-irsa/terragrunt.hcl
@@ -35,6 +35,7 @@ inputs = {
       actions = ["sqs:*"]
       resources = [
         "arn:aws:sqs:*:*:${local.name}-event-queue",
+        "arn:aws:sqs:*:*:${local.name}-message-save-queue.fifo",
       ]
     }
     sqs-generic = {

--- a/infrastructure/cloud/aws/jung2bot-dev/sqs/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/sqs/terragrunt.hcl
@@ -11,5 +11,9 @@ inputs = {
     event = {
       name = "jung2bot-dev-event-queue"
     }
+    message_save = {
+      name = "jung2bot-dev-message-save-queue.fifo"
+      fifo = true
+    }
   }
 }

--- a/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot/iam-irsa/terragrunt.hcl
@@ -35,6 +35,7 @@ inputs = {
       actions = ["sqs:*"]
       resources = [
         "arn:aws:sqs:*:*:${local.name}-prod-event-queue",
+        "arn:aws:sqs:*:*:${local.name}-prod-message-save-queue.fifo",
       ]
     }
     sqs-generic = {

--- a/infrastructure/cloud/aws/jung2bot/sqs/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot/sqs/terragrunt.hcl
@@ -11,5 +11,9 @@ inputs = {
     event = {
       name = "jung2bot-prod-event-queue"
     }
+    message_save = {
+      name = "jung2bot-prod-message-save-queue.fifo"
+      fifo = true
+    }
   }
 }

--- a/infrastructure/modules/aws-sqs/00-vars.tf
+++ b/infrastructure/modules/aws-sqs/00-vars.tf
@@ -1,5 +1,6 @@
 variable "sqss" {
   type = map(object({
     name = string
+    fifo = optional(bool, false)
   }))
 }

--- a/infrastructure/modules/aws-sqs/01-main.tf
+++ b/infrastructure/modules/aws-sqs/01-main.tf
@@ -7,6 +7,7 @@ module "sqs" {
   for_each = var.sqss
 
   name                              = each.value.name
+  fifo_queue                        = each.value.fifo
   visibility_timeout_seconds        = 600
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = 86400


### PR DESCRIPTION
## Summary

- create prod and dev FIFO message-save queues
- grant the Jung2bot IRSA roles access to their queues
- pass non-secret queue URLs to the Helm workload

## Validation

- `make test`
- local `terragrunt apply` and follow-up no-drift plans for both SQS and IRSA units