### PR TITLE
fix(teslamate): make verify-pitr pass reliably (LSN target + descheduler exclusion)

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -105,6 +105,10 @@ descheduler:
               # eviction cut it off. Short-lived, bounded-duration batch
               # Job -- excluding it here only defers node consolidation by
               # the run's own duration, not indefinitely.
+              # 2026-08-27: teslamate-verify-pitr added for the same reason
+              # -- its scheduled 14:00 UTC run failed 5/5 the same way, the
+              # script pod evicted mid-restore while the CNPG recovery was
+              # still progressing.
               labelSelector:
                 matchExpressions:
                   - key: app.kubernetes.io/name
@@ -112,6 +116,7 @@ descheduler:
                     values:
                       - blocky
                       - teslamate-verify-pg-dump
+                      - teslamate-verify-pitr
           - name: HighNodeUtilization
             args:
               thresholds:

--- a/helm-charts/teslamate/templates/verify-pitr.yaml
+++ b/helm-charts/teslamate/templates/verify-pitr.yaml
@@ -74,6 +74,9 @@ spec:
       backoffLimit: {{ .Values.backup.backoffLimit }}
       activeDeadlineSeconds: {{ .Values.backup.verifyPitr.activeDeadlineSeconds }}
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: teslamate-verify-pitr
         spec:
           serviceAccountName: {{ .Values.name }}-verify-pitr
           containers:
@@ -140,41 +143,11 @@ spec:
                   VERIFY_BACKUP_STOPPED_AT=$(echo "${VERIFY_BACKUP_META}" | cut -d'|' -f1)
                   VERIFY_BACKUP_ID=$(echo "${VERIFY_BACKUP_META}" | cut -d'|' -f2)
                   VERIFY_BACKUP_TIMELINE=$(echo "${VERIFY_BACKUP_META}" | cut -d'|' -f4)
-                  VERIFY_TARGET_SCAN_COUNT=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- psql -d "${VERIFY_DATABASE}" -Atq <<'SQL'
-                  SELECT count(*)
-                  FROM information_schema.columns
-                  WHERE table_schema = 'public'
-                    AND data_type IN ('timestamp without time zone', 'timestamp with time zone', 'date');
-                  SQL
-                  )
-                  VERIFY_TARGET_TIME=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- psql -d "${VERIFY_DATABASE}" -Atq <<'SQL'
-                  WITH generated AS (
-                    SELECT 'SELECT max(max_value) FROM (' ||
-                      string_agg(
-                        format(
-                          'SELECT max(%I::timestamptz) AS max_value FROM %I.%I',
-                          column_name,
-                          table_schema,
-                          table_name
-                        ),
-                        ' UNION ALL '
-                      ) ||
-                      ') t'
-                      AS sql
-                    FROM information_schema.columns
-                    WHERE table_schema = 'public'
-                      AND data_type IN ('timestamp without time zone', 'timestamp with time zone', 'date')
-                  )
-                  SELECT sql FROM generated \gexec
-                  SQL
-                  )
-
-                  if [ -z "${VERIFY_SOURCE_PRIMARY}" ] || [ -z "${VERIFY_BACKUP_ID}" ] || [ -z "${VERIFY_TARGET_TIME}" ] || [ -z "${VERIFY_BACKUP_STOPPED_AT}" ]; then
+                  if [ -z "${VERIFY_SOURCE_PRIMARY}" ] || [ -z "${VERIFY_BACKUP_ID}" ] || [ -z "${VERIFY_BACKUP_STOPPED_AT}" ]; then
                     echo "Error: failed to derive PITR inputs."
                     echo "VERIFY_SOURCE_PRIMARY=${VERIFY_SOURCE_PRIMARY}"
                     echo "VERIFY_BACKUP_ID=${VERIFY_BACKUP_ID}"
                     echo "VERIFY_BACKUP_STOPPED_AT=${VERIFY_BACKUP_STOPPED_AT}"
-                    echo "VERIFY_TARGET_TIME=${VERIFY_TARGET_TIME}"
                     exit 1
                   fi
 
@@ -191,46 +164,24 @@ spec:
                     fi
                   fi
 
