### PR TITLE
test(jung2bot): pin evening cron to 10 so SQS can scale

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -35,7 +35,7 @@ app:
     stage: prod
   autoscaling:
     min: 3
-    cron: 20
+    cron: 10
     max: 40
 
 cron:


### PR DESCRIPTION
## Summary

- Prod cron `desiredReplicas` 20 to 10.
- Max stays 40. SQS `scaleOnInFlight` can raise above 10 during the 17:55 to 18:15 HKT window.

This is a one-night test of queue scaling. Cron 20 already drained the fan-out before SQS had work.

## Test plan

- [x] `helm lint` / template: min 3, cron 10, max 40, `scaleOnInFlight: true`
- [ ] Argo `jung2bot` Synced
- [ ] ScaledObject cron `desiredReplicas=10`
- [ ] Tonight 17:55 HKT: start at 10, SQS raises if in-flight is deep