### PR TITLE
fix(jung2bot): restore evening cron baseline to 20

### DIFF
--- a/helm-charts/jung2bot/values.yaml
+++ b/helm-charts/jung2bot/values.yaml
@@ -35,7 +35,7 @@ app:
     stage: prod
   autoscaling:
     min: 3
-    cron: 10
+    cron: 20
     max: 40
 
 cron:


### PR DESCRIPTION
## Summary

- Prod cron `desiredReplicas` 10 to 20.
- Max stays 40. SQS `scaleOnInFlight` remains the backup if the queue builds.

Cron 10 made the fan-out fill the queue, then SQS jumped to 40. Cron 20 already drains with an empty queue. SQS only needs to go high when that baseline is not enough.

## Test plan

- [x] `make test`
- [ ] Argo `jung2bot` Synced
- [ ] ScaledObject cron `desiredReplicas=20`, max 40
- [ ] Next weekday 17:55 HKT: start at 20, SQS only if depth is high