### PR TITLE
deploy(jung2bot): update prod to 6.1.2

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.1.0@sha256:7ab65aeaf61f3864ca0c83ec462f6079b86a724c7642bc9c5198fb638799ceef
+    tag: jung2bot-6.1.2@sha256:7d2791126cae74a144f90a5892e3f3dab002b9e01f46dc3c779009a5c332e4f4
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
## Summary

- pin production `jung2bot` to `jung2bot-6.1.2` by immutable image digest
- enables the FIFO message-save queue in production

## Validation

- `jung2bot-6.1.2` has run in dev since PR #3147 with no errors and no
  message-save queue backlog
- `make test` passes except for `validate-helm-charts`, which fails locally
  only because `docker-credential-osxkeychain` is unavailable in this
  environment when fetching the unrelated `gateway-helm` OCI chart; CI runs
  this step in a working environment