### PR TITLE
fix(descheduler): exclude openclaw from consolidation eviction

### DIFF
--- a/helm-charts/descheduler/values.yaml
+++ b/helm-charts/descheduler/values.yaml
@@ -119,6 +119,13 @@ descheduler:
               # instance pods (teslamate, umami, hydra); they are stateful
               # with attached volumes, so consolidation churn costs more
               # than the packing it buys.
+              # 2026-09-08: openclaw excluded -- same loop again. This
+              # single-replica Deployment with a Longhorn RWO volume was
+              # evicted from nuc-00/raspberrypi-00 every ~5 minutes for 40+
+              # minutes, each new pod stuck in Init on Multi-Attach /
+              # DeadlineExceeded while the volume was still detaching, then
+              # evicted again before it ever went Ready -- volume left
+              # state=attaching robustness=unknown, app down the whole time.
               # matchExpressions are ANDed: a pod must satisfy every entry
               # to be eligible for eviction under this profile.
               labelSelector:
@@ -127,6 +134,7 @@ descheduler:
                     operator: NotIn
                     values:
                       - blocky
+                      - openclaw
                       - teslamate-verify-pg-dump
                       - teslamate-verify-pitr
                   - key: cnpg.io/podRole


### PR DESCRIPTION
## Problem

`openclaw` (single-replica Deployment, Longhorn RWO volume) has been evicted by the `consolidate` profile's `HighNodeUtilization` every ~5 minutes for 40+ minutes. Each replacement pod is stuck in `Init:0/1` on `Multi-Attach` / `DeadlineExceeded` while the volume is still detaching from the previous node, then gets evicted again before it ever goes Ready. The Longhorn volume `openclaw-vol` ended up `state=attaching robustness=unknown` and the app is down.

Same failure mode and fix as `blocky` (2026-07-20) and the CNPG pods (PR #3214, 2026-09-06).

## Change

Add `openclaw` to the `consolidate` `DefaultEvictor` `labelSelector` `NotIn` list on `app.kubernetes.io/name`.

## Verification

- `helm template` shows the four-value `NotIn` list.
- `helm lint helm-charts/descheduler` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)