### PR TITLE
fix(teslamate): bump garbage-collected main image digest (6th occurrence)

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -38,7 +38,12 @@ deployment:
     # upstream in turn -- fifth occurrence of this recurring failure mode
     # (ImagePullBackOff, confirmed NotFound against the registry).
     # Bumped to the current main digest again.
-    tag: main@sha256:3751c1ebb9023618bf2869b176b6ff25cc03e97c90b12afc67e3d067c0adc283
+    # 2026-09-03: previous main@3751c1eb digest was garbage-collected
+    # upstream in turn -- sixth occurrence. teslamate Deployment could not
+    # roll a restart (new pod ImagePullBackOff, NotFound against ghcr.io);
+    # old pod kept serving so no outage, but the Application went Degraded.
+    # Bumped to the current multi-arch main digest (linux/amd64 + arm64).
+    tag: main@sha256:50dea666c3a360318c005e458077f6321f67aec87ec06b943746a9f3071351c8
   envFrom:
     - secretRef:
         name: teslamate


### PR DESCRIPTION
## What

Bump the teslamate `main` image pin from the garbage-collected
`sha256:3751c1eb…` to the current multi-arch digest
`sha256:50dea666…` (linux/amd64 + linux/arm64, verified against ghcr.io).

## Why

The pinned digest was garbage-collected upstream at `ghcr.io`. A rollout
restart at 2026-09-03 13:40Z left the new pod in `ImagePullBackOff`
(`NotFound` against the registry). The previous pod kept serving so there
was no user-facing outage, but the teslamate Argo Application went
`Degraded` and the Deployment could not complete the roll.

Sixth recurrence of the floating-tag-digest GC failure mode for this
image. Moving to a stable release tag remains blocked on upstream
publishing a 4.x point release (see the standing comment in `values.yaml`).

## Verification

- `helm template helm-charts/teslamate` renders the new digest cleanly.
- New digest confirmed present and multi-arch at `ghcr.io`.
- Post-merge: teslamate Application returns to Synced/Healthy, new pod
  pulls and passes probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)