### PR TITLE
fix(monitoring): allow YACE account alias lookup

### DIFF
--- a/infrastructure/cloud/aws/monitoring/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/monitoring/iam-irsa/terragrunt.hcl
@@ -22,5 +22,9 @@ inputs = {
       actions   = ["cloudwatch:GetMetricStatistics"]
       resources = ["*"]
     }
+    iam = {
+      actions   = ["iam:ListAccountAliases"]
+      resources = ["*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- allow YACE to read the AWS account alias required by its static SQS jobs
- stop the recurring `ListAccountAliases` access-denied warnings

## Validation

- `make test`