### PR TITLE
fix(monitoring): raise Loki memory limit to 1Gi (wedged at 608Mi)

### DIFF
--- a/helm-charts/monitoring/values.yaml
+++ b/helm-charts/monitoring/values.yaml
@@ -592,12 +592,16 @@ loki:
       istio.io/dataplane-mode: none
     resources:
       # KRR 2026-07-05: live peak ~583Mi working set; 512Mi request (#2567) left ~70Mi headroom.
+      # 2026-09-07: Loki wedged for ~7h at 606/608Mi (99.7%). Not OOMKilled --
+      # the Go runtime GC held it just under the limit, starving CPU: /ready
+      # probe timed out x75, pushes took 1m+ and 500'd, in-process gRPC
+      # connections dropped. App went Degraded. Raised to 1Gi for real headroom.
       requests:
         cpu: 100m
-        memory: 608Mi
+        memory: 1Gi
         ephemeral-storage: 128Mi
       limits:
-        memory: 608Mi
+        memory: 1Gi
         ephemeral-storage: 128Mi
   minio:
     enabled: false


### PR DESCRIPTION
## Problem

`monitoring-loki-0` sat wedged for ~7h at 606/608Mi (99.7% of its memory limit). It was **not** OOMKilled — the Go runtime GC held it just under the limit, which starved CPU:

- `/ready` readiness probe timed out (`x75 over 7h`)
- `POST /loki/api/v1/push` took 1m+ and returned 500 (`context deadline exceeded`)
- in-process gRPC connections to its own ingester/scheduler dropped (`use of closed network connection`)

The `monitoring` Argo Application went `Degraded` (Loki `1/2` ready). Node `raspberrypi-02` shows no memory/disk pressure, so this is Loki's own limit, not the host.

## Change

Raise the `loki.singleBinary` request/limit from `608Mi` to `1Gi`. The StatefulSet `RollingUpdate` recreates `loki-0` with the new limit on sync, which also clears the wedge.

## Verification

- `helm template` renders `loki` container at `1Gi` request+limit.
- `helm lint helm-charts/monitoring` clean; `validate-grafana-dashboards.py` passes (307 targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)