### PR TITLE
fix(monitoring): draw jung2bot scrape and replica panels as timeseries

### DIFF
--- a/helm-charts/monitoring/dashboards/jung2bot.yaml
+++ b/helm-charts/monitoring/dashboards/jung2bot.yaml
@@ -766,7 +766,7 @@ grafana:
                 ],
                 "title": "Metrics scrape",
                 "transparent": true,
-                "type": "stat"
+                "type": "timeseries"
               },
               {
                 "datasource": {
@@ -900,7 +900,7 @@ grafana:
                 ],
                 "title": "Replica count",
                 "transparent": true,
-                "type": "stat"
+                "type": "timeseries"
               },
               {
                 "collapsed": false,


### PR DESCRIPTION
## Summary

- set Metrics scrape and Replica count panel type to `timeseries`
- both panels already had timeseries options, range queries, and height 10
- Grafana was painting them as giant stats instead of a 0/1 scrape line and replica history

## Validation

- `python3 hack/validate-grafana-dashboards.py`
- `make test`