### PR TITLE
fix(teslamate): exclude verify-pg-dump Job from descheduler eviction

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -97,12 +97,21 @@ descheduler:
               # labelSelector is an allow-list (only matching pods are
               # eligible for eviction under this profile), so excluding
               # blocky here is the correct mechanism.
+              # 2026-08-26: teslamate-verify-pg-dump added -- every attempt
+              # of this daily backup-verification Job was evicted mid-run
+              # by this profile's HighNodeUtilization on an over-committed
+              # node, exhausting backoffLimit (5/5 failed) even though the
+              # restore+verify logic itself completed successfully before
+              # eviction cut it off. Short-lived, bounded-duration batch
+              # Job -- excluding it here only defers node consolidation by
+              # the run's own duration, not indefinitely.
               labelSelector:
                 matchExpressions:
                   - key: app.kubernetes.io/name
                     operator: NotIn
                     values:
                       - blocky
+                      - teslamate-verify-pg-dump
           - name: HighNodeUtilization
             args:
               thresholds:

--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -11,6 +11,9 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
       backoffLimit: {{ .Values.backup.backoffLimit }}
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: teslamate-verify-pg-dump
         spec:
           shareProcessNamespace: true
           containers:


### PR DESCRIPTION
## Root cause

Dug into why \`teslamate-verify-pg-dump\` failed again after PR #3156
fixed the capability issue. All 5 pod attempts today were evicted by
the \`consolidate\` profile's \`HighNodeUtilization\` strategy
(\`kubectl get events\`: \`HighNodeUtilization ... pod eviction ... by
sigs.k8s.io/descheduler\` on every one). One attempt's full log
(recovered from Loki before pod GC) shows it actually completed its
real work successfully -- restore from S3, \`pg_dump verification
successful!\`, heartbeat POSTed and acknowledged -- before the
eviction cut it off, so the Job still counted it as a failure.

This is the same node-memory-pressure eviction pattern already
affecting other workloads today, and the same one blocky was excluded
from in \`documentation/gotcha.md\` ("descheduler.alpha.kubernetes.io/
evict: false Does Not Stop Eviction").

## Fix

- Labels the Job's pods (\`app.kubernetes.io/name:
  teslamate-verify-pg-dump\`), which had no labels at all before.
- Adds that label to the \`consolidate\` profile's \`DefaultEvictor\`
  \`labelSelector\` \`NotIn\` list alongside blocky, using the exact
  pattern already documented and verified to work.

Scoped to this one profile/strategy; other descheduler strategies
(\`PodLifeTime\`, restart-count checks) still apply normally, and this
only defers consolidation by the run's own bounded duration (this
Job typically finishes in single-digit minutes), not indefinitely.

## Test plan

- [x] \`helm lint\`/\`helm template\` for both affected charts
- [ ] Confirm tomorrow's 2026-08-27 12:00 UTC run completes without a
  \`HighNodeUtilization\` eviction