### PR TITLE
deploy(jung2bot): update dev to 6.1.3

### DIFF
--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -7,7 +7,7 @@ secret:
 app:
   # Pinned here so dev and prod can diverge if needed; rollback is one line.
   image:
-    tag: jung2bot-6.1.2@sha256:7d2791126cae74a144f90a5892e3f3dab002b9e01f46dc3c779009a5c332e4f4
+    tag: jung2bot-6.1.3@sha256:2187187fe7ef160a9efb88b971aba12eeb3a0d1c1bd7b39cf19c58180ccd0c8b
   env:
     chatIdTable: jung2bot-dev-chatIds
     logLevel: debug


### PR DESCRIPTION
## Summary

- pin dev `jung2bot` to `jung2bot-6.1.3` by immutable image digest

## Why

6.1.2 (PR #3149) hit an SQS `SendMessageBatch` 400 in production
(`Number of message attributes [11] exceeds the allowed maximum [10]`)
and was rolled back in #3150. `jung2bot-6.1.3` includes the fix
(siutsin/telegram-jung2-bot#3134): the unused `updateId` attribute is
dropped, restoring headroom for the `enqueuedAt` attribute the queue
producer adds. Verifying in dev before re-pinning prod.

## Validation

- `make test` (all steps pass except `validate-helm-charts`, which fails
  locally only on a missing `docker-credential-osxkeychain`; unrelated to
  this change, CI runs it in a working environment)