### PR TITLE
fix(keda): persist operator IRSA and SQS identityOwner

### DIFF
--- a/argocd/manifest.jsonnet
+++ b/argocd/manifest.jsonnet
@@ -166,10 +166,17 @@ local _grafanaDashboards = [
 
 local jung2botHelm = { parameters: [{ name: 'irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }] };
 local kedaHelm = {
-  parameters: [{
-    name: 'keda.serviceAccount.operator.annotations.eks\\.amazonaws\\.com/role-arn',
-    value: 'arn:aws:iam::' + std.extVar('AWS_ACCOUNT_ID') + ':role/keda',
-  }],
+  valuesObject: {
+    keda: {
+      serviceAccount: {
+        operator: {
+          annotations: {
+            'eks.amazonaws.com/role-arn': 'arn:aws:iam::' + std.extVar('AWS_ACCOUNT_ID') + ':role/keda',
+          },
+        },
+      },
+    },
+  },
 };
 local monitoringHelm = {
   parameters: [{ name: 'yace.irsa.awsAccountId', value: std.extVar('AWS_ACCOUNT_ID') }],

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -267,7 +267,8 @@ workload SA token. There was no operator IRSA.
 
 **Solution:** Role `keda` (`infrastructure/cloud/aws/keda/iam-irsa`) with
 `sqs:GetQueueAttributes` on the event queues. Annotate `keda-operator`
-with that role. Apply Terraform before GitOps. Do not use workload IRSA.
+with that role. Set trigger `identityOwner: operator`. Apply Terraform
+before GitOps. Do not use `identityOwner: workload`.
 
 ---
 

--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -30,10 +30,11 @@ spec:
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
         desiredReplicas: {{ .Values.app.autoscaling.max | quote }}
-    # Visible queue depth. Auth is operator IRSA role/keda, not workload identity.
+    # Visible queue depth. identityOwner operator uses keda-operator IRSA.
     - type: aws-sqs-queue
       metadata:
         queueURL: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.eventQueueName | quote }}
         queueLength: "2"
         awsRegion: {{ .Values.app.env.awsRegion | quote }}
         scaleOnInFlight: "false"
+        identityOwner: operator


### PR DESCRIPTION
## Summary

- set keda-operator `role-arn` via Helm `valuesObject` (the escaped helm parameter did not land on the ServiceAccount)
- SQS trigger `identityOwner: operator` so KEDA uses that IRSA instead of static keys

## Validation

- `make test`