### PR TITLE
config(jung2bot): shorten message queue flush

### DIFF
--- a/helm-charts/jung2bot/templates/deployment.yaml
+++ b/helm-charts/jung2bot/templates/deployment.yaml
@@ -92,3 +92,5 @@ spec:
                   name: jung2bot-secrets
             - name: MESSAGE_SAVE_QUEUE_URL
               value: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.messageSaveQueueName | quote }}
+            - name: MESSAGE_SAVE_QUEUE_FLUSH_SECONDS
+              value: {{ .Values.app.env.messageSaveQueueFlushSeconds | quote }}

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -26,6 +26,7 @@ app:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds
     logLevel: info
+    messageSaveQueueFlushSeconds: 10
     messageSaveQueueName: jung2bot-prod-message-save-queue.fifo
     messageTable: jung2bot-prod-messages
     profile: default


### PR DESCRIPTION
## Summary

- configure the message-save queue flush interval in the chart
- set the shared dev and production default to 10 seconds

## Validation

- make test