### PR TITLE
fix(monitoring): clarify jung2bot dashboard signals

### DIFF
--- a/helm-charts/monitoring/dashboards/jung2bot.yaml
+++ b/helm-charts/monitoring/dashboards/jung2bot.yaml
@@ -670,7 +670,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "Per-pod scrape state: 1 = /metrics reachable, 0 = scrape failing",
+                "description": "Lowest scrape state across jung2bot pods: 1 = /metrics reachable, 0 = a scrape is failing.",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -758,15 +758,15 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "up{app_kubernetes_io_name=\"jung2bot\",namespace=\"$ns\"}",
-                    "legendFormat": "{{pod}}",
+                    "expr": "min(up{app_kubernetes_io_name=\"jung2bot\",namespace=\"$ns\"})",
+                    "legendFormat": "",
                     "range": true,
                     "refId": "A"
                   }
                 ],
-                "title": "Pod up",
+                "title": "Metrics scrape",
                 "transparent": true,
-                "type": "timeseries"
+                "type": "stat"
               },
               {
                 "datasource": {
@@ -900,7 +900,7 @@ grafana:
                 ],
                 "title": "Replica count",
                 "transparent": true,
-                "type": "timeseries"
+                "type": "stat"
               },
               {
                 "collapsed": false,
@@ -920,7 +920,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_http_requests_total: requests/min per fixed public route",
+                "description": "telegram_jung2_bot_http_requests_total: requests/s per fixed public route",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -936,7 +936,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1006,7 +1006,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum(rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route=\"stage_ping\"}[$__rate_interval])) * 60",
+                    "expr": "sum(rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route=\"stage_ping\"}[$__rate_interval]))",
                     "legendFormat": "/ping",
                     "range": true,
                     "refId": "A"
@@ -1017,7 +1017,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum(rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route=\"stage_webhook\"}[$__rate_interval])) * 60",
+                    "expr": "sum(rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route=\"stage_webhook\"}[$__rate_interval]))",
                     "legendFormat": "/",
                     "range": true,
                     "refId": "B"
@@ -1028,7 +1028,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (route) (rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route!~\"stage_ping|stage_webhook\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (route) (rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\",route!~\"stage_ping|stage_webhook\"}[$__rate_interval]))",
                     "legendFormat": "{{route}}",
                     "range": true,
                     "refId": "C"
@@ -1043,7 +1043,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_http_requests_total: responses/min by HTTP status code, stacked",
+                "description": "telegram_jung2_bot_http_requests_total: responses/s by HTTP status code, stacked",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1059,7 +1059,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1129,7 +1129,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (code) (rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (code) (rate(telegram_jung2_bot_http_requests_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{code}}",
                     "range": true,
                     "refId": "A"
@@ -1280,7 +1280,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_webhook_updates_total: accepted Telegram updates/min by outcome",
+                "description": "telegram_jung2_bot_webhook_updates_total: accepted Telegram updates/s by outcome",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1296,7 +1296,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1366,7 +1366,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (outcome) (rate(telegram_jung2_bot_webhook_updates_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (outcome) (rate(telegram_jung2_bot_webhook_updates_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{outcome}}",
                     "range": true,
                     "refId": "A"
@@ -1381,7 +1381,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_webhook_commands_enqueued_total: commands/min queued from webhook updates",
+                "description": "telegram_jung2_bot_webhook_commands_enqueued_total: commands/s queued from webhook updates",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1397,7 +1397,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1467,7 +1467,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (action) (rate(telegram_jung2_bot_webhook_commands_enqueued_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (action) (rate(telegram_jung2_bot_webhook_commands_enqueued_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{action}}",
                     "range": true,
                     "refId": "A"
@@ -1495,7 +1495,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_worker_actions_total: queue actions/min by action and outcome",
+                "description": "telegram_jung2_bot_worker_actions_total: queue actions/s by action and outcome",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1511,7 +1511,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1581,7 +1581,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (action, outcome) (rate(telegram_jung2_bot_worker_actions_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (action, outcome) (rate(telegram_jung2_bot_worker_actions_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{action}} {{outcome}}",
                     "range": true,
                     "refId": "A"
@@ -1697,7 +1697,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_dependency_requests_total: outbound calls/min by dependency, operation and result",
+                "description": "telegram_jung2_bot_dependency_requests_total: outbound calls/s by dependency, operation and result",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1713,7 +1713,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1783,7 +1783,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (dependency, operation, result) (rate(telegram_jung2_bot_dependency_requests_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (dependency, operation, result) (rate(telegram_jung2_bot_dependency_requests_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{dependency}} {{operation}} {{result}}",
                     "range": true,
                     "refId": "A"
@@ -1912,7 +1912,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_off_work_reports_enqueued_total: scheduled report enqueue attempts/min by result",
+                "description": "telegram_jung2_bot_off_work_reports_enqueued_total: scheduled report enqueue attempts/s by result",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -1928,7 +1928,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -1998,7 +1998,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (result) (rate(telegram_jung2_bot_off_work_reports_enqueued_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (result) (rate(telegram_jung2_bot_off_work_reports_enqueued_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{result}}",
                     "range": true,
                     "refId": "A"
@@ -2013,7 +2013,7 @@ grafana:
                   "type": "prometheus",
                   "uid": "PBFA97CFB590B2093"
                 },
-                "description": "telegram_jung2_bot_scale_up_total: DynamoDB scale-up attempts/min by result",
+                "description": "telegram_jung2_bot_scale_up_total: DynamoDB scale-up attempts/s by result",
                 "fieldConfig": {
                   "defaults": {
                     "color": {
@@ -2029,7 +2029,7 @@ grafana:
                         }
                       ]
                     },
-                    "unit": "suffix: /min",
+                    "unit": "suffix: /s",
                     "decimals": 2,
                     "custom": {
                       "axisBorderShow": false,
@@ -2099,7 +2099,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "sum by (result) (rate(telegram_jung2_bot_scale_up_total{namespace=\"$ns\"}[$__rate_interval])) * 60",
+                    "expr": "sum by (result) (rate(telegram_jung2_bot_scale_up_total{namespace=\"$ns\"}[$__rate_interval]))",
                     "legendFormat": "{{result}}",
                     "range": true,
                     "refId": "A"
@@ -2327,7 +2327,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "aws_sqs_approximate_number_of_messages_visible_maximum{custom_tag_environment=\"${ns:text}\"}",
+                    "expr": "aws_sqs_approximate_number_of_messages_visible_maximum{custom_tag_namespace=\"$ns\"}",
                     "legendFormat": "visible",
                     "range": true,
                     "refId": "A"
@@ -2338,7 +2338,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "aws_sqs_approximate_number_of_messages_not_visible_maximum{custom_tag_environment=\"${ns:text}\"}",
+                    "expr": "aws_sqs_approximate_number_of_messages_not_visible_maximum{custom_tag_namespace=\"$ns\"}",
                     "legendFormat": "in-flight",
                     "range": true,
                     "refId": "B"
@@ -2447,7 +2447,7 @@ grafana:
                       "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "aws_sqs_approximate_age_of_oldest_message_maximum{custom_tag_environment=\"${ns:text}\"}",
+                    "expr": "aws_sqs_approximate_age_of_oldest_message_maximum{custom_tag_namespace=\"$ns\"}",
                     "legendFormat": "oldest message",
                     "range": true,
                     "refId": "A"
@@ -2516,6 +2516,6 @@ grafana:
             "timezone": "browser",
             "title": "jung2bot",
             "uid": "jung2bot",
-            "version": 6,
+            "version": 7,
             "weekStart": ""
           }

--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -454,6 +454,8 @@ yace:
         customTags:
           - key: environment
             value: prod
+          - key: namespace
+            value: jung2bot
         metrics:
           - name: ApproximateAgeOfOldestMessage
             statistics:
@@ -480,6 +482,8 @@ yace:
         customTags:
           - key: environment
             value: dev
+          - key: namespace
+            value: jung2bot-dev
         metrics:
           - name: ApproximateAgeOfOldestMessage
             statistics:


### PR DESCRIPTION
## Summary

- show scrape and autoscaler information as stat panels
- use per-second units for all counter rate panels
- add YACE namespace tags so the SQS panels follow the dashboard namespace selector

## Validation

- `make test`