### PR TITLE
fix(jung2bot): cut SQS event visibility to 15s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ the previous value was too low.
 KEDA SQS scalers use operator IRSA, not workload identity. See
 `documentation/gotcha.md`.
 
+Jung2bot event-queue visibility is 15s (HTTP timeout 10s). FIFO save
+visibility is 30s (flush 10s). See `documentation/gotcha.md`.
+
 Use the Kubernetes MCP tools for live cluster inspection whenever they are
 available. Prefer them for read-only diagnostics such as listing Pods, reading
 events, checking Argo CD Applications, inspecting resources, logs, and metrics

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -272,6 +272,23 @@ before GitOps. Do not use `identityOwner: workload`.
 
 ---
 
+## SQS Visibility Must Beat HTTP Timeout And FIFO Flush
+
+**Problem:** Event-queue retries showed as ~10 min `offFromWork` wait. The
+queue was not a 10 min backlog.
+
+**Cause:** `visibility_timeout_seconds` was 600. Queue wait is enqueue to
+the next pickup. A failed or interrupted receive comes back after that
+timeout. The bot HTTP client times out at 10 s. The FIFO save worker
+flushes every 10 s.
+
+**Solution:** Event queues default to 15 s (above the 10 s HTTP timeout,
+so a hang does not double-send). FIFO save queues stay at 30 s so a
+message cannot become visible mid-flush. Do not set event visibility at
+or below 10 s.
+
+---
+
 ## Metrics Server API Fails Through Ambient
 
 Metrics Server exposes `metrics.k8s.io` through a Kubernetes aggregated APIService. The kube-apiserver calls

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -274,18 +274,34 @@ before GitOps. Do not use `identityOwner: workload`.
 
 ## SQS Visibility Must Beat HTTP Timeout And FIFO Flush
 
-**Problem:** Event-queue retries showed as ~10 min `offFromWork` wait. The
-queue was not a 10 min backlog.
+**Problem:** Grafana showed ~10 min `offFromWork` queue wait after the
+evening fan-out, even with 20 pods and almost no visible SQS backlog.
+That looked like another drain failure. It was not.
 
-**Cause:** `visibility_timeout_seconds` was 600. Queue wait is enqueue to
-the next pickup. A failed or interrupted receive comes back after that
-timeout. The bot HTTP client times out at 10 s. The FIFO save worker
-flushes every 10 s.
+**Why it happens:** queue wait is enqueue time to the next pickup.
+`visibility_timeout_seconds` was 600 on every jung2bot queue, set in
+January 2024 with no workload reason. A failed or interrupted receive
+therefore came back after 10 minutes, and the histogram landed in the
+600 s bucket. The bot HTTP client times out at 10 s, so a hung Telegram
+send can last that long. The FIFO save worker flushes every 10 s, so a
+message that becomes visible mid-flush can be saved twice.
 
-**Solution:** Event queues default to 15 s (above the 10 s HTTP timeout,
-so a hang does not double-send). FIFO save queues stay at 30 s so a
-message cannot become visible mid-flush. Do not set event visibility at
-or below 10 s.
+### Symptoms: Long Wait With An Empty Visible Queue
+
+- `offFromWork` p95 wait hits 600 s in a short window while SQS visible
+  depth is 0 to 2 and in-flight is often 1.
+- Long waits cluster about 10 minutes after the first receive (for
+  example 18:11 HKT after an 18:01 pickup), or after cron scale-down
+  at 18:15 HKT.
+- `worker_actions_total{outcome="dropped"}` stays 0: the retry succeeds.
+
+### Resolution: 15 s Event, 30 s FIFO
+
+Event queues default to 15 s in `infrastructure/modules/aws-sqs`. That
+is above the 10 s HTTP timeout, so a hang does not double-send. FIFO
+save queues set `visibility_timeout_seconds = 30` so the 10 s flush can
+finish. Do not set event visibility at or below 10 s. Apply the SQS
+Terragrunt stacks after merge; this is AWS queue config, not Argo.
 
 ---
 

--- a/infrastructure/cloud/aws/jung2bot-dev/sqs/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot-dev/sqs/terragrunt.hcl
@@ -14,6 +14,8 @@ inputs = {
     message_save = {
       name = "jung2bot-dev-message-save-queue.fifo"
       fifo = true
+      # Flush interval is 10s. Visibility must last the whole batch.
+      visibility_timeout_seconds = 30
     }
   }
 }

--- a/infrastructure/cloud/aws/jung2bot/sqs/terragrunt.hcl
+++ b/infrastructure/cloud/aws/jung2bot/sqs/terragrunt.hcl
@@ -14,6 +14,8 @@ inputs = {
     message_save = {
       name = "jung2bot-prod-message-save-queue.fifo"
       fifo = true
+      # Flush interval is 10s. Visibility must last the whole batch.
+      visibility_timeout_seconds = 30
     }
   }
 }

--- a/infrastructure/modules/aws-sqs/00-vars.tf
+++ b/infrastructure/modules/aws-sqs/00-vars.tf
@@ -1,6 +1,7 @@
 variable "sqss" {
   type = map(object({
-    name = string
-    fifo = optional(bool, false)
+    name                       = string
+    fifo                       = optional(bool, false)
+    visibility_timeout_seconds = optional(number)
   }))
 }

--- a/infrastructure/modules/aws-sqs/01-main.tf
+++ b/infrastructure/modules/aws-sqs/01-main.tf
@@ -8,7 +8,8 @@ module "sqs" {
 
   name                              = each.value.name
   fifo_queue                        = each.value.fifo
-  visibility_timeout_seconds        = 600
+  # Event work is a few seconds. HTTP client timeout is 10s, so 15s is the floor.
+  visibility_timeout_seconds        = coalesce(each.value.visibility_timeout_seconds, 15)
   kms_master_key_id                 = "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = 86400
 }


### PR DESCRIPTION
## Summary

- Event queue visibility 600s to 15s. Failed receives were showing as a 10 minute wait.
- 15s is above the bot HTTP timeout of 10s, so a hung send does not double-deliver.
- FIFO save queue stays at 30s so the 10s flush cannot become visible mid-batch.
- `AGENTS.md` holds the numbers. `documentation/gotcha.md` holds the 10 minute wait explanation.

## Test plan

- [x] Markdown, Terraform, Terragrunt, EditorConfig lint
- [ ] `terragrunt apply` prod and dev SQS
- [ ] Live `VisibilityTimeout` 15 on event queues, 30 on FIFO