### PR TITLE
revert(jung2bot): roll production back to 6.1.0

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.1.2@sha256:7d2791126cae74a144f90a5892e3f3dab002b9e01f46dc3c779009a5c332e4f4
+    tag: jung2bot-6.1.0@sha256:7ab65aeaf61f3864ca0c83ec462f6079b86a724c7642bc9c5198fb638799ceef
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
## Summary

- reverts production `jung2bot` from `6.1.2` to `6.1.0` (previous known-good
  image, immutable digest)

## Why

PR #3149 pinned production to `6.1.2` to enable the FIFO message-save queue.
Within minutes, 3 of 4 prod pods logged a tight retry loop of:

```
level=ERROR msg="flush queued messages" err="send SQS message batch:
operation error SQS: SendMessageBatch, ... api error InvalidParameterValue:
Number of message attributes [11] exceeds the allowed maximum [10]."
```

`ApproximateNumberOfMessages` on the prod message-save queue stayed at 0
throughout, so `SendMessageBatch` is rejecting the request before anything
reaches the queue: production is currently dropping queued messages instead
of persisting them. This did not reproduce in dev, so some production
message shape pushes the attribute count from 10 to 11.

## Validation

- `make test` passes except for `validate-helm-charts`, which fails locally
  only because `docker-credential-osxkeychain` is unavailable in this
  environment when fetching the unrelated `gateway-helm` OCI chart; CI runs
  this step in a working environment