### PR TITLE
fix(jung2bot): drop broken KEDA SQS trigger to clear Degraded

### DIFF
--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -1,16 +1,4 @@
 apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: {{ .Values.name }}-aws
-  namespace: {{ .Values.namespace }}
-spec:
-  # Use the workload IRSA role (sqs:* on the event queue). The KEDA
-  # operator has no AWS credentials of its own.
-  podIdentity:
-    provider: aws
-    identityOwner: workload
----
-apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ .Values.name }}
@@ -42,14 +30,12 @@ spec:
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
         desiredReplicas: {{ .Values.app.autoscaling.max | quote }}
-    # Off-work fan-out dumps one SQS message per due chat. CPU/memory stay
-    # low, so scale on visible queue depth. Target 2 waiting messages per
-    # pod; in-flight messages are already being sent.
-    - type: aws-sqs-queue
-      authenticationRef:
-        name: {{ .Values.name }}-aws
-      metadata:
-        queueURL: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.eventQueueName | quote }}
-        queueLength: "2"
-        awsRegion: {{ .Values.app.env.awsRegion | quote }}
-        scaleOnInFlight: "false"
+    # 2026-08-27: removed the aws-sqs-queue trigger and its
+    # TriggerAuthentication (added in #3174). KEDA 2.20 no longer mints a
+    # per-workload token for identityOwner: workload, and with no roleArn
+    # on the TriggerAuthentication the operator falls back to its own
+    # (absent) credentials, so every SQS metric read failed with
+    # "no EC2 IMDS role found" and both jung2bot Applications went
+    # Degraded. Re-adding SQS scaling needs the operator itself to hold an
+    # AWS identity (roleArn on the TriggerAuthentication plus KEDA operator
+    # IRSA, or an IAM trust path). Tracked separately.


### PR DESCRIPTION
## What

Remove the `aws-sqs-queue` KEDA trigger and its `TriggerAuthentication` from the jung2bot chart, restoring the pre-#3174 `ScaledObject` (cpu / memory / cron triggers only).

## Why

The trigger added in #3174 never authenticated. In KEDA 2.20, `podIdentity` with `provider: aws` and `identityOwner: workload` but no `roleArn` leaves KEDA on the SDK default credential chain, which on this bare-metal cluster ends at a non-existent EC2 IMDS endpoint. Since #3174 synced:

- KEDA operator logged `no EC2 IMDS role found` / `dial tcp 169.254.169.254:80: i/o timeout` for both `jung2bot` and `jung2bot-dev` on every reconcile
- `keda-hpa-jung2bot` reported `FailedGetExternalMetric`
- the `jung2bot-dev` Application went `Degraded`

App pods and the cpu/memory/cron triggers were unaffected, so the only lost behaviour is backlog-driven scaling on SQS depth.

## Scope

Single file. Straight revert of the `scaled-object.yaml` hunk from #3174. The `values.yaml` `max: 20` bump and the dashboard panel from #3174 are left in place. `eventQueueName` in the values files is now unused but harmless and kept for the follow-up.

## Verification

- `helm template` / `helm lint` for both prod and dev value sets: renders only the `ScaledObject`, no `TriggerAuthentication`; charts lint clean
- Local `make test` passes except an unrelated local Docker credential-helper gap fetching the envoy-gateway OCI chart; CI covers full Helm validation

## Follow-up

Closes #3176 - re-adding SQS-depth scaling needs the KEDA operator to hold its own AWS identity (IAM work, escalated).