### PR TITLE
docs(self-healing): auto-merge hardening fixes, document VPA/descheduler churn

### DIFF
--- a/.claude/skills/right-sizing/SKILL.md
+++ b/.claude/skills/right-sizing/SKILL.md
@@ -224,6 +224,22 @@ and `k8s-cleaner` are the initial trial (`helm-charts/reloader/values.yaml`,
     recommendation when the pod is next recreated for an unrelated reason,
     which may never happen for a long-lived Deployment -- not a real
     alternative for actually getting the fix applied.
+5. Set `minAllowed` with real headroom above observed peaks, not just
+    above steady-state. VPA's own `target`/`upperBound` can still settle
+    below a value that already caused an OOMKill if steady-state samples
+    outweigh a brief burst in its 8-day window — the `minAllowed` floor,
+    not the recommendation, is what actually prevents a repeat. Confirmed
+    on `jung2bot` (2026-08-25): a KEDA scale-out burst OOMKilled pods at
+    the then-current 64Mi limit; VPA's own target then settled to ~47Mi
+    (below the value that had just OOMKilled), so raising `minAllowed`
+    to 128Mi — above VPA's observed `upperBound` (~93Mi), not just above
+    the failure point — was the actual fix (PR #3154). Raising the floor
+    trades one problem for a smaller one: a higher per-replica memory
+    request can increase descheduler `HighNodeUtilization` and VPA's own
+    `InPlaceOrRecreate` eviction frequency on memory-tight nodes — see
+    `.claude/skills/self-healing/runbooks/workloads.md`'s "VPA +
+    descheduler eviction churn" gotcha before treating a resulting
+    increase in pod churn as a separate, unrelated incident.
 
 ## Journal
 

--- a/.claude/skills/self-healing/runbooks/merge-policy.md
+++ b/.claude/skills/self-healing/runbooks/merge-policy.md
@@ -102,6 +102,33 @@ Precedent: `jung2bot` `MESSAGE_SAVE_QUEUE_URL` `printf %s` on an int64 →
 literal `%!s(int64=...)`, invalid URL, crash loop; fixed to `%v`, PR #3144,
 2026-08-25.
 
+### Scoped hardening-regression fix exception
+
+Auto-merge once green, even though it touches a container's
+`securityContext`/capabilities, when **all** hold:
+
+- A recent, identifiable commit (via `git log`) added a hardening change
+  (`capabilities: drop: [ALL]`, `readOnlyRootFilesystem`, `runAsNonRoot`,
+  etc.) that is the confirmed root cause of a currently active incident.
+- Root cause is confirmed via concrete evidence (container/Job logs — Loki
+  if the pod is already gone — showing the exact permission/capability
+  error), not guessed from the diff.
+- The fix restores only the minimal capability/permission that error
+  needs (name the exact capabilities to `add` back) — not a blanket
+  revert of the hardening commit, not disabling the policy, and no RBAC,
+  auth, network exposure, mesh/gateway, or cluster-wide policy touched.
+- Verified against rendered output (`helm template`), not lint alone.
+- `make test` (or the affected chart's `helm lint`/`template` if blocked
+  by a known unrelated gap) passed and CI is green.
+
+Precedent: `teslamate` `verify-pg-dump`'s `postgres-sidecar` container got
+`capabilities: drop: [ALL]` (PR #3112), breaking the stock postgres
+image's own entrypoint (chowns/chmods its data dir and setuids to
+`postgres` as root first) — confirmed via Loki logs showing `chmod: ...
+Operation not permitted` / `failed switching to 'postgres': operation not
+permitted`. Fixed by adding back only `CHOWN`, `DAC_OVERRIDE`, `FOWNER`,
+`SETGID`, `SETUID`, PR #3156, 2026-08-25.
+
 ## Non-trivial
 
 Push, watch CI to green, address review feedback, then stop and leave the

--- a/.claude/skills/self-healing/runbooks/workloads.md
+++ b/.claude/skills/self-healing/runbooks/workloads.md
@@ -15,6 +15,20 @@
   pod stuck `CrashLoopBackOff` still reports phase `Running` and can look
   fine at a glance if this step is skipped, especially on an abbreviated
   scheduled check; run it every pass, not just on a full sweep.
+- **Eviction/resize churn on a healthy-looking multi-replica workload:**
+  `kubectl get events -A --sort-by='.lastTimestamp' | grep -E
+  'EvictedByVPA|HighNodeUtilization|ResizeDeferred'` — a single
+  `--field-selector reason=X,reason=Y` call ANDs the values (a match
+  needs both reasons on the same event, which never happens) and
+  silently returns nothing, so grep the reason column instead, or run
+  one `--field-selector reason=<X>` call per reason. A Deployment with a
+  PDB
+  covering it (`maxUnavailable: 1` or similar) can churn a pod every few
+  minutes indefinitely with the Application staying `Synced`/`Healthy`
+  and the Deployment staying `Available`/`MinimumReplicasAvailable` the
+  entire time — neither surfaces single-replica-at-a-time disruption. Run
+  this check every pass, not only when something already looks unhealthy;
+  see the gotcha below for why aggregate health alone misses it.
 
 ## Triage
 
@@ -128,6 +142,53 @@
   Check `kubectl get vpa -n <namespace>` before treating this as drift or an
   issue. See `.claude/skills/right-sizing/SKILL.md` **VPA-managed workloads**
   for how these are configured and vetted.
+
+- **VPA + descheduler eviction churn on a multi-replica workload is
+  invisible at the Application/Deployment level.** A PDB
+  (`maxUnavailable: 1` or similar) correctly caps blast radius to one pod
+  at a time, but that same cap means the ArgoCD `Application` can stay
+  `Synced`/`Healthy` and the Deployment can stay
+  `Available`/`MinimumReplicasAvailable` continuously while a pod is
+  still being replaced every few minutes, indefinitely — neither field
+  reflects single-replica-at-a-time disruption. The only visible symptom
+  can be a per-pod readiness panel on an external dashboard (e.g.
+  Grafana) showing brief "not ready" blips, with nothing in
+  `kubectl get applications`/`kubectl get deploy` pointing at it.
+  Confirmed on `jung2bot` (2026-08-25): raising a VPA's `minAllowed`
+  memory floor to fix an OOMKill loop (see the `right-sizing` VPA section
+  below) roughly doubled the per-replica memory request, which increased
+  how often `sigs.k8s.io/descheduler`'s `HighNodeUtilization` strategy
+  evicted this workload's pods on already memory-tight nodes, compounding
+  with VPA's own `InPlaceOrRecreate` evictions
+  (`EvictedByVPA`/`InPlaceResizedByVPA` events) applying the same
+  recommendation repeatedly. Both are individually legitimate
+  (descheduler protecting node balance, VPA applying its own target) but
+  together produced near-continuous one-pod-at-a-time churn.
+  - **Detect:** the eviction/resize churn check above; also
+    `ResizeDeferred` events with a message like `Node didn't have enough
+    resource: memory, requested: X, used: Y, capacity: Z` mean the node's
+    *requested* (not actual) memory is saturated — cross-check
+    `kubectl describe node <name> | grep -A5 "Allocated resources"` to
+    confirm requests are near 100% while `kubectl top node` shows real
+    usage well below that (the same requests-vs-usage gap as
+    `documentation/gotcha.md`'s "Multi-Container Pods Fail to Schedule
+    Despite 'Enough' Free Cluster Memory", applied here to live resize
+    instead of initial scheduling).
+  - **Not itself a new incident if the workload's PDB is intact and pods
+    keep reaching `Ready` shortly after each replacement** — the
+    self-healing/right-sizing fix that raised the memory floor was still
+    the correct call (an OOMKill loop is worse than brief readiness
+    blips). Journal it as a known, accepted side effect rather than
+    re-chasing it as a fresh mystery, and only escalate if churn
+    frequency keeps climbing or a replacement pod stops reaching `Ready`
+    within a normal startup window.
+  - **Durable fix, if this recurs often enough to matter:** either free
+    real headroom on the affected nodes (the cluster's existing paired
+    descheduler `HighNodeUtilization` + kube-scheduler `MostAllocated`
+    tuning already aims at this) or lower `helm-charts/vpa`'s update
+    frequency/thresholds for this specific workload — do not lower the
+    VPA floor back down as the fix, that reopens the original OOMKill
+    loop.
 
 ## Known data-durability gotchas
 


### PR DESCRIPTION
## Why

Two things came up today that the skill didn't handle well:

1. I held PR #3156 (a narrow, log-verified capability fix for a
   hardening regression) for manual merge instead of auto-merging it.
2. A separate agent found jung2bot pods churning every few minutes
   (descheduler + VPA evictions) causing dashboard "not ready" blips
   that self-healing's checks never caught, because the Application
   and Deployment status stayed green throughout (PDB caps disruption
   to one pod at a time).

## Change

- `runbooks/merge-policy.md`: new "Scoped hardening-regression fix
  exception" — auto-merge a fix that restores only the specific
  capability a recent hardening commit broke, when confirmed via
  concrete log evidence and scoped narrowly.
- `runbooks/workloads.md`: a proactive events check for
  `EvictedByVPA`/`HighNodeUtilization`/`ResizeDeferred`, and a new
  gotcha explaining why this class of churn is invisible at the
  Application/Deployment level.
- `right-sizing/SKILL.md`: notes that a VPA `minAllowed` floor needs
  headroom above observed peaks (not just the failure point) to
  actually stop repeat OOMKills, and that raising it trades one
  problem for a smaller one (more frequent eviction churn).

## Test plan

- [x] `make test` (markdown/YAML/editorconfig clean; Helm validation
  blocked by the known unrelated `docker-credential-osxkeychain` gap)