### PR TITLE
fix(keda): give the operator IRSA for SQS queue depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ the previous value was too low.
 
 ## Cluster Access
 
+KEDA SQS scalers use operator IRSA, not workload identity. See
+`documentation/gotcha.md`.
+
 Use the Kubernetes MCP tools for live cluster inspection whenever they are
 available. Prefer them for read-only diagnostics such as listing Pods, reading
 events, checking Argo CD Applications, inspecting resources, logs, and metrics

--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -165,6 +165,12 @@ local _grafanaDashboards = [
 ];
 
 local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };
+local kedaHelm = {
+  parameters: [{
+    name: 'keda.serviceAccount.operator.annotations.eks\\.amazonaws\\.com/role-arn',
+    value: 'arn:aws:iam::' + std.extVar('AWS_ACCOUNT_ID') + ':role/keda',
+  }],
+};
 local monitoringHelm = {
   parameters: [{ name: 'yace.irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }],
   valueFiles: _grafanaDashboards,
@@ -294,7 +300,7 @@ local monitoring = [
 local scheduling = [
   { wave: '02', name: 'descheduler', namespace: 'descheduler' },
   { wave: '02', name: 'k8s-cleaner', namespace: 'k8s-cleaner', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.scheduling['k8s-cleaner'] },
-  { wave: '02', name: 'keda', namespace: 'keda' },
+  { wave: '02', name: 'keda', namespace: 'keda', helm: kedaHelm },
   { wave: '02', name: 'reloader', namespace: 'reloader', syncOptions: ['RespectIgnoreDifferences=true'], ignoreDifferences: _ignoreDifferences.scheduling.reloader },
   { wave: '05', name: 'vpa', namespace: 'vpa' },  // after cert-manager (wave 02)
 ];

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -256,6 +256,21 @@ kubectl get apiservice v1beta1.external.metrics.k8s.io
 
 ---
 
+## KEDA SQS Scaler Needs Operator IRSA
+
+**Problem:** `identityOwner: workload` on this k3s cluster does not give
+KEDA AWS credentials. The operator hits EC2 IMDS, SQS metric reads fail,
+and the HPA goes Degraded.
+
+**Cause:** The scaler runs in the operator. KEDA 2.20 does not mint a
+workload SA token. There was no operator IRSA.
+
+**Solution:** Role `keda` (`infrastructure/cloud/aws/keda/iam-irsa`) with
+`sqs:GetQueueAttributes` on the event queues. Annotate `keda-operator`
+with that role. Apply Terraform before GitOps. Do not use workload IRSA.
+
+---
+
 ## Metrics Server API Fails Through Ambient
 
 Metrics Server exposes `metrics.k8s.io` through a Kubernetes aggregated APIService. The kube-apiserver calls

--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -1,16 +1,4 @@
 apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: {{ .Values.name }}-aws
-  namespace: {{ .Values.namespace }}
-spec:
-  # Use the workload IRSA role (sqs:* on the event queue). The KEDA
-  # operator has no AWS credentials of its own.
-  podIdentity:
-    provider: aws
-    identityOwner: workload
----
-apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ .Values.name }}
@@ -42,12 +30,8 @@ spec:
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
         desiredReplicas: {{ .Values.app.autoscaling.max | quote }}
-    # Off-work fan-out dumps one SQS message per due chat. CPU/memory stay
-    # low, so scale on visible queue depth. Target 2 waiting messages per
-    # pod; in-flight messages are already being sent.
+    # Visible queue depth. Auth is operator IRSA role/keda, not workload identity.
     - type: aws-sqs-queue
-      authenticationRef:
-        name: {{ .Values.name }}-aws
       metadata:
         queueURL: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.eventQueueName | quote }}
         queueLength: "2"

