### PR TITLE
fix(teslamate): give verify-pg-dump the KILL capability

### DIFF
--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -24,18 +24,10 @@ spec:
                 capabilities:
                   drop:
                     - ALL
-                  # 2026-08-27: PR #3112 dropped ALL here too, which removed
-                  # KILL. This container runs as root but the sibling
-                  # postgres-sidecar's postmaster runs as the postgres user,
-                  # so the final `pkill -TERM postgres` (which stops the
-                  # sidecar so the pod can complete) needs KILL to signal a
-                  # process it does not own. Without it busybox pkill
-                  # silently no-ops, the sidecar keeps running, the pod
-                  # stays 1/2, the Job never completes, and
-                  # teslamate-verify-pg-dump shows Degraded until it is
-                  # manually cleared (first stuck run 2026-08-25 12:00 UTC,
-                  # once postgres:17-alpine's busybox stopped surfacing the
-                  # EPERM).
+                  # 2026-08-27: the final `pkill -TERM postgres` stops the
+                  # sidecar postmaster (postgres user) so the pod exits;
+                  # that needs KILL. #3112 dropped it with ALL, so the Job
+                  # hung at 1/2 and the app showed Degraded.
                   add:
                     - KILL
               command: ["/bin/sh", "-c"]

--- a/helm-charts/teslamate/templates/verify-pg-dump.yaml
+++ b/helm-charts/teslamate/templates/verify-pg-dump.yaml
@@ -24,6 +24,20 @@ spec:
                 capabilities:
                   drop:
                     - ALL
+                  # 2026-08-27: PR #3112 dropped ALL here too, which removed
+                  # KILL. This container runs as root but the sibling
+                  # postgres-sidecar's postmaster runs as the postgres user,
+                  # so the final `pkill -TERM postgres` (which stops the
+                  # sidecar so the pod can complete) needs KILL to signal a
+                  # process it does not own. Without it busybox pkill
+                  # silently no-ops, the sidecar keeps running, the pod
+                  # stays 1/2, the Job never completes, and
+                  # teslamate-verify-pg-dump shows Degraded until it is
+                  # manually cleared (first stuck run 2026-08-25 12:00 UTC,
+                  # once postgres:17-alpine's busybox stopped surfacing the
+                  # EPERM).
+                  add:
+                    - KILL
               command: ["/bin/sh", "-c"]
               args:
                 - |


### PR DESCRIPTION
## What

Add `KILL` to the `verify-pg-dump` container's capabilities (keeping `drop: [ALL]`).

## Why

`teslamate-verify-pg-dump` has shown `Degraded` since 2026-08-25 (last successful run 2026-08-24). Argo rolls the CronJob's failed state up to the whole `teslamate` Application.

Root cause: the job's `verify-pg-dump` container finishes with `pkill -TERM postgres` to stop the sibling `postgres-sidecar` so the pod can complete. That container runs as root; the sidecar postmaster runs as the `postgres` user. Signalling a process owned by another user needs `CAP_KILL`.

PR #3112 added `drop: [ALL]` to this container, removing `KILL`. Since a recent `postgres:17-alpine` refresh (busybox 1.37), busybox `pkill` no longer surfaces the resulting `EPERM` - it exits 0 while delivering nothing. So the sidecar keeps running, the pod stays `1/2 NotReady`, the Job never completes, and the CronJob (and app) stay `Degraded` until the stuck Job is cleared by hand.

## Verified live

- Manually triggered the job: the pg_dump download from object storage, restore into the sidecar, and `SELECT count(*) FROM positions` (1,152,365 rows) all pass. Only the pod exit hangs.
- In the running pod, `kill -TERM <postmaster-pid>` from a root shell returns `Operation not permitted`; `pkill` returns rc 0 regardless.
- `helm lint` / `helm template` clean. `require-drop-all-capabilities` only checks that `drop` contains `ALL`, which is unchanged, so no PolicyException is needed (the sidecar already carries its own `add` list under the same policy).

## Scope

Single container, one capability restored to its pre-#3112 state. No change to the script, the sidecar, secrets, or RBAC.