### PR TITLE
deploy(jung2bot): update prod to 6.1.3

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.1.0@sha256:7ab65aeaf61f3864ca0c83ec462f6079b86a724c7642bc9c5198fb638799ceef
+    tag: jung2bot-6.1.3@sha256:2187187fe7ef160a9efb88b971aba12eeb3a0d1c1bd7b39cf19c58180ccd0c8b
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
## Summary

- pin production `jung2bot` to `jung2bot-6.1.3` by immutable image digest
- re-enables the FIFO message-save queue in production

## Why

6.1.2 (PR #3149) hit an SQS `SendMessageBatch` 400
(`Number of message attributes [11] exceeds the allowed maximum [10]`) on
every flush in production and was rolled back to 6.1.0 in #3150.
`jung2bot-6.1.3` includes the fix
(siutsin/telegram-jung2-bot#3134): the unused `updateId` attribute is
dropped, restoring headroom for the `enqueuedAt` attribute the queue
producer adds. Verified clean in dev in #3151 with no errors.

## Validation

- `make test` (all steps pass except `validate-helm-charts`, which fails
  locally only on a missing `docker-credential-osxkeychain`; unrelated to
  this change, CI runs it in a working environment)