### PR TITLE
fix(teslamate): restore capabilities postgres-sidecar's entrypoint needs

### DIFF
--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -114,11 +114,29 @@ spec:
 
             - name: postgres-sidecar
               image: postgres:{{ .Values.backup.database.postgresVersion }}-alpine
+              # 2026-08-25: PR #3112 dropped ALL capabilities here, but this
+              # container runs the stock postgres image's own entrypoint,
+              # which chowns/chmods its data dir as root then setuids to the
+              # postgres user before starting the server -- that needs
+              # CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID. Without them the
+              # entrypoint failed ("chmod: ... Operation not permitted",
+              # "failed switching to 'postgres': operation not permitted"),
+              # postgres never started, and teslamate-verify-pg-dump hit
+              # BackoffLimitExceeded (first run after #3112, 2026-08-25
+              # 12:00 UTC). The sibling verify-pg-dump container only runs
+              # psql/pg_isready as a client and never setuids, so it keeps
+              # dropping ALL.
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:
                     - ALL
+                  add:
+                    - CHOWN
+                    - DAC_OVERRIDE
+                    - FOWNER
+                    - SETGID
+                    - SETUID
               env:
                 - name: POSTGRES_USER
                   valueFrom:


### PR DESCRIPTION
## Root cause

Dug into today's \`teslamate-verify-pg-dump\` \`BackoffLimitExceeded\`
failure via Loki (the Job's pods were already garbage-collected). The
\`postgres-sidecar\` container's logs showed:

\`\`\`
chmod: /var/lib/postgresql/data: Operation not permitted
chmod: /var/run/postgresql: Operation not permitted
error: failed switching to 'postgres': operation not permitted
\`\`\`

PR #3112 (merged 2026-08-24 23:06 +0100, a hardening pass) added
\`capabilities: drop: [ALL]\` to this container. It runs the stock
\`postgres:17-alpine\` image's own entrypoint, which needs to
chown/chmod its data directory as root and then setuid to the
\`postgres\` user before starting the server -- both steps need
capabilities that \`drop: ALL\` removes. Yesterday's run (before #3112)
succeeded; today's -- the first run after the change -- was the first
failure.

## Fix

Add back only the five capabilities that specific entrypoint step
needs: \`CHOWN\`, \`DAC_OVERRIDE\`, \`FOWNER\`, \`SETGID\`, \`SETUID\`. The
sibling \`verify-pg-dump\` container (psql/pg_isready client only, never
setuids) is untouched and keeps dropping \`ALL\`.

## Impact while broken

The actual scheduled backup (CNPG's own Barman-based backup) succeeded
independently and was never affected -- no data-loss risk. This job
only verifies an existing S3 pg_dump backup restores cleanly.

## Test plan

- [x] \`helm lint\`/\`helm template\` for the affected chart
- [ ] Confirm tomorrow's 12:00 UTC run succeeds