### PR TITLE
fix(jung2bot): scale on SQS depth and cap at 20 pods

### DIFF
--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -1,4 +1,16 @@
 apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ .Values.name }}-aws
+  namespace: {{ .Values.namespace }}
+spec:
+  # Use the workload IRSA role (sqs:* on the event queue). The KEDA
+  # operator has no AWS credentials of its own.
+  podIdentity:
+    provider: aws
+    identityOwner: workload
+---
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ .Values.name }}
@@ -30,3 +42,14 @@ spec:
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
         desiredReplicas: {{ .Values.app.autoscaling.max | quote }}
+    # Off-work fan-out dumps one SQS message per due chat. CPU/memory stay
+    # low, so scale on visible queue depth. Target 2 waiting messages per
+    # pod; in-flight messages are already being sent.
+    - type: aws-sqs-queue
+      authenticationRef:
+        name: {{ .Values.name }}-aws
+      metadata:
+        queueURL: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.eventQueueName | quote }}
+        queueLength: "2"
+        awsRegion: {{ .Values.app.env.awsRegion | quote }}
+        scaleOnInFlight: "false"

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -10,6 +10,7 @@ app:
     tag: jung2bot-6.1.3@sha256:2187187fe7ef160a9efb88b971aba12eeb3a0d1c1bd7b39cf19c58180ccd0c8b
   env:
     chatIdTable: jung2bot-dev-chatIds
+    eventQueueName: jung2bot-dev-event-queue
     logLevel: debug
     messageSaveQueueName: jung2bot-dev-message-save-queue.fifo
     messageTable: jung2bot-dev-messages

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -27,6 +27,7 @@ app:
     chatIdTable: jung2bot-prod-chatIds
     logLevel: info
     messageSaveQueueFlushSeconds: 10
+    eventQueueName: jung2bot-prod-event-queue
     messageSaveQueueName: jung2bot-prod-message-save-queue.fifo
     messageTable: jung2bot-prod-messages
     profile: default
@@ -34,7 +35,7 @@ app:
     stage: prod
   autoscaling:
     min: 3
-    max: 10
+    max: 20
 
 cron:
   offWork:

--- a/helm-charts/monitoring/dashboards/jung2bot.yaml
+++ b/helm-charts/monitoring/dashboards/jung2bot.yaml
@@ -2280,7 +2280,7 @@ grafana:
                 },
                 "gridPos": {
                   "h": 10,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 102
                 },
@@ -2400,8 +2400,8 @@ grafana:
                 },
                 "gridPos": {
                   "h": 10,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 8,
                   "y": 102
                 },
                 "id": 33,
@@ -2438,6 +2438,107 @@ grafana:
                   }
                 ],
                 "title": "Oldest message age",
+                "transparent": true,
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+                },
+                "description": "Enqueue to worker pickup, by action. offFromWork is the off-work report lag.",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        }
+                      ]
+                    },
+                    "unit": "s",
+                    "decimals": 3,
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "drawStyle": "line",
+                      "fillOpacity": 15,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "smooth",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "never",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 10,
+                  "w": 8,
+                  "x": 16,
+                  "y": 102
+                },
+                "id": 34,
+                "options": {
+                  "legend": {
+                    "calcs": [
+                      "mean",
+                      "max",
+                      "lastNotNull"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true,
+                    "sortBy": "Mean",
+                    "sortDesc": true
+                  },
+                  "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                  }
+                },
+                "pluginVersion": "11.2.1",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PBFA97CFB590B2093"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.95,sum by(le,action)(rate(telegram_jung2_bot_worker_queue_wait_duration_seconds_bucket{namespace=\"$ns\"}[$__rate_interval])))",
+                    "legendFormat": "{{action}}",
+                    "range": true,
+                    "refId": "A"
+                  }
+                ],
+                "title": "p95 queue wait",
                 "transparent": true,
                 "type": "timeseries"
               }
@@ -2500,6 +2601,6 @@ grafana:
             "timezone": "browser",
             "title": "jung2bot",
             "uid": "jung2bot",
-            "version": 9,
+            "version": 10,
             "weekStart": ""
           }


### PR DESCRIPTION
## Summary

- KEDA `aws-sqs-queue` trigger on the event queue, 2 visible messages per pod, using the workload IRSA role
- prod max replicas 3 to 20 (dev stays 1 to 4)
- keep the 17:55 to 18:15 Hong Kong cron pre-scale, now to 20
- Grafana p95 queue wait (`worker_queue_wait_duration_seconds`) next to oldest message age

## Validation

- `python3 hack/validate-grafana-dashboards.py`
- `helm template` of prod and dev ScaledObject
- `make test`