### PR TITLE
fix(teslamate): bump garbage-collected main image digest (8th occurrence)

### DIFF
--- a/helm-charts/teslamate/values.yaml
+++ b/helm-charts/teslamate/values.yaml
@@ -35,10 +35,11 @@ deployment:
     # a rollout restart the new pod then hits ImagePullBackOff while the old
     # pod keeps serving, so no outage but the Application goes Degraded.
     # Occurrences with a digest bump each time: 2026-08-05, 2026-08-12,
-    # 2026-08-21, 2026-09-03, 2026-09-06 (7th; digest 50dea666 gone).
+    # 2026-08-21, 2026-09-03, 2026-09-06, 2026-09-10 (8th; digest
+    # 4682b927 gone).
     repository: ghcr.io/teslamate-org/teslamate
     # Multi-arch main digest (linux/amd64 + arm64).
-    tag: main@sha256:4682b92780d3a83f0cef0db5f9378f430fee1acf4ad079e75c4bd81f896f5c8e
+    tag: main@sha256:0d32891a6c3072ffa338fa5d6b4ff104900411666007ed85e9b1fccabd13a453
   envFrom:
     - secretRef:
         name: teslamate


### PR DESCRIPTION
## Problem

The pinned teslamate `main` digest `4682b927` was garbage-collected upstream at ghcr.io and returns `NotFound`. A rollout restart left the new pod (`teslamate-85fb5f8b54-*`) in `ImagePullBackOff` ~6 min; the previous pod keeps serving so no outage, but the Argo Application went `Progressing`/Degraded.

8th occurrence of this recurring failure mode (upstream publishes no semver tags, only floating `main`).

## Change

Bump `teslamate` to the current multi-arch `main` digest (`0d32891a`, verified linux/amd64 + arm64). The `teslamate-grafana` digest is still present upstream, so it's left unchanged.

## Verification

- `helm template` renders the new digest; `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)