### PR TITLE
revert(longhorn): pin chart back to 1.12.0, 1.12.1 removed upstream

### DIFF
--- a/helm-charts/longhorn/Chart.lock
+++ b/helm-charts/longhorn/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: longhorn
   repository: https://charts.longhorn.io
-  version: 1.12.1
-digest: sha256:c6a6ac4349746ecae639553d1d69a401e1e0e89e79340b3c50e8428de773c5fc
-generated: "2026-08-21T06:13:19.978856866Z"
+  version: 1.12.0
+digest: sha256:c3261f9779b6ff974ac57c216633b5462d6bbe89d8803010ee47b86f9cb7eb81
+generated: "2026-08-26T13:50:41.116766+01:00"

--- a/helm-charts/longhorn/Chart.yaml
+++ b/helm-charts/longhorn/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.1
 icon: https://raw.githubusercontent.com/helm/helm/main/assets/images/helm.svg
 dependencies:
 - name: longhorn
-  version: 1.12.1
+  version: 1.12.0
   repository: https://charts.longhorn.io


### PR DESCRIPTION
## Problem

Every PR's \`make test\` was failing on \`Update Helm dependencies\`:

\`\`\`
Save error occurred: could not download
https://github.com/longhorn/charts/releases/download/longhorn-1.12.1/longhorn-1.12.1.tgz:
failed to fetch ... : 404 Not Found
\`\`\`

Confirmed live (not transient): the \`longhorn-1.12.1\` GitHub release
no longer exists upstream at all (missing from the repo's own releases
API listing).

## Fix

Reverts \`helm-charts/longhorn/Chart.yaml\`'s pinned dependency version
from \`1.12.1\` back to \`1.12.0\` -- the exact version pinned
immediately before the \`1.12.1\` bump (#3070) -- and regenerates
\`Chart.lock\`. This is a straight revert to the last known-good pin,
matching the incident-revert pattern already used for a similar
Renovate-bump breakage (PR #3034).

## Test plan

- [x] \`helm dependency update helm-charts/longhorn\` succeeds
- [x] \`helm lint helm-charts/longhorn\`
- [x] \`make test\` (markdown/YAML/editorconfig/terraform all pass;
  Helm validation still blocked only by the known unrelated
  \`docker-credential-osxkeychain\` OCI-fetch gap, unaffected by this
  change)