### PR TITLE
fix(teslamate): clamp verify-pitr target time into the recoverable window

### DIFF
--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -192,13 +192,20 @@ spec:
                   fi
 
                   VERIFY_RAW_TARGET_TIME="${VERIFY_TARGET_TIME}"
+                  # Clamp into the recoverable window: no later than the last
+                  # archived WAL, and no earlier than the backup we restore
+                  # from. The lower bound matters when the source DB is idle
+                  # (TeslaMate logs nothing while the car is away), so
+                  # max(data timestamp) predates every retained backup and
+                  # PITR would never reach the target.
                   VERIFY_TARGET_TIME=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
-                    psql -d postgres -Atq -c "SELECT LEAST(
-                      '${VERIFY_RAW_TARGET_TIME}'::timestamptz,
-                      '${VERIFY_ARCHIVER_LAST_ARCHIVED_TIME}'::timestamptz - interval '30 seconds'
-                    )")
+                    psql -d postgres -Atq -c "SELECT CASE WHEN lo > hi THEN NULL
+                        ELSE GREATEST(LEAST('${VERIFY_RAW_TARGET_TIME}'::timestamptz, hi), lo) END
+                      FROM (SELECT
+                        '${VERIFY_BACKUP_STOPPED_AT}'::timestamptz + interval '1 minute' AS lo,
+                        '${VERIFY_ARCHIVER_LAST_ARCHIVED_TIME}'::timestamptz - interval '30 seconds' AS hi) w")
                   if [ -z "${VERIFY_TARGET_TIME}" ]; then
-                    echo "Error: failed to derive a recoverable target time."
+                    echo "Error: no recoverable PITR window (backup stoppedAt ${VERIFY_BACKUP_STOPPED_AT} vs last archived ${VERIFY_ARCHIVER_LAST_ARCHIVED_TIME})."
                     exit 1
                   fi
                   if [ -n "${VERIFY_BACKUP_TIMELINE}" ] && [ -n "${VERIFY_CLUSTER_TIMELINE}" ] && [ "${VERIFY_BACKUP_TIMELINE}" != "${VERIFY_CLUSTER_TIMELINE}" ]; then


### PR DESCRIPTION
## Why

`teslamate-verify-pitr` has been failing (last real success predates the current retained backups). A manual run confirmed the CNPG recovery pod ends with `FATAL: recovery ended before configured recovery target was reached`.

Root cause: the script derives the PITR target from `max(timestamptz)` across every timestamp/date column, assuming the source DB is continuously written. TeslaMate has logged no new data since April 2026 (car away / token expired), so that timestamp is older than every retained base backup. Postgres replays all WAL, never reaches a target in the past, and aborts. The existing guard only capped the target on a timeline mismatch, which didn't apply here.

## Change

One clamp, replacing the previous `LEAST(target, last_archived - 30s)`:

- upper bound: last archived WAL time − 30s (unchanged)
- lower bound: backup `stoppedAt` + 1 minute (new)
- if the bounds cross, exit with a clear message instead of an unreachable target

Single `psql` call, no extra round trips. `helm lint` / `template` clean.

## Verify

Re-run the job manually after merge; expect it to restore, reach the target, pass `SELECT count(*) FROM positions`, and tear down its throwaway cluster.