### PR TITLE
fix(descheduler): exclude CNPG instance pods from consolidation eviction

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -109,6 +109,18 @@ descheduler:
               # -- its scheduled 14:00 UTC run failed 5/5 the same way, the
               # script pod evicted mid-restore while the CNPG recovery was
               # still progressing.
+              # 2026-09-06: cnpg.io/podRole=instance excluded -- the umami
+              # CloudNativePG replica hit the same disruptive no-op loop on
+              # raspberrypi-00 (evicted every ~5 minutes 19:05-20:15 UTC,
+              # rescheduled straight back, thrashing its Longhorn volume
+              # detach/attach each cycle). Required pod anti-affinity plus a
+              # near-uniform per-node memory picture leaves the evicted
+              # instance nowhere better to go. Excludes all CNPG database
+              # instance pods (teslamate, umami, hydra); they are stateful
+              # with attached volumes, so consolidation churn costs more
+              # than the packing it buys.
+              # matchExpressions are ANDed: a pod must satisfy every entry
+              # to be eligible for eviction under this profile.
               labelSelector:
                 matchExpressions:
                   - key: app.kubernetes.io/name
@@ -117,6 +129,10 @@ descheduler:
                       - blocky
                       - teslamate-verify-pg-dump
                       - teslamate-verify-pitr
+                  - key: cnpg.io/podRole
+                    operator: NotIn
+                    values:
+                      - instance
           - name: HighNodeUtilization
             args:
               thresholds:


### PR DESCRIPTION
## Problem

The umami CloudNativePG replica `umami-20260614-0001-3` hit the same disruptive no-op eviction loop previously seen with `blocky`:

- The `consolidate` profile's `HighNodeUtilization` evicted it from `raspberrypi-00` every ~5 minutes (19:05–20:15 UTC on 2026-09-06).
- The scheduler put it straight back because required pod anti-affinity plus a near-uniform per-node memory picture left nowhere better to go.
- Each cycle thrashed its Longhorn volume with a detach/attach, once producing a transient `Multi-Attach` error.

The CNPG cluster stayed Healthy throughout and the loop eventually self-settled when an unrelated rollout shifted node memory, but the churn will recur under the same conditions.

## Change

Add a second `matchExpression` to the `consolidate` `DefaultEvictor` `labelSelector` (`helm-charts/descheduler/values.yaml`) so pods labelled `cnpg.io/podRole=instance` are not eligible for eviction under that profile.

`matchExpressions` are ANDed, so this exempts every CNPG database instance pod (teslamate, umami, hydra) while leaving all other consolidation behaviour unchanged. These pods are stateful with attached volumes, so consolidation churn costs more than the packing it buys — the same rationale already applied to `blocky` and the teslamate verify jobs in this file.

## Verification

- `helm template helm-charts/descheduler` renders the two-expression selector.
- `helm lint helm-charts/descheduler` clean.
- EditorConfig + YAML checks pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)