### PR TITLE
fix(jung2bot): raise VPA memory floor to stop OOMKill loop

### DIFF
--- a/helm-charts/jung2bot/templates/verticalpodautoscaler.yaml
+++ b/helm-charts/jung2bot/templates/verticalpodautoscaler.yaml
@@ -16,8 +16,14 @@ spec:
       - containerName: {{ .Values.name }}
         controlledResources: [memory]
         controlledValues: RequestsAndLimits
+        # 2026-08-25: VPA had resized memory down to 64Mi, then ~47Mi (its
+        # own target), causing repeated OOMKilled (exit 137) restarts on
+        # both new KEDA scale-out pods and previously-stable long-running
+        # pods during a scale-out burst. Raised the floor above the VPA's
+        # own observed upperBound (~93Mi) so it can no longer resize into
+        # the range that was already crash-looping.
         minAllowed:
-          memory: 16Mi
+          memory: 128Mi
         maxAllowed:
           memory: 192Mi
 {{- end }}


### PR DESCRIPTION
## Problem

`jung2bot` prod pods have been repeatedly `OOMKilled` (exit 137) over the
last ~1h30m, starting with a KEDA scale-out burst and continuing on
previously-stable long-running pods (5 and 4 restarts respectively at time
of writing).

VPA (memory-only, `InPlaceOrRecreate`) had already resized the container
down to 64Mi, then further to its own live target of ~47Mi -- both below
its own observed upperBound of ~93Mi, and both in the range that was
already crash-looping.

## Fix

Raise the VPA's `minAllowed.memory` from 16Mi to 128Mi, above VPA's own
upperBound recommendation, so it can no longer resize into the range
that was OOMing. `maxAllowed` (192Mi) is unchanged.

## Test plan

- [x] `helm lint`/`helm template` for the affected chart
- [ ] Confirm pods stop OOMKilling after merge and VPA re-applies the new
  floor