### PR TITLE
fix(jung2bot): count SQS in-flight messages when scaling

### DIFF
--- a/helm-charts/jung2bot/templates/scaled-object.yaml
+++ b/helm-charts/jung2bot/templates/scaled-object.yaml
@@ -30,11 +30,12 @@ spec:
         start: "55 17 * * 1-5"  # Scale up at 5:55 PM, Monday to Friday, Hong Kong time
         end: "15 18 * * 1-5"    # Scale down at 6:15 PM, Monday to Friday, Hong Kong time
         desiredReplicas: {{ .Values.app.autoscaling.cron | quote }}
-    # Visible queue depth. identityOwner operator uses keda-operator IRSA.
+    # Count in-flight too. Off-work lag was hidden messages, not visible depth.
+    # identityOwner operator uses keda-operator IRSA.
     - type: aws-sqs-queue
       metadata:
         queueURL: {{ printf "https://sqs.%s.amazonaws.com/%v/%s" .Values.app.env.awsRegion .Values.irsa.awsAccountId .Values.app.env.eventQueueName | quote }}
         queueLength: "2"
         awsRegion: {{ .Values.app.env.awsRegion | quote }}
-        scaleOnInFlight: "false"
+        scaleOnInFlight: "true"
         identityOwner: operator


### PR DESCRIPTION
## Summary

- Set `scaleOnInFlight: true` on the jung2bot SQS trigger.
- Visible depth peaked at 17 (about 9 pods at `queueLength` 2). In-flight peaked at 44 during off-work.
- With in-flight counted, `(17+44)/2` is about 31 pods, capped at 40.

## Test plan

- [x] `make test`
- [ ] Argo `jung2bot` and `jung2bot-dev` Synced/Healthy
- [ ] ScaledObject `scaleOnInFlight: true`, Ready True
- [ ] HPA SQS metric still numeric (`0/2`, not FailedGetExternalMetric)