### PR TITLE
deploy(jung2bot): update to 6.1.4

### DIFF
--- a/helm-charts/jung2bot/value/dev.yaml
+++ b/helm-charts/jung2bot/value/dev.yaml
@@ -7,7 +7,7 @@ secret:
 app:
   # Pinned here so dev and prod can diverge if needed; rollback is one line.
   image:
-    tag: jung2bot-6.1.3@sha256:2187187fe7ef160a9efb88b971aba12eeb3a0d1c1bd7b39cf19c58180ccd0c8b
+    tag: jung2bot-6.1.4@sha256:1db2e606671e5df5fddcf5df771080d11b99e47b6dc5f603c009efdd2ab75884
   env:
     chatIdTable: jung2bot-dev-chatIds
     eventQueueName: jung2bot-dev-event-queue

--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -21,7 +21,7 @@ irsa:
 app:
   image:
     repository: ghcr.io/siutsin/telegram-jung2-bot
-    tag: jung2bot-6.1.3@sha256:2187187fe7ef160a9efb88b971aba12eeb3a0d1c1bd7b39cf19c58180ccd0c8b
+    tag: jung2bot-6.1.4@sha256:1db2e606671e5df5fddcf5df771080d11b99e47b6dc5f603c009efdd2ab75884
   env:
     awsRegion: eu-west-1
     chatIdTable: jung2bot-prod-chatIds


### PR DESCRIPTION
## Summary

- Pin prod and dev `jung2bot` to `jung2bot-6.1.4` by digest.
- Image includes [telegram-jung2-bot#3143](https://github.com/siutsin/telegram-jung2-bot/pull/3143): drop SQS messages after five failed receives.

## Test plan

- [x] `make test`
- [ ] Argo `jung2bot` and `jung2bot-dev` Synced/Healthy
- [ ] Pods running `jung2bot-6.1.4`