-                  VERIFY_RAW_TARGET_TIME="${VERIFY_TARGET_TIME}"
-                  # Clamp into the recoverable window: no later than the last
-                  # archived WAL, and no earlier than the backup we restore
-                  # from. The lower bound matters when the source DB is idle
-                  # (TeslaMate logs nothing while the car is away), so
-                  # max(data timestamp) predates every retained backup and
-                  # PITR would never reach the target.
-                  VERIFY_TARGET_TIME=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
-                    psql -d postgres -Atq -c "SELECT CASE WHEN lo > hi THEN NULL
-                        ELSE GREATEST(LEAST('${VERIFY_RAW_TARGET_TIME}'::timestamptz, hi), lo) END
-                      FROM (SELECT
-                        '${VERIFY_BACKUP_STOPPED_AT}'::timestamptz + interval '1 minute' AS lo,
-                        '${VERIFY_ARCHIVER_LAST_ARCHIVED_TIME}'::timestamptz - interval '30 seconds' AS hi) w")
-                  if [ -z "${VERIFY_TARGET_TIME}" ]; then
-                    echo "Error: no recoverable PITR window (backup stoppedAt ${VERIFY_BACKUP_STOPPED_AT} vs last archived ${VERIFY_ARCHIVER_LAST_ARCHIVED_TIME})."
-                    exit 1
-                  fi
-                  if [ -n "${VERIFY_BACKUP_TIMELINE}" ] && [ -n "${VERIFY_CLUSTER_TIMELINE}" ] && [ "${VERIFY_BACKUP_TIMELINE}" != "${VERIFY_CLUSTER_TIMELINE}" ]; then
-                    VERIFY_TARGET_TIME=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
-                      psql -d postgres -Atq -c "SELECT LEAST(
-                        '${VERIFY_TARGET_TIME}'::timestamptz,
-                        '${VERIFY_BACKUP_STOPPED_AT}'::timestamptz
-                      )")
-                    echo "Backup timeline ${VERIFY_BACKUP_TIMELINE} differs from cluster timeline ${VERIFY_CLUSTER_TIMELINE}; capping targetTime to backup stoppedAt."
-                  fi
-                  if [ "${VERIFY_TARGET_TIME}" != "${VERIFY_RAW_TARGET_TIME}" ]; then
-                    echo "Capped targetTime from ${VERIFY_RAW_TARGET_TIME} to recoverable ${VERIFY_TARGET_TIME}"
-                  fi
-
-                  kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
-                    psql -d postgres -Atq -c "SELECT pg_logical_emit_message(false, 'teslamate_verify_pitr', 'archive target WAL')" >/dev/null
-
+                  # Recover to a WAL LSN, not a wall-clock time. TeslaMate's
+                  # source DB is often idle (nothing logged while the car is
+                  # away), and recovery_target_time matches transaction commit
+                  # timestamps -- with no commits after the base backup a time
+                  # target is never reached and Postgres aborts with "recovery
+                  # ended before configured recovery target was reached". An
+                  # LSN always advances: the logical message below writes a
+                  # real WAL record past the backup and returns its LSN.
+                  VERIFY_TARGET_LSN=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
+                    psql -d postgres -Atq -c "SELECT pg_logical_emit_message(false, 'teslamate_verify_pitr', 'recovery target marker')")
                   VERIFY_TARGET_WAL=$(kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
-                    psql -d postgres -Atq -c "SELECT pg_walfile_name(pg_current_wal_lsn())")
-                  if [ -z "${VERIFY_TARGET_WAL}" ]; then
-                    echo "Error: failed to determine current WAL file."
+                    psql -d postgres -Atq -c "SELECT pg_walfile_name('${VERIFY_TARGET_LSN}'::pg_lsn)")
+                  if [ -z "${VERIFY_TARGET_LSN}" ] || [ -z "${VERIFY_TARGET_WAL}" ]; then
+                    echo "Error: failed to emit or locate the recovery target LSN."
                     exit 1
                   fi
 
-                  echo "Forcing WAL switch so targetTime is archived in ${VERIFY_TARGET_WAL}"
+                  echo "Forcing WAL switch so target LSN ${VERIFY_TARGET_LSN} is archived in ${VERIFY_TARGET_WAL}"
                   kubectl exec -i -n "${VERIFY_NAMESPACE}" "${VERIFY_SOURCE_PRIMARY}" -- \
                     psql -d postgres -Atq -c "SELECT pg_switch_wal()" >/dev/null
 
@@ -256,8 +207,7 @@ spec:
                   echo "Using source primary ${VERIFY_SOURCE_PRIMARY}"
                   echo "Using backupID ${VERIFY_BACKUP_ID} (timeline ${VERIFY_BACKUP_TIMELINE:-unknown}, stoppedAt ${VERIFY_BACKUP_STOPPED_AT})"
                   echo "Using cluster timeline ${VERIFY_CLUSTER_TIMELINE:-unknown}"
-                  echo "Scanned ${VERIFY_TARGET_SCAN_COUNT} timestamp-like columns in public"
-                  echo "Using targetTime ${VERIFY_TARGET_TIME}"
+                  echo "Using targetLSN ${VERIFY_TARGET_LSN}"
 
                   cat <<EOF | kubectl apply -f -
                   apiVersion: postgresql.cnpg.io/v1
@@ -316,7 +266,7 @@ spec:
                         owner: ${VERIFY_OWNER}
                         recoveryTarget:
                           backupID: "${VERIFY_BACKUP_ID}"
-                          targetTime: "${VERIFY_TARGET_TIME}"
+                          targetLSN: "${VERIFY_TARGET_LSN}"
                     externalClusters:
                       - name: verify-pitr-source
                         plugin:


### PR DESCRIPTION
The scheduled 14:00 UTC `teslamate-verify-pitr` run failed 5/5 (BackoffLimitExceeded), leaving the `teslamate` Application `Degraded`. Two independent bugs:

## 1. Time-based recovery target is unreachable on an idle DB

`recovery_target_time` matches transaction *commit* timestamps. TeslaMate has logged no new data since April (car away), so no commit lands after the base backup and the target is never reached: `FATAL: recovery ended before configured recovery target was reached` (confirmed in a recovery-pod log). An earlier manual run only passed because a background `oban` heartbeat happened to commit inside the target minute.

Fix: recover to a **WAL LSN**. The logical message the script already emits writes a real WAL record past the backup and returns its LSN; an LSN target always advances (the forced WAL switch moves it) and is reachable on an idle DB. Removes the now-unused `max(timestamp)` derivation and the clamp added in an earlier change.

## 2. Descheduler evicts the Job pod mid-restore

Exactly what #3161 fixed for `verify-pg-dump`: the consolidate profile's `HighNodeUtilization` evicts the verify-pitr script pod while the CNPG recovery is still running. The `sleep` in the wait loop takes the SIGTERM, `set -e` fires, and the trap tears down the in-flight recovery cluster. Every retry hits the same thing.

Fix: label the Job's pods and add `teslamate-verify-pitr` to the descheduler `labelSelector` exclusion, same pattern as `verify-pg-dump`.

## Verification

`helm lint` / `template` clean. After merge + sync I will run the CronJob manually and confirm it reaches `PITR verification successful!` and tears its throwaway cluster down.