### PR TITLE
fix(make): skip Helm repo refresh per chart during validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,12 @@ generate-diagrams: poetry-install format-python ## Generate architecture diagram
 .PHONY: validate-helm-charts
 validate-helm-charts: ## Validate all Helm charts
 	@echo "$(GREEN)Validating Helm charts...$(NC)"
+	@# Helm 4.2.4 can fail with "could not find : no matching version" when every
+	@# chart refreshes every duplicate repo. Update once, then skip-refresh.
+	@helm repo update
 	@for chart in helm-charts/*/; do \
 		if [ -f "$$chart/Chart.yaml" ]; then \
-			helm dependency build "$$chart" > /dev/null || exit 1; \
+			helm dependency build "$$chart" --skip-refresh > /dev/null || exit 1; \
 			helm dependency list "$$chart" | awk ' \
 				NR > 1 && NF > 0 && $$4 !~ /^(ok|unpacked)$$/ { \
 					print "Helm dependency not current in " chart ": " $$0; \

--- a/documentation/gotcha.md
+++ b/documentation/gotcha.md
@@ -44,6 +44,24 @@ kubectl -n kube-system get secret raspberrypi-03.node-password.k3s
 
 ---
 
+## Helm 4 Dependency Build Fails With Empty Chart Name
+
+**Problem:** Local `make test` dies in `validate-helm-charts` with
+`could not find : no matching version` on `istio-base`, even though
+`helm search` shows `base` 1.30.4 and CI is green.
+
+**Why it happens:** Helm 4.2.4 refreshes every configured repo on each
+`helm dependency build`. This machine has the same Istio URL under several
+repo names. That refresh is flaky and sometimes resolves an empty chart
+name. CI runs `make update-helm-deps` first, so it often misses the race.
+
+**Solution:** `validate-helm-charts` runs `helm repo update` once, then
+`helm dependency build --skip-refresh` per chart. Do not remove
+`--skip-refresh`. Duplicate `helm repo add` entries for the same URL
+make the flake more likely.
+
+---
+
 ## Atlantis Is Unsafe for This Public Repo
 
 Atlantis is not a safe fit for this repository while it remains public.


### PR DESCRIPTION
## Summary

- Local `make test` failed on `istio-base` with `could not find : no matching version`.
- Helm 4.2.4 refreshes every repo on each `helm dependency build`. Duplicate Istio repo names make that lookup flake.
- `validate-helm-charts` now runs `helm repo update` once, then `helm dependency build --skip-refresh`.

## Test plan

- [x] Local `make test` green
- [ ] CI `test` job green