--- a/infrastructure/cloud/aws/keda/iam-irsa/.terraform.lock.hcl
+++ b/infrastructure/cloud/aws/keda/iam-irsa/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.62.0"
+  constraints = "~> 6.55"
+  hashes = [
+    "h1:5x/4mMlIqSyeMJQ8tD0A+FTNynpdHW8IA7F2zqrgpwU=",
+    "h1:Etlx1tUvlB7sqFWPciSn9Yz1g50ctM+dGlyVMpu720I=",
+    "h1:FBnaqFZDf3DdVb4SVpCPoT+TZQUSChNmmDViEGPV1rw=",
+    "h1:MRIBAtFWiQAyo4kpbBUtIvxlSmpQ9Eel0nLMYCb6MH4=",
+    "h1:MeMP80kzq1meAJQ0l+kU6KVW1S+4EhIRSy6q3L++LPU=",
+    "h1:N8W8KgcjlG1kb9mPapfieH/vYzyNrJBsb4RS0axwg5Y=",
+    "h1:OB5obEZKuaX4gQ7DYxYvAMaf4I6v2keeKOPfOpFMkgI=",
+    "h1:WnhkO4yQc0QvVgx/xJFI+UbM1y8BC8yvApoDUlhb5XY=",
+    "h1:fN9PvxrT2/rAiT86Hen0vicyMbKXAZG6VC/TEP9ZpD8=",
+    "h1:kRrdLje5ab/tmObt9lOKOi2KCyIB8B3xZCKhcfdS2K0=",
+    "h1:l5VASLhVAOCr2Q+7ywGqWb+JSEIJ5UjilOMBjFMdQ7U=",
+    "h1:mugvZRK3/kSysUmpt664tMNpOZtGbQd6nGKaM4p3kwo=",
+    "h1:nY4ct0BTUQ7se8gbnzXsPCN2tiP4mZsGnEw2juSpXNs=",
+    "h1:qRFHk1ksyfMj2KOrs9pEntzagM+Tzqm+qznJfxVrJj0=",
+    "h1:szVx4GPJr2hJt9t82VilK2Gu/N9WR/KbdeLZ9wb0Nek=",
+    "zh:072d542e40ca0b8c5e081c9f834e3e41aa2ad31c01219522f314685d5c482823",
+    "zh:0b2643473f5bb154d724e64e75632814d74acda5fd81b6488d0ed13f413152b2",
+    "zh:108b3e175886e45c4e955f1ef323aa849dfd82fc450108238be2ab7c0d1f0c2e",
+    "zh:3586ca03a5d07e40a67b01b7fdebc6f7636a42c2a2f6ab88635ffca8f6928dfe",
+    "zh:47bd626153ee94e6b45533c7c02f579dc6d586d6d9580e03a040643f647be50b",
+    "zh:49aafbe6f665b3c4c97522905fd09229f2758a782c7cfc508280607030134ef8",
+    "zh:6e3397227c3f8f3becc04f95ebcb977d7012f025c9921f9ef5e603fe6d5da665",
+    "zh:70f4478658a13eeb57725e3b424329494a0ffbd78ac2734effea4e60d802cfa2",
+    "zh:774d4357447f94a5d4981c7569f85cd140ac577974174c5e7b477d834c6bfb43",
+    "zh:7971ef7bc532ab0edb3ee739ac3010b46321ec8541f873956a20dabbd6a0f189",
+    "zh:8ec18fba906468a9e6ce15329aa098dfb45ab1b9dca446a8fc2079a0d6ef590c",
+    "zh:98328661edd4dfc4e4782fd03a7010854218d3fbf35435837ac33e7ee8aafe7e",
+    "zh:9cbbf5033116f72749ebd4cf9add6aadf7e9e4bc7704eec86a8f4c139c16c120",
+    "zh:9faf944474f9233ddbb3606bc495570d4b952fea21f09c28676f9847d619e50f",
+    "zh:d0636d6de8a7b0b0bcc2add80556ee7118981d738998d4772558b9de0df99af1",
+  ]
+}

--- a/infrastructure/cloud/aws/keda/iam-irsa/terragrunt.hcl
+++ b/infrastructure/cloud/aws/keda/iam-irsa/terragrunt.hcl
@@ -1,0 +1,29 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}//modules/aws-iam-irsa"
+}
+
+locals {
+  oidc_vars = read_terragrunt_config(find_in_parent_folders("oidc.hcl")).locals
+
+  name          = "keda"
+  oidc_provider = local.oidc_vars.oidc_provider
+}
+
+inputs = {
+  name            = local.name
+  oidc_provider   = local.oidc_provider
+  service_account = "system:serviceaccount:keda:keda-operator"
+  role_policies = {
+    sqs = {
+      actions = ["sqs:GetQueueAttributes"]
+      resources = [
+        "arn:aws:sqs:*:*:jung2bot-prod-event-queue",
+        "arn:aws:sqs:*:*:jung2bot-dev-event-queue",
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Terraform role `keda` with `sqs:GetQueueAttributes` on both event queues (already applied)
- annotate `keda-operator` with that role
- drop the broken `identityOwner: workload` TriggerAuthentication; the SQS scaler uses the operator identity

Supersedes #3177. Close that revert if this lands first.

## Validation

- `make test`
- `terragrunt apply` for `infrastructure/cloud/aws/keda/iam-irsa`