### PR TITLE
config(jung2bot): reduce prod min replicas to 3

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -33,7 +33,7 @@ app:
     scaleUpReadCapacity: 600
     stage: prod
   autoscaling:
-    min: 4
+    min: 3
     max: 10
 
 cron:


### PR DESCRIPTION
## Summary

- reduce prod `jung2bot` KEDA `minReplicaCount` from 4 to 3

## Why

The FIFO message-save producer buffers per pod and flushes on whichever
comes first: a ten-message batch or the ten-second timer. Fewer pods
concentrate more traffic per buffer, so the ten-message threshold is
reached sooner, lowering typical persistence latency. Live prod traffic
right now (~180-220 msgs/min) put per-pod fill time at ~12s at 4
replicas (timer-bound); at 3 replicas it drops toward the ten-second
mark. `min: 3` still leaves enough replicas for a zero-downtime rolling
deploy, unlike dropping to 1-2.

## Validation

- `make test` (all steps pass except `validate-helm-charts`, which fails
  locally only on a missing `docker-credential-osxkeychain`; unrelated to
  this change, CI runs it in a working environment)