### PR TITLE
chore(teslamate): bump verify-pitr container CPU request per KRR

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -373,9 +373,13 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.labels['batch.kubernetes.io/job-name']
+              # KRR 2026-08-26: 14d peak ~208m CPU against a 50m request (OK,
+              # ~4x under). This container polls the CNPG cluster/psql in a
+              # tight loop during restore, so real usage is above the
+              # original guess. Memory unchanged (still GOOD at 128Mi).
               resources:
                 requests:
-                  cpu: 50m
+                  cpu: 200m
                   memory: 128Mi
                   ephemeral-storage: 128Mi
                 limits:


### PR DESCRIPTION
## Summary
- KRR right-sizing pass (2026-08-26): `teslamate-verify-pitr`'s `verify-pitr` container has a 14d CPU peak of ~208m against a 50m request (OK, ~4x under). Bumped the request to 200m.

Replaces #3167 -- that PR's `test`/`zizmor`/`claude-status` checks got stuck on a stale GitHub check-suite that a rebase didn't clear. Same content, fresh branch/commit.

## Test plan
- [x] `helm lint helm-charts/teslamate`
- [x] `make check-yaml lint-editorconfig check-markdown`