### PR TITLE
fix(jung2bot): pin evening cron to 20 and raise SQS max to 40

### DIFF
--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -29,7 +29,7 @@ spec:
         timezone: "Asia/Hong_Kong"
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
-        desiredReplicas: {{ .Values.app.autoscaling.max | quote }}
+        desiredReplicas: {{ .Values.app.autoscaling.cron | quote }}
     # Visible queue depth. identityOwner operator uses keda-operator IRSA.
     - type: aws-sqs-queue
       metadata:

--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -20,4 +20,5 @@ app:
     stage: dev
   autoscaling:
     min: 1
+    cron: 2
     max: 4

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -35,7 +35,8 @@ app:
     stage: prod
   autoscaling:
     min: 3
-    max: 20
+    cron: 20
+    max: 40
 
 cron:
   offWork:


### PR DESCRIPTION
## Summary

- Split `app.autoscaling.cron` from `app.autoscaling.max`.
- Prod: cron 20 in the weekday 17:55 to 18:15 HKT window, SQS max 40.
- Dev: cron 2, max 4.

The evening window is the off-work fan-out that waited ~10 minutes at max 10. Cron 20 is the drain lever. SQS can raise to 40 after that window if the queue is still deep.

## Test plan

- [x] `make test`
- [ ] Argo `jung2bot` Synced/Healthy
- [ ] ScaledObject `maxReplicaCount=40`, cron `desiredReplicas=20`, Ready True
- [ ] HPA `maxReplicas=40`, SQS metric still numeric