### PR TITLE
fix(jung2bot): fix broken MESSAGE_SAVE_QUEUE_URL format string

### DIFF
--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -91,4 +91,4 @@ spec:
                   key: EVENT_QUEUE_URL
                   name: jung2bot-secrets
             - name: MESSAGE_SAVE_QUEUE_URL
-              value: {{ printf "https://sqs.%s.amazonaws.com/%s/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.messageSaveQueueName | quote }}
+              value: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.messageSaveQueueName | quote }}


### PR DESCRIPTION
## Problem

`jung2bot-dev` crash-looped: `MESSAGE_SAVE_QUEUE_URL must be an absolute URL`.

The rendered env var was:
`https://sqs.eu-west-1.amazonaws.com/%!s(int64=477397881710)/jung2bot-dev-message-save-queue.fifo`

`irsa.awsAccountId` is passed to Helm via an ArgoCD parameter, which Helm
parses as an int64. Go's `fmt` package cannot format a non-string value
with `%s`, so it emits the literal error text `%!s(int64=...)` instead of
the number, producing an invalid URL.

## Fix

Use `%v` instead of `%s` for that argument in the `printf` call, which
formats correctly regardless of the value's underlying type.

## Test plan

- [x] `helm template` with `--set irsa.awsAccountId=477397881710` renders
  a valid absolute URL
- [x] `helm lint` passes for both prod and dev values
- [ ] Confirm `jung2bot-dev` pod goes Ready after merge and sync